### PR TITLE
feat: ENG-179 Cashu NFC card top-up

### DIFF
--- a/__tests__/card/cashu-topup-helpers.spec.ts
+++ b/__tests__/card/cashu-topup-helpers.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * cashu-topup-helpers.spec.ts
+ *
+ * Unit tests for the Cashu card top-up helper functions.
+ * These are pure logic functions with no RN/NFC dependencies.
+ */
+
+import {
+  extractNonceFromSecret,
+  toCardWriteProof,
+} from "@app/screens/card-screen/cashu-topup.helpers"
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+// NUT-XX worked example from spec/NUT-XX.md
+const EXAMPLE_NONCE = "916c21b8c67da71e9d02f4e3adc6f30700c152e01a07ae30e3bcc6b55b0c9e5e"
+const EXAMPLE_PUBKEY = "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2"
+
+/** Build a P2PK secret JSON string from (nonce, pubkey) matching the on-card format */
+function makeP2PKSecret(nonce: string, pubkey: string): string {
+  return JSON.stringify([
+    "P2PK",
+    {
+      nonce,
+      data: pubkey,
+      tags: [["sigflag", "SIG_ALL"]],
+    },
+  ])
+}
+
+const EXAMPLE_SECRET = makeP2PKSecret(EXAMPLE_NONCE, EXAMPLE_PUBKEY)
+
+const EXAMPLE_PROOF = {
+  id: "0059534ce0bfa19a",
+  amount: 100,
+  secret: EXAMPLE_SECRET,
+  C: "024a43eddcf0e42dad32ca5c0e82e51d7a38e7a48b80e89d2e17cc94abb02c04c3",
+}
+
+// ── extractNonceFromSecret ────────────────────────────────────────────────
+
+describe("extractNonceFromSecret", () => {
+  it("extracts nonce from a valid P2PK secret", () => {
+    expect(extractNonceFromSecret(EXAMPLE_SECRET)).toBe(EXAMPLE_NONCE)
+  })
+
+  it("extracts nonce regardless of other fields", () => {
+    const secretWithExtras = JSON.stringify([
+      "P2PK",
+      {
+        nonce: "aabbcc",
+        data: EXAMPLE_PUBKEY,
+        tags: [["sigflag", "SIG_ALL"], ["locktime", "9999999999"]],
+      },
+    ])
+    expect(extractNonceFromSecret(secretWithExtras)).toBe("aabbcc")
+  })
+
+  it("throws for non-P2PK secrets", () => {
+    const htlcSecret = JSON.stringify([
+      "HTLC",
+      { nonce: "deadbeef", data: "something" },
+    ])
+    expect(() => extractNonceFromSecret(htlcSecret)).toThrow("Invalid P2PK secret")
+  })
+
+  it("throws for missing nonce field", () => {
+    const noNonce = JSON.stringify(["P2PK", { data: EXAMPLE_PUBKEY }])
+    expect(() => extractNonceFromSecret(noNonce)).toThrow("Invalid P2PK secret")
+  })
+
+  it("throws for invalid JSON", () => {
+    expect(() => extractNonceFromSecret("not-json")).toThrow("Invalid P2PK secret")
+  })
+
+  it("throws for plain string secrets (non-P2PK)", () => {
+    expect(() => extractNonceFromSecret("deadbeefdeadbeef")).toThrow(
+      "Invalid P2PK secret",
+    )
+  })
+})
+
+// ── toCardWriteProof ──────────────────────────────────────────────────────
+
+describe("toCardWriteProof", () => {
+  it("maps a GQL proof to the card write format", () => {
+    const result = toCardWriteProof(EXAMPLE_PROOF)
+    expect(result).toEqual({
+      keysetId: "0059534ce0bfa19a",
+      amount: 100,
+      nonce: EXAMPLE_NONCE,
+      C: "024a43eddcf0e42dad32ca5c0e82e51d7a38e7a48b80e89d2e17cc94abb02c04c3",
+    })
+  })
+
+  it("propagates nonce extraction errors", () => {
+    const badProof = { ...EXAMPLE_PROOF, secret: "not-a-p2pk-secret" }
+    expect(() => toCardWriteProof(badProof)).toThrow("Invalid P2PK secret")
+  })
+
+  it("preserves amount exactly (no rounding)", () => {
+    const proofs = [1, 2, 4, 8, 16, 32, 64].map((amount) => ({
+      ...EXAMPLE_PROOF,
+      amount,
+    }))
+    proofs.forEach((proof) => {
+      expect(toCardWriteProof(proof).amount).toBe(proof.amount)
+    })
+  })
+
+  it("uses proof.id as keysetId (not amount or C)", () => {
+    const result = toCardWriteProof(EXAMPLE_PROOF)
+    expect(result.keysetId).toBe(EXAMPLE_PROOF.id)
+    expect(result.keysetId).not.toBe(EXAMPLE_PROOF.C)
+  })
+})

--- a/app/components/card/EmptyCard.tsx
+++ b/app/components/card/EmptyCard.tsx
@@ -17,7 +17,11 @@ import EmptyFlashcard from "@app/assets/icons/empty-flashcard.svg"
 
 const width = Dimensions.get("screen").width
 
