### PR TITLE
[bug] Fix precision issue for small transactions in JMD

### DIFF
--- a/app/hooks/use-price-conversion.ts
+++ b/app/hooks/use-price-conversion.ts
@@ -87,6 +87,7 @@ export const usePriceConversion = () => {
     return <T extends WalletOrDisplayCurrency>(
       moneyAmount: MoneyAmount<WalletOrDisplayCurrency>,
       toCurrency: T,
+      shouldRound?: boolean,
     ): MoneyAmount<T> => {
       // If the money amount is already the correct currency, return it
       if (moneyAmountIsCurrencyType(moneyAmount, toCurrency)) {
@@ -96,9 +97,11 @@ export const usePriceConversion = () => {
       let amount =
         moneyAmount.amount * priceOfCurrencyInCurrency(moneyAmount.currency, toCurrency)
 
-      // if (toCurrency === "BTC") {
-      //   amount = Math.round(amount)
-      // }
+      // Only round when converting to BTC AND shouldRound is explicitly true
+      // This ensures BTC wallet operations get integer satoshis while USD wallet operations maintain precision
+      if (toCurrency === "BTC" && shouldRound) {
+        amount = Math.round(amount)
+      }
 
       if (
         moneyAmountIsCurrencyType(moneyAmount, DisplayCurrency) &&

--- a/app/hooks/useSwap.ts
+++ b/app/hooks/useSwap.ts
@@ -129,7 +129,8 @@ export const useSwap = () => {
     if (usdWallet && btcWallet) {
       // fetch breez(BTC) invoice
       // @ts-ignore: Unreachable code error
-      const convertedAmount = convertMoneyAmount(settlementSendAmount, "BTC")
+      // Round to ensure integer satoshis for Breez SDK
+      const convertedAmount = convertMoneyAmount(settlementSendAmount, "BTC", true)
       const invoiceRes = await receivePaymentBreezSDK(
         convertedAmount.amount,
         "Swap USD to BTC",

--- a/app/screens/receive-bitcoin-screen/payment/payment-request-creation-data.ts
+++ b/app/screens/receive-bitcoin-screen/payment/payment-request-creation-data.ts
@@ -83,9 +83,13 @@ export const createPaymentRequestCreationData = <T extends WalletCurrency>(
   const { unitOfAccountAmount } = params
   let settlementAmount: WalletAmount<T> | undefined = undefined
   if (unitOfAccountAmount) {
+    // Only round for BTC wallet to ensure integer satoshis
+    // USD wallet can handle fractional cents for better precision
+    const shouldRound = receivingWalletDescriptor.currency === WalletCurrency.Btc
     settlementAmount = convertMoneyAmount(
       unitOfAccountAmount,
       receivingWalletDescriptor.currency,
+      shouldRound,
     )
   }
 

--- a/app/screens/redeem-lnurl-withdrawal-screen/redeem-bitcoin-detail-screen.tsx
+++ b/app/screens/redeem-lnurl-withdrawal-screen/redeem-bitcoin-detail-screen.tsx
@@ -63,7 +63,8 @@ const RedeemBitcoinDetailScreen: React.FC<Prop> = ({ route, navigation }) => {
 
   const amountIsFlexible = minSats.amount !== maxSats.amount
 
-  const btcMoneyAmount = convertMoneyAmount(unitOfAccountAmount, WalletCurrency.Btc)
+  // Round to ensure integer satoshis for LNURL withdrawal validation
+  const btcMoneyAmount = convertMoneyAmount(unitOfAccountAmount, WalletCurrency.Btc, true)
 
   const validAmount =
     btcMoneyAmount.amount !== null &&

--- a/app/screens/send-bitcoin-screen/payment-details/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/index.types.ts
@@ -32,6 +32,7 @@ import { LnUrlPayServiceResponse } from "lnurl-pay/dist/types/types"
 export type ConvertMoneyAmount = <W extends WalletOrDisplayCurrency>(
   moneyAmount: MoneyAmount<WalletOrDisplayCurrency>,
   toCurrency: W,
+  shouldRound?: boolean,
 ) => MoneyAmount<W>
 
 export type BaseCreatePaymentDetailsParams<T extends WalletCurrency> = {

--- a/app/screens/send-bitcoin-screen/payment-details/intraledger.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/intraledger.ts
@@ -33,9 +33,12 @@ export const createIntraledgerPaymentDetails = <T extends WalletCurrency>(
   } = params
 
   const memo = destinationSpecifiedMemo || senderSpecifiedMemo
+  // Only round for BTC wallet to ensure integer satoshis
+  const shouldRound = sendingWalletDescriptor.currency === WalletCurrency.Btc
   const settlementAmount = convertMoneyAmount(
     unitOfAccountAmount,
     sendingWalletDescriptor.currency,
+    shouldRound,
   )
 
   const getFee: GetFee<T> = (_) => {

--- a/app/screens/send-bitcoin-screen/payment-details/lightning.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/lightning.ts
@@ -41,9 +41,12 @@ export const createNoAmountLightningPaymentDetails = <T extends WalletCurrency>(
   } = params
 
   const memo = destinationSpecifiedMemo || senderSpecifiedMemo
+  // Only round for BTC wallet to ensure integer satoshis
+  const shouldRound = sendingWalletDescriptor.currency === WalletCurrency.Btc
   const settlementAmount = convertMoneyAmount(
     unitOfAccountAmount,
     sendingWalletDescriptor.currency,
+    shouldRound,
   )
 
   const setConvertMoneyAmount = (convertMoneyAmount: ConvertMoneyAmount) => {
@@ -232,9 +235,12 @@ export const createAmountLightningPaymentDetails = <T extends WalletCurrency>(
   } = params
 
   const memo = destinationSpecifiedMemo || senderSpecifiedMemo
+  // Only round for BTC wallet to ensure integer satoshis
+  const shouldRound = sendingWalletDescriptor.currency === WalletCurrency.Btc
   const settlementAmount = convertMoneyAmount(
     paymentRequestAmount,
     sendingWalletDescriptor.currency,
+    shouldRound,
   )
   const unitOfAccountAmount = paymentRequestAmount
 
@@ -415,9 +421,12 @@ export const createLnurlPaymentDetails = <T extends WalletCurrency>(
       }
     }
   } else {
+    // Only round for BTC wallet to ensure integer satoshis
+    const shouldRound = sendingWalletDescriptor.currency === WalletCurrency.Btc
     settlementAmount = convertMoneyAmount(
       unitOfAccountAmount,
       sendingWalletDescriptor.currency,
+      shouldRound,
     )
   }
 

--- a/app/screens/send-bitcoin-screen/payment-details/onchain.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/onchain.ts
@@ -37,9 +37,12 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
     address,
   } = params
 
+  // Only round for BTC wallet to ensure integer satoshis
+  const shouldRound = sendingWalletDescriptor.currency === WalletCurrency.Btc
   const settlementAmount = convertMoneyAmount(
     unitOfAccountAmount,
     sendingWalletDescriptor.currency,
+    shouldRound,
   )
   const memo = destinationSpecifiedMemo || senderSpecifiedMemo
 
@@ -343,9 +346,12 @@ export const createAmountOnchainPaymentDetails = <T extends WalletCurrency>(
     address,
   } = params
 
+  // Only round for BTC wallet to ensure integer satoshis
+  const shouldRound = sendingWalletDescriptor.currency === WalletCurrency.Btc
   const settlementAmount = convertMoneyAmount(
     destinationSpecifiedAmount,
     sendingWalletDescriptor.currency,
+    shouldRound,
   )
   const unitOfAccountAmount = destinationSpecifiedAmount
 


### PR DESCRIPTION
Change:
 - Remove (or keep commented) lines 99-101 in app/hooks/use-price-conversion.ts
 - This allows precise conversions for all currency pairs including JMD ↔ USD ↔ BTC