### PR TITLE
Fix import new breez btc wallet

### DIFF
--- a/app/screens/import-wallet-screen/ImportWallet.tsx
+++ b/app/screens/import-wallet-screen/ImportWallet.tsx
@@ -76,6 +76,9 @@ const ImportWallet: React.FC<Props> = ({ navigation, route }) => {
         return {
           ...state,
           btcTransactions: [],
+          breezBalance: undefined,
+          btcBalance: undefined,
+          convertedBtcBalance: undefined,
           btcWalletImported,
         }
       return undefined


### PR DESCRIPTION
Reset breezBalance, btcBalance and convertedBtcBalance when  new btc wallet is imported