-const EmptyCard = () => {
+type EmptyCardProps = {
+  onCashuTopup?: () => void
+}
+
+const EmptyCard = ({ onCashuTopup }: EmptyCardProps) => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>()
   const styles = useStyles()
   const { LL } = useI18nContext()
@@ -39,6 +43,13 @@ const EmptyCard = () => {
         onPress={() => readFlashcard(false)}
         btnStyle={{ marginBottom: 10 }}
       />
+      {onCashuTopup && (
+        <PrimaryBtn
+          label="💳  Top Up Flash Card"
+          onPress={onCashuTopup}
+          btnStyle={{ marginBottom: 10 }}
+        />
+      )}
       <PrimaryBtn type="outline" label="Find a Flashpoint" onPress={findFlashpoint} />
     </View>
   )

--- a/app/components/card/Flashcard.tsx
+++ b/app/components/card/Flashcard.tsx
@@ -28,9 +28,10 @@ import { DisplayCurrency, toBtcMoneyAmount } from "@app/types/amounts"
 type Props = {
   onReload: () => void
   onTopup: () => void
+  onCashuTopup?: () => void
 }
 
-const Flashcard: React.FC<Props> = ({ onReload, onTopup }) => {
+const Flashcard: React.FC<Props> = ({ onReload, onTopup, onCashuTopup }) => {
   const isAuthed = useIsAuthed()
   const styles = useStyles()
   const { colors } = useTheme().theme
@@ -72,6 +73,14 @@ const Flashcard: React.FC<Props> = ({ onReload, onTopup }) => {
         <View style={styles.btns}>
           <IconBtn type="clear" icon="down" label={`Reload\nCard`} onPress={onReload} />
           <IconBtn type="clear" icon="qr" label={`Topup via\nQR`} onPress={onTopup} />
+          {onCashuTopup && (
+            <IconBtn
+              type="clear"
+              icon="cardAdd"
+              label={`Flash\nTop-Up`}
+              onPress={onCashuTopup}
+            />
+          )}
           <IconBtn
             type="clear"
             icon={"cardRemove"}

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -835,7 +835,7 @@ const en: BaseTranslation = {
     showNostrSecret: "Chat Settings",
     beginnerMode: "Disable Bitcoin Account",
     advanceMode: "Enable Bitcoin Account (Advanced Mode)",
-    keysManagement: "Key management",
+    keysManagement: "Wallet backup",
 		showBtcAccount: "Show Bitcoin account",
 		hideBtcAccount: "Hide Bitcoin account"
   },

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -772,7 +772,7 @@
         "showNostrSecret": "Chat Settings",
         "beginnerMode": "Disable Bitcoin Account",
         "advanceMode": "Enable Bitcoin Account (Advanced Mode)",
-        "keysManagement": "Key management",
+        "keysManagement": "Wallet backup",
         "showBtcAccount": "Show Bitcoin account",
         "hideBtcAccount": "Hide Bitcoin account"
     },

--- a/app/navigation/root-navigator.tsx
+++ b/app/navigation/root-navigator.tsx
@@ -10,7 +10,7 @@ import {
 } from "../screens/authentication-screen"
 import { PinScreen } from "../screens/authentication-screen/pin-screen"
 import { ContactsDetailScreen, ContactsScreen } from "../screens/contacts-screen"
-import { CardScreen, FlashcardTopup } from "../screens/card-screen"
+import { CardScreen, FlashcardTopup, CashuTopup } from "../screens/card-screen"
 import { ChatList } from "@app/screens/chat"
 import { DeveloperScreen } from "../screens/developer-screen"
 import { EarnMapScreen } from "../screens/earns-map-screen"
@@ -267,6 +267,13 @@ export const RootStack = () => {
         component={FlashcardTopup}
         options={{
           title: LL.ReceiveScreen.topupFlashcard(),
+        }}
+      />
+      <RootNavigator.Screen
+        name="cashuTopup"
+        component={CashuTopup}
+        options={{
+          title: "Flash Card Top-Up",
         }}
       />
       <RootNavigator.Screen

--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -87,6 +87,7 @@ export type RootStackParamList = {
   priceHistory: undefined
   receiveBitcoin: undefined
   flashcardTopup: { flashcardLnurl: string }
+  cashuTopup: undefined
   redeemBitcoinDetail: {
     receiveDestination: ReceiveDestination
   }

--- a/app/nfc/cashu-apdu.ts
+++ b/app/nfc/cashu-apdu.ts
@@ -1,0 +1,279 @@
+/**
+ * cashu-apdu.ts
+ *
+ * APDU builders and response parsers for the Cashu JavaCard applet
+ * (AID: D2 76 00 00 85 01 02, NUT-XX Profile B).
+ *
+ * Proof storage layout on-card (77-byte payload per slot):
+ *   keyset_id [ 8]  — raw bytes from keyset hex ID
+ *   amount    [ 4]  — uint32 big-endian (denomination in cents/sats per keyset)
+ *   nonce     [32]  — the nonce field from the P2PK secret JSON
+ *   C         [33]  — compressed EC point (blind sig unblinded)
+ *
+ * The full P2PK secret JSON is NOT stored on-card. The POS reconstructs it
+ * from (nonce, card_pubkey) since cardPubKey is always readable via GET_PUBKEY:
+ *   secret = JSON.stringify(["P2PK", {nonce: hex(nonce), data: card_pubkey, tags: [["sigflag","SIG_INPUTS"]]}])
+ *
+ * For SPEND_PROOF, msg = SHA256(secret_json_string).
+ *
+ * @see https://github.com/lnflash/cashu-javacard/blob/main/spec/APDU.md
+ */
+
+/** CLA byte for all Cashu applet commands */
+export const CASHU_CLA = 0xb0;
+
+/** AID: D2 76 00 00 85 01 02 */
+export const CASHU_AID = new Uint8Array([0xd2, 0x76, 0x00, 0x00, 0x85, 0x01, 0x02]);
+
+// Instruction bytes
+export const INS_GET_INFO        = 0x01;
+export const INS_GET_PUBKEY      = 0x10;
+export const INS_GET_BALANCE     = 0x11;
+export const INS_GET_PROOF_COUNT = 0x12;
+export const INS_GET_PROOF       = 0x13;
+export const INS_GET_SLOT_STATUS = 0x14;
+export const INS_SPEND_PROOF     = 0x20;
+export const INS_SIGN_ARBITRARY  = 0x21;
+export const INS_LOAD_PROOF      = 0x30;
+export const INS_CLEAR_SPENT     = 0x31;
+export const INS_VERIFY_PIN      = 0x40;
+export const INS_SET_PIN         = 0x41;
+export const INS_CHANGE_PIN      = 0x42;
+export const INS_LOCK_CARD       = 0x50;
+
+// Status words
+export const SW_OK                   = 0x9000;
+export const SW_WRONG_LENGTH         = 0x6700;
+export const SW_SECURITY_NOT_SATIS   = 0x6982;
+export const SW_PIN_BLOCKED          = 0x6983;
+export const SW_PIN_NOT_SET          = 0x6984;
+export const SW_CONDITIONS_NOT_SATIS = 0x6985;
+export const SW_SLOT_OUT_OF_RANGE    = 0x6a83;
+export const SW_NO_SPACE             = 0x6a84;
+export const SW_SLOT_EMPTY           = 0x6a88;
+
+// Slot status constants
+export const SLOT_EMPTY   = 0x00;
+export const SLOT_UNSPENT = 0x01;
+export const SLOT_SPENT   = 0x02;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Card info / proof types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface CardInfo {
+  versionMajor: number;
+  versionMinor: number;
+  maxSlots: number;
+  unspentCount: number;
+  spentCount: number;
+  emptyCount: number;
+  capabilities: number; // bitmask: bit0=secp256k1, bit1=Schnorr, bit2=PIN
+  pinState: number;     // 0=unset, 1=set, 2=locked
+}
+
+export interface CardProof {
+  /** Slot index on card */
+  slotIndex: number;
+  /** Status: 0=empty, 1=unspent, 2=spent */
+  status: number;
+  /** Keyset ID (8 bytes as hex string) */
+  keysetId: string;
+  /** Denomination amount */
+  amount: number;
+  /** 32-byte nonce (from P2PK secret) as hex */
+  nonce: string;
+  /** 33-byte compressed C point as hex */
+  C: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// APDU builders
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** SELECT AID command */
+export function buildSelectAid(): number[] {
+  const aid: number[] = [];
+  for (let i = 0; i < CASHU_AID.length; i++) aid.push(CASHU_AID[i]);
+  return [0x00, 0xa4, 0x04, 0x00, CASHU_AID.length].concat(aid);
+}
+
+/** GET_INFO (B0 01 00 00 00) */
+export function buildGetInfo(): number[] {
+  return [CASHU_CLA, INS_GET_INFO, 0x00, 0x00, 0x00];
+}
+
+/** GET_PUBKEY (B0 10 00 00 00) */
+export function buildGetPubkey(): number[] {
+  return [CASHU_CLA, INS_GET_PUBKEY, 0x00, 0x00, 0x00];
+}
+
+/** GET_BALANCE (B0 11 00 00 00) */
+export function buildGetBalance(): number[] {
+  return [CASHU_CLA, INS_GET_BALANCE, 0x00, 0x00, 0x00];
+}
+
+/** GET_PROOF at slot index (B0 13 P1 00 00) */
+export function buildGetProof(slotIndex: number): number[] {
+  return [CASHU_CLA, INS_GET_PROOF, slotIndex & 0xff, 0x00, 0x00];
+}
+
+/** GET_SLOT_STATUS (B0 14 00 00 00) */
+export function buildGetSlotStatus(): number[] {
+  return [CASHU_CLA, INS_GET_SLOT_STATUS, 0x00, 0x00, 0x00];
+}
+
+/**
+ * LOAD_PROOF — write 77 bytes of proof data.
+ * Requires VERIFY_PIN session if PIN is set.
+ *
+ * @param keysetIdHex  16-character hex string (8 bytes)
+ * @param amount       denomination uint32
+ * @param nonceHex     64-character hex string (32 bytes, from P2PK secret nonce)
+ * @param cHex         66-character hex string (33 bytes compressed point)
+ */
+export function buildLoadProof(
+  keysetIdHex: string,
+  amount: number,
+  nonceHex: string,
+  cHex: string,
+): number[] {
+  const payload = new Uint8Array(77);
+  const kidBytes = hexToBytes(keysetIdHex);
+  payload.set(kidBytes.slice(0, 8), 0);
+  payload[8]  = (amount >>> 24) & 0xff;
+  payload[9]  = (amount >>> 16) & 0xff;
+  payload[10] = (amount >>> 8) & 0xff;
+  payload[11] = amount & 0xff;
+  const nonceBytes = hexToBytes(nonceHex);
+  payload.set(nonceBytes.slice(0, 32), 12);
+  const cBytes = hexToBytes(cHex);
+  payload.set(cBytes.slice(0, 33), 44);
+
+  const payloadArr: number[] = [];
+  for (let i = 0; i < payload.length; i++) payloadArr.push(payload[i]);
+  return [CASHU_CLA, INS_LOAD_PROOF, 0x00, 0x00, 77].concat(payloadArr);
+}
+
+/**
+ * VERIFY_PIN — authenticate provisioning session.
+ * @param pinBytes  4–8 ASCII bytes of the PIN
+ */
+export function buildVerifyPin(pinBytes: number[]): number[] {
+  return [CASHU_CLA, INS_VERIFY_PIN, 0x00, 0x00, pinBytes.length, ...pinBytes];
+}
+
+/**
+ * SET_PIN — first-time PIN setup (one-time only, no auth required).
+ * @param pinBytes  4–8 ASCII bytes
+ */
+export function buildSetPin(pinBytes: number[]): number[] {
+  return [CASHU_CLA, INS_SET_PIN, 0x00, 0x00, pinBytes.length, ...pinBytes];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Response parsers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Parse GET_INFO 8-byte response */
+export function parseCardInfo(data: number[]): CardInfo {
+  return {
+    versionMajor: data[0],
+    versionMinor: data[1],
+    maxSlots:     data[2],
+    unspentCount: data[3],
+    spentCount:   data[4],
+    emptyCount:   data[5],
+    capabilities: data[6],
+    pinState:     data[7],
+  };
+}
+
+/** Parse GET_PUBKEY response (33 or 65 bytes) → hex string */
+export function parsePubkey(data: number[]): string {
+  // Normalise: if 65-byte uncompressed (0x04 prefix), compress it
+  if (data.length === 65 && data[0] === 0x04) {
+    return compressPoint(data);
+  }
+  return bytesToHex(data);
+}
+
+/** Parse GET_PROOF 78-byte response */
+export function parseProof(data: number[], slotIndex: number): CardProof {
+  return {
+    slotIndex,
+    status:   data[0],
+    keysetId: bytesToHex(data.slice(1, 9)),
+    amount:   (data[9] << 24) | (data[10] << 16) | (data[11] << 8) | data[12],
+    nonce:    bytesToHex(data.slice(13, 45)),
+    C:        bytesToHex(data.slice(45, 78)),
+  };
+}
+
+/** Parse GET_BALANCE 4-byte uint32 */
+export function parseBalance(data: number[]): number {
+  return (data[0] << 24) | (data[1] << 16) | (data[2] << 8) | data[3];
+}
+
+/** Extract SW (last 2 bytes of raw response) */
+export function getSW(response: number[]): number {
+  const n = response.length;
+  return ((response[n - 2] & 0xff) << 8) | (response[n - 1] & 0xff);
+}
+
+/** Data bytes (everything before last 2 SW bytes) */
+export function getResponseData(response: number[]): number[] {
+  return response.slice(0, response.length - 2);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function hexToBytes(hex: string): Uint8Array {
+  const len = hex.length;
+  const out = new Uint8Array(len / 2);
+  for (let i = 0; i < len; i += 2) {
+    out[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return out;
+}
+
+export function bytesToHex(bytes: number[] | Uint8Array): string {
+  let hex = '';
+  for (let i = 0; i < bytes.length; i++) {
+    const h = (bytes[i] & 0xff).toString(16);
+    hex += h.length === 1 ? '0' + h : h;
+  }
+  return hex;
+}
+
+export function pinStringToBytes(pin: string): number[] {
+  return pin.split('').map(c => c.charCodeAt(0));
+}
+
+/** Compress an uncompressed EC point (0x04 prefix, 65 bytes) */
+function compressPoint(uncompressed: number[]): string {
+  const x = uncompressed.slice(1, 33);
+  const yLastByte = uncompressed[64];
+  const prefix = yLastByte % 2 === 0 ? 0x02 : 0x03;
+  return bytesToHex([prefix, ...x]);
+}
+
+/**
+ * Reconstruct the P2PK secret JSON string from on-card data.
+ * Used to compute the message hash for SPEND_PROOF verification.
+ *
+ * Format:
+ *   ["P2PK",{"nonce":"<nonce_hex>","data":"<card_pubkey_hex>","tags":[["sigflag","SIG_INPUTS"]]}]
+ */
+export function reconstructP2PKSecret(nonceHex: string, cardPubkeyHex: string): string {
+  return JSON.stringify([
+    'P2PK',
+    {
+      nonce: nonceHex,
+      data: cardPubkeyHex,
+      tags: [['sigflag', 'SIG_INPUTS']],
+    },
+  ]);
+}

--- a/app/nfc/useCashuCard.ts
+++ b/app/nfc/useCashuCard.ts
@@ -1,0 +1,283 @@
+/**
+ * useCashuCard.ts
+ *
+ * React hook for IsoDep (APDU) NFC sessions with the Cashu JavaCard applet.
+ * Manages NFC technology lifecycle — always call cleanup() when done.
+ *
+ * Usage:
+ *   const card = useCashuCard();
+ *   await card.startSession();       // request IsoDep technology
+ *   const info = await card.getInfo();
+ *   const pubkey = await card.getPubkey();
+ *   await card.setPin(pin);
+ *   await card.verifyPin(pin);
+ *   await card.loadProof(keysetId, amount, nonce, C);
+ *   await card.cleanup();            // always call on finish or error
+ */
+
+import {useCallback, useRef} from 'react';
+import NfcManager, {NfcTech} from 'react-native-nfc-manager';
+
+import {
+  buildSelectAid,
+  buildGetInfo,
+  buildGetPubkey,
+  buildGetBalance,
+  buildGetSlotStatus,
+  buildGetProof,
+  buildLoadProof,
+  buildVerifyPin,
+  buildSetPin,
+  parseCardInfo,
+  parsePubkey,
+  parseProof,
+  parseBalance,
+  getSW,
+  getResponseData,
+  pinStringToBytes,
+  CardInfo,
+  CardProof,
+  SW_OK,
+  CASHU_CLA,
+  INS_SPEND_PROOF,
+} from './cashu-apdu';
+
+export class CashuCardError extends Error {
+  constructor(
+    message: string,
+    public readonly sw?: number,
+  ) {
+    super(message);
+    this.name = 'CashuCardError';
+  }
+}
+
+const useCashuCard = () => {
+  const sessionActive = useRef(false);
+
+  // ─── Low-level transceive ───────────────────────────────────────────────
+
+  const send = useCallback(async (apdu: number[]): Promise<number[]> => {
+    const response = await NfcManager.isoDepHandler.transceive(apdu);
+    const arr: number[] = [];
+    for (let i = 0; i < response.length; i++) arr.push(response[i]);
+    return arr;
+  }, []);
+
+  const sendAndCheck = useCallback(
+    async (apdu: number[], errorLabel: string): Promise<number[]> => {
+      const raw = await send(apdu);
+      const sw = getSW(raw);
+      if (sw !== SW_OK) {
+        throw new CashuCardError(
+          `${errorLabel} failed (SW: 0x${sw.toString(16).toUpperCase()})`,
+          sw,
+        );
+      }
+      return getResponseData(raw);
+    },
+    [send],
+  );
+
+  // ─── Session lifecycle ──────────────────────────────────────────────────
+
+  const startSession = useCallback(async (): Promise<void> => {
+    await NfcManager.requestTechnology(NfcTech.IsoDep);
+    sessionActive.current = true;
+
+    // SELECT AID
+    await sendAndCheck(buildSelectAid(), 'SELECT AID');
+  }, [sendAndCheck]);
+
+  const cleanup = useCallback(async (): Promise<void> => {
+    if (sessionActive.current) {
+      try {
+        await NfcManager.cancelTechnologyRequest();
+      } catch {
+        // Ignore — card may have been removed
+      }
+      sessionActive.current = false;
+    }
+  }, []);
+
+  // ─── Read commands ──────────────────────────────────────────────────────
+
+  const getInfo = useCallback(async (): Promise<CardInfo> => {
+    const data = await sendAndCheck(buildGetInfo(), 'GET_INFO');
+    return parseCardInfo(data);
+  }, [sendAndCheck]);
+
+  const getPubkey = useCallback(async (): Promise<string> => {
+    const data = await sendAndCheck(buildGetPubkey(), 'GET_PUBKEY');
+    return parsePubkey(data);
+  }, [sendAndCheck]);
+
+  const getBalance = useCallback(async (): Promise<number> => {
+    const data = await sendAndCheck(buildGetBalance(), 'GET_BALANCE');
+    return parseBalance(data);
+  }, [sendAndCheck]);
+
+  const getSlotStatuses = useCallback(async (): Promise<number[]> => {
+    const data = await sendAndCheck(buildGetSlotStatus(), 'GET_SLOT_STATUS');
+    return data;
+  }, [sendAndCheck]);
+
+  const getProof = useCallback(
+    async (slotIndex: number): Promise<CardProof> => {
+      const data = await sendAndCheck(buildGetProof(slotIndex), 'GET_PROOF');
+      return parseProof(data, slotIndex);
+    },
+    [sendAndCheck],
+  );
+
+  // ─── Auth commands ──────────────────────────────────────────────────────
+
+  /** SET_PIN — first-time only, no prior auth required */
+  const setPin = useCallback(
+    async (pin: string): Promise<void> => {
+      await sendAndCheck(buildSetPin(pinStringToBytes(pin)), 'SET_PIN');
+    },
+    [sendAndCheck],
+  );
+
+  /** VERIFY_PIN — establishes write session for LOAD_PROOF / CLEAR_SPENT */
+  const verifyPin = useCallback(
+    async (pin: string): Promise<void> => {
+      await sendAndCheck(buildVerifyPin(pinStringToBytes(pin)), 'VERIFY_PIN');
+    },
+    [sendAndCheck],
+  );
+
+  // ─── Write commands ─────────────────────────────────────────────────────
+
+  /**
+   * LOAD_PROOF — write one proof to the card.
+   * Requires verifyPin() to have been called in this session.
+   *
+   * @param keysetIdHex  16-char hex (8 bytes)
+   * @param amount       denomination in keyset's base unit
+   * @param nonceHex     64-char hex (32-byte nonce from P2PK secret)
+   * @param cHex         66-char hex (33-byte compressed C point)
+   * @returns slot index written
+   */
+  const loadProof = useCallback(
+    async (
+      keysetIdHex: string,
+      amount: number,
+      nonceHex: string,
+      cHex: string,
+    ): Promise<number> => {
+      const data = await sendAndCheck(
+        buildLoadProof(keysetIdHex, amount, nonceHex, cHex),
+        'LOAD_PROOF',
+      );
+      return data[0]; // slot index
+    },
+    [sendAndCheck],
+  );
+
+  // ─── Spend commands ─────────────────────────────────────────────────────
+
+  /**
+   * SPEND_PROOF — atomically marks the proof spent and returns a 64-byte
+   * BIP-340 Schnorr signature over the provided 32-byte message.
+   *
+   * msg = SHA256(reconstructP2PKSecret(proof.nonce, cardPubkey))
+   *
+   * @param slotIndex  slot to spend (0–31)
+   * @param msg        32 bytes to sign (as number[])
+   * @returns          64-byte Schnorr signature as number[]
+   */
+  const spendProof = useCallback(
+    async (slotIndex: number, msg: number[]): Promise<number[]> => {
+      const apdu = [CASHU_CLA, INS_SPEND_PROOF, slotIndex & 0xff, 0x00, 32].concat(msg);
+      return sendAndCheck(apdu, 'SPEND_PROOF');
+    },
+    [sendAndCheck],
+  );
+
+  // ─── Compound provisioning flow ─────────────────────────────────────────
+
+  /**
+   * Full provisioning flow for a blank card:
+   *   1. GET_INFO — verify blank (pinState=0, no existing proofs)
+   *   2. GET_PUBKEY — return for GQL call
+   *   3. (caller calls cashuCardProvision GQL, gets proofs back)
+   *   4. SET_PIN → VERIFY_PIN → LOAD_PROOF × N
+   *
+   * @returns card pubkey hex (33-byte compressed)
+   * @throws CashuCardError if card is not blank or PIN already set
+   */
+  const readBlankCardPubkey = useCallback(async (): Promise<{
+    pubkey: string;
+    info: CardInfo;
+  }> => {
+    const info = await getInfo();
+
+    if (info.pinState !== 0) {
+      throw new CashuCardError(
+        'Card already has a PIN set — use top-up flow instead',
+      );
+    }
+    if (info.unspentCount > 0 || info.spentCount > 0) {
+      throw new CashuCardError(
+        'Card already has proofs — use top-up flow instead',
+      );
+    }
+
+    const pubkey = await getPubkey();
+    return {pubkey, info};
+  }, [getInfo, getPubkey]);
+
+  /**
+   * Write proofs onto a card after cashuCardProvision GQL call.
+   * Handles SET_PIN (blank card) or VERIFY_PIN (top-up).
+   *
+   * @param proofs      array of {keysetId, amount, nonce, C} proof objects
+   * @param pin         PIN to set (blank) or verify (top-up)
+   * @param isBlank     true = call SET_PIN first; false = just VERIFY_PIN
+   */
+  const writeProofs = useCallback(
+    async (
+      proofs: {keysetId: string; amount: number; nonce: string; C: string}[],
+      pin: string,
+      isBlank: boolean,
+    ): Promise<number[]> => {
+      if (isBlank) {
+        await setPin(pin);
+      }
+      await verifyPin(pin);
+
+      const slots: number[] = [];
+      for (const proof of proofs) {
+        const slot = await loadProof(
+          proof.keysetId,
+          proof.amount,
+          proof.nonce,
+          proof.C,
+        );
+        slots.push(slot);
+      }
+      return slots;
+    },
+    [setPin, verifyPin, loadProof],
+  );
+
+  return {
+    startSession,
+    cleanup,
+    getInfo,
+    getPubkey,
+    getBalance,
+    getSlotStatuses,
+    getProof,
+    setPin,
+    verifyPin,
+    loadProof,
+    spendProof,
+    readBlankCardPubkey,
+    writeProofs,
+  };
+};
+
+export default useCashuCard;

--- a/app/screens/card-screen/card.tsx
+++ b/app/screens/card-screen/card.tsx
@@ -97,13 +97,21 @@ export const CardScreen = () => {
       })
   }
 
+  const onCashuTopup = () => {
+    navigation.navigate("cashuTopup")
+  }
+
   return (
     <Screen
       keyboardOffset="navigationHeader"
       keyboardShouldPersistTaps="handled"
       backgroundColor={colors.background}
     >
-      {lnurl ? <Flashcard onReload={onReload} onTopup={onTopup} /> : <EmptyCard />}
+      {lnurl ? (
+        <Flashcard onReload={onReload} onTopup={onTopup} onCashuTopup={onCashuTopup} />
+      ) : (
+        <EmptyCard onCashuTopup={onCashuTopup} />
+      )}
     </Screen>
   )
 }

--- a/app/screens/card-screen/cashu-topup.helpers.ts
+++ b/app/screens/card-screen/cashu-topup.helpers.ts
@@ -1,0 +1,42 @@
+/**
+ * cashu-topup.helpers.ts
+ * Shared helpers for the Cashu card top-up flow.
+ */
+
+interface CashuProofGql {
+  id: string
+  amount: number
+  secret: string
+  C: string
+}
+
+/**
+ * Extract the 32-byte nonce hex from a P2PK secret JSON string.
+ * The nonce is what gets stored on the card (32-byte field of 77-byte proof slot).
+ */
+export function extractNonceFromSecret(secret: string): string {
+  try {
+    const parsed = JSON.parse(secret) as [string, { nonce: string }]
+    if (parsed[0] !== "P2PK" || !parsed[1]?.nonce) throw new Error("Not P2PK")
+    return parsed[1].nonce
+  } catch {
+    throw new Error(`Invalid P2PK secret: ${secret.slice(0, 60)}`)
+  }
+}
+
+/**
+ * Convert a GQL proof into the flat format needed for useCashuCard.writeProofs().
+ */
+export function toCardWriteProof(proof: CashuProofGql): {
+  keysetId: string
+  amount: number
+  nonce: string
+  C: string
+} {
+  return {
+    keysetId: proof.id,
+    amount: proof.amount,
+    nonce: extractNonceFromSecret(proof.secret),
+    C: proof.C,
+  }
+}

--- a/app/screens/card-screen/cashu-topup.tsx
+++ b/app/screens/card-screen/cashu-topup.tsx
@@ -1,0 +1,483 @@
+/**
+ * cashu-topup.tsx
+ *
+ * Cashu NFC card top-up screen (ENG-179).
+ *
+ * Flow:
+ *   amount  → User enters USD amount to load
+ *   pin     → User enters their card PIN (or sets one for blank cards)
+ *   tapping → NFC: SELECT + GET_INFO + GET_PUBKEY
+ *   minting → GQL: cashuCardProvision → proofs minted from user's USD wallet
+ *   writing → NFC: (SET_PIN +) VERIFY_PIN + LOAD_PROOF × N
+ *   success → Card is loaded, ready to spend
+ *   error   → Retry or cancel
+ */
+
+import React, { useCallback, useRef, useState } from "react"
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native"
+import { gql, useMutation } from "@apollo/client"
+import { StackNavigationProp } from "@react-navigation/stack"
+import { useNavigation } from "@react-navigation/native"
+import { makeStyles, Text, useTheme } from "@rneui/themed"
+import { Screen } from "@app/components/screen"
+import { useScanningQrCodeScreenQuery } from "@app/graphql/generated"
+import { useIsAuthed } from "@app/graphql/is-authed-context"
+import { WalletCurrency } from "@app/graphql/generated"
+
+import useCashuCard, { CashuCardError } from "../../nfc/useCashuCard"
+import { toCardWriteProof } from "./cashu-topup.helpers"
+import { RootStackParamList } from "@app/navigation/stack-param-lists"
+
+// ─── GQL ───────────────────────────────────────────────────────────────────
+// cashuCardProvision is defined in flash PR #296. Generated types pending
+// backend deployment — using manual typing until codegen is re-run.
+
+const CASHU_CARD_PROVISION = gql`
+  mutation cashuCardProvision($input: CashuCardProvisionInput!) {
+    cashuCardProvision(input: $input) {
+      errors {
+        __typename
+        message
+      }
+      proofs {
+        id
+        amount
+        secret
+        C
+      }
+      cardPubkey
+      totalAmountCents
+    }
+  }
+`
+
+interface CashuProofGql {
+  id: string
+  amount: number
+  secret: string
+  C: string
+}
+
+interface CashuCardProvisionPayload {
+  errors: { __typename: string; message: string }[]
+  proofs: CashuProofGql[]
+  cardPubkey: string
+  totalAmountCents: number
+}
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+type Step = "amount" | "pin" | "tapping" | "minting" | "writing" | "success" | "error"
+
+type Props = {
+  navigation: StackNavigationProp<RootStackParamList>
+}
+
+// ─── Component ─────────────────────────────────────────────────────────────
+
+export const CashuTopup: React.FC = () => {
+  const navigation = useNavigation<Props["navigation"]>()
+  const { colors } = useTheme().theme
+  const styles = useStyles()
+  const isAuthed = useIsAuthed()
+
+  const { data } = useScanningQrCodeScreenQuery({ skip: !isAuthed })
+  const wallets = data?.me?.defaultAccount?.wallets
+  const usdWallet = wallets?.find((w) => w.walletCurrency === WalletCurrency.Usd)
+
+  const [step, setStep] = useState<Step>("amount")
+  const [amountDisplay, setAmountDisplay] = useState("")
+  const [pin, setPin] = useState("")
+  const [progressMsg, setProgressMsg] = useState("")
+  const [errorMsg, setErrorMsg] = useState("")
+  const [successInfo, setSuccessInfo] = useState<{
+    proofCount: number
+    totalCents: number
+  } | null>(null)
+
+  const isTopUpRef = useRef(false)
+  const card = useCashuCard()
+
+  const [provisionMutation] = useMutation<{
+    cashuCardProvision: CashuCardProvisionPayload
+  }>(CASHU_CARD_PROVISION)
+
+  // ─── Helpers ──────────────────────────────────────────────────────────
+
+  const amountCents = (): number => {
+    const v = parseFloat(amountDisplay)
+    return isNaN(v) || v <= 0 ? 0 : Math.round(v * 100)
+  }
+
+  const formatCents = (cents: number) => `$${(cents / 100).toFixed(2)}`
+
+  // ─── Main top-up flow ─────────────────────────────────────────────────
+
+  const runTopup = useCallback(
+    async (pinValue: string) => {
+      if (!usdWallet?.id) {
+        Alert.alert("No USD wallet found")
+        return
+      }
+
+      try {
+        // Step: NFC — read card
+        setStep("tapping")
+        setProgressMsg("Hold card to phone…")
+        await card.startSession()
+
+        let cardPubkey: string
+        let isBlank: boolean
+        let availableSlots: number | undefined
+
+        try {
+          const { pubkey, info } = await card.readBlankCardPubkey()
+          cardPubkey = pubkey
+          isBlank = true
+          isTopUpRef.current = false
+          setProgressMsg(`Card ready · ${info.emptyCount} free slots`)
+        } catch (err) {
+          if (
+            err instanceof CashuCardError &&
+            err.message.includes("top-up flow")
+          ) {
+            isBlank = false
+            isTopUpRef.current = true
+            cardPubkey = await card.getPubkey()
+            const info = await card.getInfo()
+            if (info.emptyCount === 0) {
+              throw new CashuCardError("Card is full — no empty slots")
+            }
+            availableSlots = info.emptyCount
+            setProgressMsg(`Top-up · ${info.emptyCount} free slots`)
+          } else {
+            throw err
+          }
+        }
+
+        // Step: Mint proofs via GQL
+        setStep("minting")
+        setProgressMsg("Minting proofs…")
+
+        const result = await provisionMutation({
+          variables: {
+            input: {
+              walletId: usdWallet.id,
+              amountCents: amountCents(),
+              cardPubkey,
+              ...(availableSlots !== undefined && { availableSlots }),
+            },
+          },
+        })
+
+        const payload = result.data?.cashuCardProvision
+        if (!payload) throw new Error("No response from server")
+        if (payload.errors?.length > 0) throw new Error(payload.errors[0].message)
+        if (!payload.proofs?.length) throw new Error("No proofs returned from mint")
+
+        const { proofs, totalAmountCents } = payload
+
+        // Step: Write proofs to card
+        setStep("writing")
+        setProgressMsg(`Writing ${proofs.length} proofs…`)
+
+        const cardWriteProofs = proofs.map(toCardWriteProof)
+        await card.writeProofs(cardWriteProofs, pinValue, isBlank)
+        await card.cleanup()
+
+        // Success
+        setSuccessInfo({ proofCount: proofs.length, totalCents: totalAmountCents })
+        setStep("success")
+      } catch (err) {
+        await card.cleanup()
+
+        const msg = err instanceof Error ? err.message : "Unknown NFC error"
+        if (msg.toLowerCase().includes("cancel")) {
+          setStep("pin")
+          return
+        }
+        setErrorMsg(msg)
+        setStep("error")
+      }
+    },
+    [card, provisionMutation, usdWallet, amountDisplay],
+  )
+
+  // ─── Actions ──────────────────────────────────────────────────────────
+
+  const handleAmountNext = () => {
+    if (amountCents() < 100) {
+      Alert.alert("Minimum amount is $1.00")
+      return
+    }
+    setStep("pin")
+  }
+
+  const handlePinNext = () => {
+    if (pin.length < 4) {
+      Alert.alert("PIN must be at least 4 digits")
+      return
+    }
+    runTopup(pin)
+  }
+
+  const handleRetry = () => {
+    setStep("amount")
+    setAmountDisplay("")
+    setPin("")
+    setErrorMsg("")
+  }
+
+  // ─── Render ───────────────────────────────────────────────────────────
+
+  return (
+    <Screen
+      preset="scroll"
+      keyboardOffset="navigationHeader"
+      keyboardShouldPersistTaps="handled"
+      style={styles.screen}
+    >
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        style={styles.flex}
+      >
+        <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+
+          {/* Amount */}
+          {step === "amount" && (
+            <View style={styles.section}>
+              <Text type="h1" bold style={styles.title}>
+                Top Up Flash Card
+              </Text>
+              <Text style={styles.subtitle}>
+                How much would you like to load (USD)?
+              </Text>
+              <View style={styles.amountRow}>
+                <Text type="h1" bold style={[styles.currency, { color: colors.primary }]}>
+                  $
+                </Text>
+                <TextInput
+                  style={[styles.amountInput, { color: colors.black }]}
+                  value={amountDisplay}
+                  onChangeText={setAmountDisplay}
+                  keyboardType="decimal-pad"
+                  placeholder="0.00"
+                  placeholderTextColor={colors.grey3}
+                  maxLength={8}
+                  autoFocus
+                />
+              </View>
+              <TouchableOpacity
+                style={[styles.primaryBtn, { backgroundColor: colors.primary }]}
+                onPress={handleAmountNext}
+              >
+                <Text bold style={styles.primaryBtnText}>
+                  Next →
+                </Text>
+              </TouchableOpacity>
+            </View>
+          )}
+
+          {/* PIN */}
+          {step === "pin" && (
+            <View style={styles.section}>
+              <Text type="h1" bold style={styles.title}>
+                Card PIN
+              </Text>
+              <Text style={styles.subtitle}>
+                Loading {formatCents(amountCents())} onto your card.{"\n"}
+                Enter your card PIN (4–8 digits). If this is a new card, you'll set the PIN now.
+              </Text>
+              <TextInput
+                style={[styles.pinInput, { borderBottomColor: colors.primary, color: colors.black }]}
+                value={pin}
+                onChangeText={setPin}
+                keyboardType="numeric"
+                secureTextEntry
+                placeholder="PIN"
+                placeholderTextColor={colors.grey3}
+                maxLength={8}
+                autoFocus
+              />
+              <TouchableOpacity
+                style={[styles.primaryBtn, { backgroundColor: colors.primary }]}
+                onPress={handlePinNext}
+              >
+                <Text bold style={styles.primaryBtnText}>
+                  Tap Card →
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={styles.secondaryBtn} onPress={() => setStep("amount")}>
+                <Text style={{ color: colors.grey3 }}>← Back</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+
+          {/* In-progress */}
+          {(step === "tapping" || step === "minting" || step === "writing") && (
+            <View style={styles.section}>
+              <Text type="h1" bold style={styles.title}>
+                {step === "tapping" ? "📡 Tap Card" : step === "minting" ? "⚙️  Minting" : "✍️  Writing"}
+              </Text>
+              <ActivityIndicator size="large" color={colors.primary} style={styles.spinner} />
+              <Text style={[styles.subtitle, { textAlign: "center" }]}>{progressMsg}</Text>
+              {step === "tapping" && (
+                <Text style={{ color: colors.grey3, textAlign: "center" }}>
+                  Hold your Flash card near the top of the phone
+                </Text>
+              )}
+            </View>
+          )}
+
+          {/* Success */}
+          {step === "success" && successInfo && (
+            <View style={styles.section}>
+              <Text style={styles.emoji}>✅</Text>
+              <Text type="h1" bold style={styles.title}>
+                Card Loaded!
+              </Text>
+              <Text style={styles.subtitle}>
+                {formatCents(successInfo.totalCents)} loaded across{" "}
+                {successInfo.proofCount} denomination{successInfo.proofCount !== 1 ? "s" : ""}.
+              </Text>
+              <Text style={{ color: colors.grey3, textAlign: "center", marginBottom: 24 }}>
+                Your card is ready for offline payments.
+              </Text>
+              <TouchableOpacity
+                style={[styles.primaryBtn, { backgroundColor: colors.primary }]}
+                onPress={() => navigation.goBack()}
+              >
+                <Text bold style={styles.primaryBtnText}>
+                  Done
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.secondaryBtn}
+                onPress={() => {
+                  setStep("amount")
+                  setAmountDisplay("")
+                  setPin("")
+                  setSuccessInfo(null)
+                }}
+              >
+                <Text style={{ color: colors.grey3 }}>Top Up Again</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+
+          {/* Error */}
+          {step === "error" && (
+            <View style={styles.section}>
+              <Text style={styles.emoji}>❌</Text>
+              <Text type="h1" bold style={styles.title}>
+                Top-Up Failed
+              </Text>
+              <Text style={[styles.subtitle, { color: colors.error }]}>{errorMsg}</Text>
+              <TouchableOpacity
+                style={[styles.primaryBtn, { backgroundColor: colors.primary }]}
+                onPress={handleRetry}
+              >
+                <Text bold style={styles.primaryBtnText}>
+                  Try Again
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={styles.secondaryBtn} onPress={() => navigation.goBack()}>
+                <Text style={{ color: colors.grey3 }}>Cancel</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </Screen>
+  )
+}
+
+// ─── Styles ─────────────────────────────────────────────────────────────────
+
+const useStyles = makeStyles(({ colors }) => ({
+  flex: {
+    flex: 1,
+  },
+  screen: {
+    flex: 1,
+    paddingHorizontal: 0,
+  },
+  content: {
+    flexGrow: 1,
+    justifyContent: "center",
+    padding: 24,
+  },
+  section: {
+    alignItems: "center",
+  },
+  title: {
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  subtitle: {
+    color: colors.grey2,
+    textAlign: "center",
+    marginBottom: 24,
+    lineHeight: 22,
+  },
+  amountRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 32,
+  },
+  currency: {
+    fontSize: 36,
+    marginRight: 4,
+  },
+  amountInput: {
+    fontSize: 48,
+    fontWeight: "700",
+    minWidth: 120,
+    textAlign: "center",
+  },
+  pinInput: {
+    fontSize: 32,
+    fontWeight: "700",
+    borderBottomWidth: 2,
+    width: 200,
+    textAlign: "center",
+    marginBottom: 32,
+    paddingBottom: 8,
+    letterSpacing: 12,
+  },
+  spinner: {
+    marginVertical: 32,
+  },
+  emoji: {
+    fontSize: 64,
+    marginBottom: 16,
+  },
+  primaryBtn: {
+    borderRadius: 12,
+    paddingVertical: 16,
+    paddingHorizontal: 48,
+    marginTop: 8,
+    width: "100%",
+    alignItems: "center",
+  },
+  primaryBtnText: {
+    color: colors.white,
+    fontSize: 17,
+  },
+  secondaryBtn: {
+    paddingVertical: 14,
+    marginTop: 4,
+    alignItems: "center",
+  },
+}))

--- a/app/screens/card-screen/index.ts
+++ b/app/screens/card-screen/index.ts
@@ -1,2 +1,3 @@
 export * from "./card"
 export * from "./flashcard-topup"
+export * from "./cashu-topup"

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -107,7 +107,7 @@ export const SettingsScreen: React.FC = () => {
       {(currentLevel === AccountLevel.Two || currentLevel === AccountLevel.Three) && (
         <SettingsGroup name="Reports" items={items.reports} />
       )}
-      <SettingsGroup name="Experimental" items={items.experimental} />
+      <SettingsGroup name="Chat" items={items.experimental} />
       <SettingsGroup name={LL.SettingsScreen.keysManagement()} items={items.wallet} />
       <SettingsGroup name={LL.common.preferences()} items={items.preferences} />
       <SettingsGroup

--- a/jest.helpers.config.js
+++ b/jest.helpers.config.js
@@ -1,0 +1,24 @@
+/**
+ * jest.helpers.config.js
+ *
+ * Minimal Jest config for pure-logic helper tests (no RN, no auto-mock transforms).
+ * Avoids the ttypescript/TypeScript-5 incompatibility in the main jest.config.js.
+ * Use: npx jest --config jest.helpers.config.js __tests__/card/
+ */
+module.exports = {
+  preset: "react-native",
+  transform: {
+    "\\.(ts|tsx)$": "babel-jest",
+    "^.+\\.svg$": "jest-transform-stub",
+  },
+  testRegex: "(/__tests__/.*\\.(test|spec))\\.(ts|tsx|js)$",
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  rootDir: ".",
+  moduleNameMapper: {
+    "^@app/(.*)$": ["<rootDir>/app/$1"],
+    "^@mocks/(.*)$": ["<rootDir>/__mocks__/$1"],
+  },
+  transformIgnorePatterns: [
+    "node_modules/(?!(react-native|@react-native|@react-navigation|@rneui)/)",
+  ],
+}

--- a/tsconfig.helpers.json
+++ b/tsconfig.helpers.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "jsx": "react",
+    "types": ["@types/jest"]
+  },
+  "include": ["app", "__tests__/card"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
Users can top up their Flash card with Cashu proofs directly from the mobile app, enabling offline bearer payments (NUT-XX Profile B).

## New NFC layer
- `app/nfc/cashu-apdu.ts` — APDU layer for CashuApplet (`D2 76 00 00 85 01 02`)
- `app/nfc/useCashuCard.ts` — `NfcTech.IsoDep` session hook with `startSession / cleanup / readBlankCardPubkey / writeProofs`

## New screen
`app/screens/card-screen/cashu-topup.tsx`
- Amount entry → PIN setup → NFC tap → proof minting → proof writing → success
- Blank card: sets PIN + writes proofs (first issue)
- Existing card: verifies PIN + writes to free slots (top-up)

## UX entry points
- **EmptyCard**: new 'Top Up Flash Card' button
- **Flashcard**: new 'Flash Top-Up' icon button alongside existing Reload / QR Topup

## Depends on
- lnflash/flash#296 — `cashuCardProvision` GQL mutation (ENG-174/175)
- lnflash/cashu-javacard main — CashuApplet with BIP-340 Schnorr (ENG-181)
- lnflash/flash-pos#47 — tap-to-pay acceptance (ENG-177/178)