### PR TITLE
Upgrade breez-sdk-liquid version to v0.7.8

### DIFF
--- a/app/components/send-flow/ConfirmationWalletFee.tsx
+++ b/app/components/send-flow/ConfirmationWalletFee.tsx
@@ -63,6 +63,7 @@ const ConfirmationWalletFee: React.FC<Props> = ({
         !!flashUserAddress ? flashUserAddress : paymentDetail.destination,
         settlementAmount.amount,
         feeRateSatPerVbyte,
+        paymentDetail.isSendingMax,
       )
       if (fee !== null) {
         setFee({

--- a/app/components/send-flow/DetailAmountNote.tsx
+++ b/app/components/send-flow/DetailAmountNote.tsx
@@ -30,7 +30,6 @@ import {
 } from "@app/utils/breez-sdk-liquid"
 
 type Props = {
-  recommendedFees?: RecommendedFees
   selectedFee?: number
   usdWallet: any
   paymentDetail: PaymentDetail<WalletCurrency>
@@ -39,7 +38,6 @@ type Props = {
 }
 
 const DetailAmountNote: React.FC<Props> = ({
-  recommendedFees,
   selectedFee,
   usdWallet,
   paymentDetail,
@@ -214,18 +212,8 @@ const DetailAmountNote: React.FC<Props> = ({
     let moneyAmount: MoneyAmount<WalletCurrency>
 
     if (paymentDetail.sendingWalletDescriptor.currency === WalletCurrency.Btc) {
-      let feeRateSatPerVbyte = selectedFee ? selectedFee : recommendedFees?.fastestFee
-
-      const { fee }: { fee: any; err: any } = await fetchBreezFee(
-        paymentDetail?.paymentType,
-        paymentDetail?.destination,
-        Math.round(btcWallet.balance * 0.9),
-        feeRateSatPerVbyte,
-      )
-      console.log("on-chain fee:", feeRateSatPerVbyte, fee)
-
       moneyAmount = {
-        amount: btcWallet.balance - Math.round(fee * 1.005),
+        amount: btcWallet.balance,
         currency: WalletCurrency.Btc,
         currencyCode: "BTC",
       }

--- a/app/contexts/BreezContext.tsx
+++ b/app/contexts/BreezContext.tsx
@@ -74,7 +74,7 @@ export const BreezProvider = ({ children }: Props) => {
   const getBreezInfo = async () => {
     setLoading(true)
     await initializeBreezSDK()
-    const walletInfo = await getInfo()
+    const { walletInfo } = await getInfo()
 
     setBtcWallet({
       id: walletInfo.pubkey,

--- a/app/screens/conversion-flow/use-convert.ts
+++ b/app/screens/conversion-flow/use-convert.ts
@@ -18,7 +18,7 @@ import {
 import { getErrorMessages } from "@app/graphql/utils"
 
 // Breez SDK
-import { parseInvoiceBreezSDK, sendPaymentBreezSDK } from "@app/utils/breez-sdk-liquid"
+import { parseInvoiceBreezSDK, payLightningBreez } from "@app/utils/breez-sdk-liquid"
 
 // types
 import { SendPaymentMutation } from "../send-bitcoin-screen/payment-details"
@@ -88,7 +88,7 @@ export const useConvert = (): UseConvertResult => {
         try {
           const invoice = await parseInvoiceBreezSDK(paymentRequest)
           if (invoice.amountMsat !== null) {
-            const response = await sendPaymentBreezSDK(paymentRequest)
+            const response = await payLightningBreez(paymentRequest)
             console.log("BreezSDK LNInvoice response:", response)
             return {
               status: PaymentSendResult.Success,

--- a/app/screens/receive-bitcoin-screen/receive-screen.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-screen.tsx
@@ -163,6 +163,7 @@ const ReceiveScreen = () => {
             settlementAmount={request.settlementAmount}
             receiveViaNFC={request.receiveViaNFC}
             onPaid={() => setUpdatedPaymentState(PaymentRequestState.Paid)}
+            note={request.memo}
           />
         </Screen>
       </>

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -76,23 +76,11 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
   const { data } = useSendBitcoinConfirmationScreenQuery({ skip: !useIsAuthed() })
   const usdWallet = getUsdWallet(data?.me?.defaultAccount?.wallets)
 
-  const convertedDestination =
-    sendingWalletDescriptor.currency === "BTC" && paymentType === "intraledger"
-      ? destination + `@${lnDomain}`
-      : destination
-
   const {
     loading: sendPaymentLoading,
     sendPayment,
     hasAttemptedSend,
-  } = useSendPayment(
-    sendPaymentMutation,
-    convertedDestination,
-    settlementAmount,
-    feeRateSatPerVbyte,
-    note,
-    isSendingMax,
-  )
+  } = useSendPayment(sendPaymentMutation, paymentDetail, feeRateSatPerVbyte)
 
   useEffect(() => {
     setWalletText()

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -91,6 +91,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
     settlementAmount,
     feeRateSatPerVbyte,
     note,
+    isSendingMax,
   )
 
   useEffect(() => {

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -169,6 +169,7 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
           !!flashUserAddress ? flashUserAddress : pd?.destination,
           pd?.settlementAmount.amount,
           selectedFee, // feeRateSatPerVbyte
+          pd.isSendingMax,
         )
         if (fee === null && err) {
           setAsyncErrorMessage(`${err?.message || err} (amount + fee)` || "")
@@ -304,7 +305,6 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
           paymentDetail={paymentDetail}
         />
         <DetailAmountNote
-          recommendedFees={recommendedFees}
           selectedFee={selectedFee}
           usdWallet={usdWallet}
           paymentDetail={paymentDetail}

--- a/app/screens/send-bitcoin-screen/use-send-payment.ts
+++ b/app/screens/send-bitcoin-screen/use-send-payment.ts
@@ -1,5 +1,4 @@
 import { useMemo, useState } from "react"
-import * as sdk from "@breeztech/react-native-breez-sdk-liquid"
 
 // gql
 import {
@@ -17,23 +16,25 @@ import {
   WalletCurrency,
 } from "@app/graphql/generated"
 
+// hooks
+import { useAppConfig } from "@app/hooks"
+
 // utils
 import { getErrorMessages } from "@app/graphql/utils"
 
 // types
-import { SendPaymentMutation } from "./payment-details/index.types"
-import { WalletAmount } from "@app/types/amounts"
+import { PaymentDetail, SendPaymentMutation } from "./payment-details/index.types"
 
 // Breez SDK
 import {
-  sendPaymentBreezSDK,
-  parseInvoiceBreezSDK,
-  sendOnchainBreezSDK,
-  payLnurlBreezSDK,
+  payLightningBreez,
+  payOnchainBreez,
+  payLnurlBreez,
 } from "@app/utils/breez-sdk-liquid"
 
 type UseSendPaymentResult = {
   loading: boolean
+  hasAttemptedSend: boolean
   sendPayment:
     | (() => Promise<{
         status: PaymentSendResult | null | undefined
@@ -41,17 +42,15 @@ type UseSendPaymentResult = {
       }>)
     | undefined
     | null
-  hasAttemptedSend: boolean
 }
 
 export const useSendPayment = (
   sendPaymentMutation?: SendPaymentMutation | null,
-  paymentRequest?: string,
-  amountSats?: WalletAmount<WalletCurrency>,
+  paymentDetail?: PaymentDetail<WalletCurrency>,
   feeRateSatPerVbyte?: number,
-  memo?: string,
-  isSendingMax?: boolean,
 ): UseSendPaymentResult => {
+  const { lnAddressHostname } = useAppConfig().appConfig.galoyInstance
+
   const [intraLedgerPaymentSend, { loading: intraLedgerPaymentSendLoading }] =
     useIntraLedgerPaymentSendMutation({ refetchQueries: [HomeAuthedDocument] })
   const [intraLedgerUsdPaymentSend, { loading: intraLedgerUsdPaymentSendLoading }] =
@@ -94,66 +93,45 @@ export const useSendPayment = (
     return sendPaymentMutation && !hasAttemptedSend
       ? async () => {
           setHasAttemptedSend(true)
-          if (paymentRequest && amountSats?.currency === "BTC") {
-            let invoice: sdk.LnInvoice | null = null
-            if (
-              paymentRequest.length > 110 &&
-              !paymentRequest.toLowerCase().startsWith("lnurl")
-            ) {
-              try {
-                console.log("Parsing invoice using Breez SDK")
-                invoice = await parseInvoiceBreezSDK(paymentRequest)
-              } catch (error) {
-                console.error("Error parsing invoice with Breez SDK:", error)
-                return {
-                  status: PaymentSendResult.Failure,
-                  errorsMessage: "Failed to parse invoice",
-                }
-              }
-            }
+
+          if (paymentDetail && paymentDetail.sendingWalletDescriptor.currency === "BTC") {
+            const { settlementAmount, memo, isSendingMax, destination, paymentType } =
+              paymentDetail
 
             try {
-              if (
-                sendPaymentMutation.name === "sendPaymentMutation" &&
-                paymentRequest.length > 110 &&
-                !paymentRequest.toLowerCase().startsWith("lnurl") &&
-                invoice?.amountMsat !== null
-              ) {
-                console.log("Starting sendPaymentBreezSDK using invoice with amount")
-                const response = await sendPaymentBreezSDK(paymentRequest)
-                console.log("BreezSDK LNInvoice response:", response)
+              if (paymentType === "lightning") {
+                console.log("Starting payLightningBreez")
+                const response = await payLightningBreez(destination)
+                console.log("Response payLightningBreez: ", response)
                 return {
                   status: PaymentSendResult.Success,
                   errorsMessage: undefined,
                 }
-              } else if (
-                sendPaymentMutation?.name === "sendPaymentMutation" &&
-                (paymentRequest.toLowerCase().startsWith("lnurl") ||
-                  paymentRequest.includes("@"))
-              ) {
-                console.log("Starting payLnurlBreezSDK using lnurl or lightning address")
-                const response = await payLnurlBreezSDK(
-                  paymentRequest,
-                  amountSats?.amount,
-                  memo || "",
+              } else if (paymentType === "lnurl" || paymentType === "intraledger") {
+                console.log("Starting payLnurlBreez", memo)
+                const updatedDestination =
+                  paymentType === "intraledger"
+                    ? destination + `@${lnAddressHostname}`
+                    : destination
+                const response = await payLnurlBreez(
+                  updatedDestination,
+                  settlementAmount?.amount,
+                  "",
                 )
-                console.log("BreezSDK LNURL response:", response)
+                console.log("Response payLnurlBreez: ", response)
                 return {
                   status: PaymentSendResult.Success,
                   errorsMessage: undefined,
                 }
-              } else if (
-                sendPaymentMutation?.name === "sendPaymentMutation" &&
-                paymentRequest.length < 64
-              ) {
-                console.log("Starting sendOnchainBreezSDK using destination address")
-                const response = await sendOnchainBreezSDK(
-                  paymentRequest,
-                  amountSats.amount,
+              } else if (paymentType === "onchain") {
+                console.log("Starting payOnchainBreez")
+                const response = await payOnchainBreez(
+                  destination,
+                  settlementAmount.amount,
                   feeRateSatPerVbyte,
                   isSendingMax,
                 )
-                console.log("BreezSDK onchain response:", response)
+                console.log("Response payOnchainBreez: ", response)
                 return {
                   status: PaymentSendResult.Success,
                   errorsMessage: undefined,
@@ -197,7 +175,8 @@ export const useSendPayment = (
   }, [
     sendPaymentMutation,
     hasAttemptedSend,
-    paymentRequest,
+    paymentDetail,
+    feeRateSatPerVbyte,
     intraLedgerPaymentSend,
     intraLedgerUsdPaymentSend,
     lnInvoicePaymentSend,

--- a/app/screens/send-bitcoin-screen/use-send-payment.ts
+++ b/app/screens/send-bitcoin-screen/use-send-payment.ts
@@ -50,6 +50,7 @@ export const useSendPayment = (
   amountSats?: WalletAmount<WalletCurrency>,
   feeRateSatPerVbyte?: number,
   memo?: string,
+  isSendingMax?: boolean,
 ): UseSendPaymentResult => {
   const [intraLedgerPaymentSend, { loading: intraLedgerPaymentSendLoading }] =
     useIntraLedgerPaymentSendMutation({ refetchQueries: [HomeAuthedDocument] })
@@ -150,6 +151,7 @@ export const useSendPayment = (
                   paymentRequest,
                   amountSats.amount,
                   feeRateSatPerVbyte,
+                  isSendingMax,
                 )
                 console.log("BreezSDK onchain response:", response)
                 return {

--- a/app/utils/breez-sdk-liquid/index.ts
+++ b/app/utils/breez-sdk-liquid/index.ts
@@ -270,9 +270,7 @@ export const receiveOnchainBreezSDK = async (
   }
 }
 
-export const sendPaymentBreezSDK = async (
-  bolt11: string,
-): Promise<SendPaymentResponse> => {
+export const payLightningBreez = async (bolt11: string): Promise<SendPaymentResponse> => {
   try {
     const prepareResponse = await prepareSendPayment({
       destination: bolt11,
@@ -295,7 +293,7 @@ export const sendPaymentBreezSDK = async (
   }
 }
 
-export const sendOnchainBreezSDK = async (
+export const payOnchainBreez = async (
   destinationAddress: string,
   amountSat: number,
   feeRateSatPerVbyte?: number,
@@ -322,7 +320,7 @@ export const sendOnchainBreezSDK = async (
   }
 }
 
-export const payLnurlBreezSDK = async (
+export const payLnurlBreez = async (
   lnurl: string,
   amountSat: number,
   memo: string,

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4,12 +4,12 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 7.13)
     - PromisesObjC (~> 2.3)
   - boost (1.76.0)
-  - breez_sdk_liquid (0.5.1):
-    - BreezSDKLiquid (= 0.5.1)
+  - breez_sdk_liquid (0.7.8):
+    - BreezSDKLiquid (= 0.7.8)
     - React-Core
-  - breez_sdk_liquidFFI (0.5.1)
-  - BreezSDKLiquid (0.5.1):
-    - breez_sdk_liquidFFI (= 0.5.1)
+  - breez_sdk_liquidFFI (0.7.8)
+  - BreezSDKLiquid (0.7.8):
+    - breez_sdk_liquidFFI (= 0.7.8)
   - BVLinearGradient (2.8.3):
     - React-Core
   - DoubleConversion (1.1.6)
@@ -143,7 +143,7 @@ PODS:
   - GoogleUtilities/UserDefaults (7.13.3):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GT3Captcha-iOS (0.15.8.4)
+  - GT3Captcha-iOS (0.15.9)
   - hermes-engine (0.72.7):
     - hermes-engine/Pre-built (= 0.72.7)
   - hermes-engine/Pre-built (0.72.7)
@@ -153,7 +153,7 @@ PODS:
     - nanopb/encode (= 2.30909.1)
   - nanopb/decode (2.30909.1)
   - nanopb/encode (2.30909.1)
-  - OpenSSL-Universal (3.3.2000)
+  - OpenSSL-Universal (3.3.3000)
   - PromisesObjC (2.4.0)
   - PromisesSwift (2.4.0):
     - PromisesObjC (= 2.4.0)
@@ -1039,10 +1039,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppCheckCore: 9feb4300caa596a36416cde10674dc5bec1e022e
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
-  breez_sdk_liquid: 8528aefaa995706819939f420f869bc1d90bd5c5
-  breez_sdk_liquidFFI: 60003088e92e35cf6fc5a8686883b346023a26d1
-  BreezSDKLiquid: 2895e61f32ed200952104575a56e937b0a787df8
+  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
+  breez_sdk_liquid: 7bc2b2ea8f758ab8a9a33f96781361e09160b943
+  breez_sdk_liquidFFI: a843656a6e839f603401fb84a70cca17b08af9ca
+  BreezSDKLiquid: e848f16b29414c77f1282af4561e022665c0e9eb
   BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 5fbbff1d7734827299274638deb8ba3024f6c597
@@ -1066,11 +1066,11 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 68afe759316673c6554dac35a0c7ae8f5d6cb4ed
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
-  GT3Captcha-iOS: 3e7737ece3b2210ba19802be381b9aa88007f045
+  GT3Captcha-iOS: aeb6fed2e8594099821430a89208679e5a55b740
   hermes-engine: 9180d43df05c1ed658a87cc733dc3044cf90c00a
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
-  OpenSSL-Universal: b60a3702c9fea8b3145549d421fdb018e53ab7b4
+  OpenSSL-Universal: d776ce24dab24323e6995dfb17c64d598885d05c
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@apollo/client": "3.9.0-alpha.5",
     "@bitcoinerlab/secp256k1": "^1.0.5",
-    "@breeztech/react-native-breez-sdk-liquid": "^0.5.1",
+    "@breeztech/react-native-breez-sdk-liquid": "^0.7.8",
     "@flash/client": "git+https://github.com/lnflash/flash-client.git",
     "@flyerhq/react-native-chat-ui": "^1.4.3",
     "@flyerhq/react-native-link-preview": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,10 +1402,10 @@
     "@noble/hashes" "^1.1.5"
     "@noble/secp256k1" "^1.7.1"
 
-"@breeztech/react-native-breez-sdk-liquid@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.npmjs.org/@breeztech/react-native-breez-sdk-liquid/-/react-native-breez-sdk-liquid-0.5.1.tgz#e6c893b887b33e414b6b5d3503cb6e441e5ca7dd"
-  integrity sha512-1ZvcTE+ahEb79aMJXQjL1dvNCJyaTNtjOMcsFs2ivSD59/1efp5fpgJ0J7WUK/1ESJdxJeXXGXJoAB7TnNrFOg==
+"@breeztech/react-native-breez-sdk-liquid@^0.7.8":
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/@breeztech/react-native-breez-sdk-liquid/-/react-native-breez-sdk-liquid-0.7.8.tgz#58eccaea3a0eddc9ca052198d2eab0dfaaa2399b"
+  integrity sha512-J7fTUvvVuJNgLY+Vs0cNfPaMsYQr3p4LIdTX0aelmfdH6VPKnijXWbjiV+/xInoGlkbW8f3EdbUU9fXJ/l76qA==
 
 "@callstack/react-theme-provider@3.0.3":
   version "3.0.3"
@@ -23164,7 +23164,7 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -23181,6 +23181,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^2.1.1:
   version "2.1.1"
@@ -23273,7 +23282,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -23300,6 +23309,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -25691,7 +25707,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -25712,6 +25728,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Breez SDK Liquid has updated most of its methods and structure in the new version. We need to conduct full testing. I’ve listed the most common use cases I’m familiar with and have tested the ones I marked—they are working as expected for me.
- [x] Receive via nfc
- [x] Receive via lightning
- [x] Receive via on-chain
- [x] Send via lignting
- [x] Send via LNURL
- [x] Send via on-chain
- [x] Send via on-chain (max amount)
- [x] BTC to USD swap
- [x] USD to BTC swap
- [x] Refund
- [x] Redeem