### PR TITLE
fix: rename Settings section labels (Experimental → Chat, Key management → Wallet backup)

### DIFF
--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -835,7 +835,7 @@ const en: BaseTranslation = {
     showNostrSecret: "Chat Settings",
     beginnerMode: "Disable Bitcoin Account",
     advanceMode: "Enable Bitcoin Account (Advanced Mode)",
-    keysManagement: "Key management",
+    keysManagement: "Wallet backup",
 		showBtcAccount: "Show Bitcoin account",
 		hideBtcAccount: "Hide Bitcoin account"
   },

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -772,7 +772,7 @@
         "showNostrSecret": "Chat Settings",
         "beginnerMode": "Disable Bitcoin Account",
         "advanceMode": "Enable Bitcoin Account (Advanced Mode)",
-        "keysManagement": "Key management",
+        "keysManagement": "Wallet backup",
         "showBtcAccount": "Show Bitcoin account",
         "hideBtcAccount": "Hide Bitcoin account"
     },

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -107,7 +107,7 @@ export const SettingsScreen: React.FC = () => {
       {(currentLevel === AccountLevel.Two || currentLevel === AccountLevel.Three) && (
         <SettingsGroup name="Reports" items={items.reports} />
       )}
-      <SettingsGroup name="Experimental" items={items.experimental} />
+      <SettingsGroup name="Chat" items={items.experimental} />
       <SettingsGroup name={LL.SettingsScreen.keysManagement()} items={items.wallet} />
       <SettingsGroup name={LL.common.preferences()} items={items.preferences} />
       <SettingsGroup


### PR DESCRIPTION
## Summary

Closes #566

Renames two developer-speak section labels in Settings to user-friendly names, as flagged by Lori in the app audit.

| Before | After |
|--------|-------|
| Experimental | Chat |
| Key management | Wallet backup |

## Changes

- `settings-screen.tsx`: hardcoded label `"Experimental"` → `"Chat"`
- `en/index.ts` + `raw-i18n/source/en.json`: `keysManagement` string updated to `"Wallet backup"`

No changes to section contents or structure.