### PR TITLE
fix subdomain - development.flashapp.me

### DIFF
--- a/app/config/galoy-instances.ts
+++ b/app/config/galoy-instances.ts
@@ -71,11 +71,11 @@ export const GALOY_INSTANCES: readonly GaloyInstance[] = [
   {
     id: "Staging",
     name: "Staging",
-    graphqlUri: "https://api.staging.flashapp.me:8080/graphql",
-    graphqlWsUri: "ws://ws.staging.flashapp.me:4000/graphql",
-    authUrl: "https://api.staging.flashapp.me:8080",
-    posUrl: "http://staging.flashapp.me:3000",
-    lnAddressHostname: "staging.flashapp.me:3000",
+    graphqlUri: "https://api.development.flashapp.me:8080/graphql",
+    graphqlWsUri: "ws://ws.development.flashapp.me:4000/graphql",
+    authUrl: "https://api.development.flashapp.me:8080",
+    posUrl: "http://development.flashapp.me:3000",
+    lnAddressHostname: "development.flashapp.me:3000",
     blockExplorer: "https://mempool.space/signet/tx/",
   },
   {


### PR DESCRIPTION
We are moving back to the development.flashapp.me subdomain for now, since we hit the limit on SSL certs for the week on the staging subdomain. 


A separate issue is logged [here](https://github.com/lnflash/flash/issues/45) to resolve the issue of having to recreate the cert every time we have to reload the staging environment.