### PR TITLE
fix "USD Balance and USD Transaction History calculation variance"

### DIFF
--- a/app/components/version/version.tsx
+++ b/app/components/version/version.tsx
@@ -40,8 +40,6 @@ export const VersionComponent = () => {
     <Pressable onPress={() => setSecretMenuCounter(secretMenuCounter + 1)}>
       <Text {...testProps("Version Build Text")} style={styles.version}>
         {readableVersion}
-        {"\n"}
-        {LL.GetStartedScreen.headline()}
       </Text>
     </Pressable>
   )

--- a/app/components/version/version.tsx
+++ b/app/components/version/version.tsx
@@ -40,6 +40,8 @@ export const VersionComponent = () => {
     <Pressable onPress={() => setSecretMenuCounter(secretMenuCounter + 1)}>
       <Text {...testProps("Version Build Text")} style={styles.version}>
         {readableVersion}
+        {"\n"}
+        {LL.GetStartedScreen.headline()}
       </Text>
     </Pressable>
   )

--- a/app/hooks/use-display-currency.ts
+++ b/app/hooks/use-display-currency.ts
@@ -76,7 +76,7 @@ const formatCurrencyHelper = ({
     maximumFractionDigits: decimalPlaces,
     // FIXME this workaround of using .format and not .formatNumber is
     // because hermes haven't fully implemented Intl.NumberFormat yet
-  }).format(Math.abs(Number(amountInMajorUnits)))
+  }).format(Math.abs(Math.floor(Number(amountInMajorUnits) * 100) / 100))
   return `${isApproximate ? "~ " : ""}${
     isNegative && withSign ? "-" : ""
   }${symbol}${amountStr}${currencyCode ? ` ${currencyCode}` : ""}`

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -476,7 +476,7 @@ const en: BaseTranslation = {
     createAccount: "Create new account",
     exploreWallet: "Explore wallet",
     logBackInWith: "Log back in with",
-    headline: "Wallet powered by Galoy",
+    headline: "Made in Jamaica",
     startTrialAccount: "Start with a trial account",
     startWithTrialAccount: "Start with trial account",
     registerPhoneAccount: "Register phone account",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -5202,7 +5202,7 @@ export type TranslationFunctions = {
 		 */
 		logBackInWith: () => LocalizedString
 		/**
-		 * Wallet powered by Galoy
+		 * Made in Jamaica
 		 */
 		headline: () => LocalizedString
 		/**

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -447,7 +447,7 @@
         "createAccount": "Create new account",
         "exploreWallet": "Explore wallet",
         "logBackInWith": "Log back in with",
-        "headline": "Wallet powered by Galoy",
+        "headline": "Made in Jamaica",
         "startTrialAccount": "Start with a trial account",
         "startWithTrialAccount": "Start with trial account",
         "registerPhoneAccount": "Register phone account",


### PR DESCRIPTION
- Fix 'USD Balance and USD Transaction History calculation variance' issue
- Remove 'Wallet powered by Galoy' text on the settings screen