### PR TITLE
fix: JMD Currency Precision — Mobile (Send/Receive, TxItem, Breez)

### DIFF
--- a/app/components/transaction-item/TxItem.tsx
+++ b/app/components/transaction-item/TxItem.tsx
@@ -77,12 +77,24 @@ export const TxItem: React.FC<Props> = React.memo(({ tx }) => {
     })
     secondaryAmount = formatMoneyAmount({ moneyAmount })
   } else {
-    // Ibex transaction - always USD
-    const amount = tx.transaction.settlementAmount * 100
-    const moneyAmount = toUsdMoneyAmount(amount ?? NaN)
-    primaryAmount = moneyAmountToDisplayCurrencyString({
-      moneyAmount,
-    })
+    // Ibex transaction — use the historical settlementDisplayAmount from the API
+    // instead of re-computing from the live BTC price (which changes over time).
+    // settlementAmount is already in cents — do NOT multiply by 100.
+    const settlementDisplay = tx.transaction.settlementDisplayAmount
+    const settlementDisplayCurrency = tx.transaction.settlementDisplayCurrency
+
+    if (settlementDisplay && settlementDisplayCurrency) {
+      // Use the locked-in display amount from settlement time
+      primaryAmount = `${settlementDisplayCurrency === "USD" ? "$" : ""}${settlementDisplay} ${settlementDisplayCurrency}`
+    } else {
+      // Fallback: convert from settlement amount (already in cents)
+      const moneyAmount = toUsdMoneyAmount(tx.transaction.settlementAmount ?? NaN)
+      primaryAmount = moneyAmountToDisplayCurrencyString({
+        moneyAmount,
+      })
+    }
+
+    const moneyAmount = toUsdMoneyAmount(tx.transaction.settlementAmount ?? NaN)
     if (convertMoneyAmount) {
       secondaryAmount = formatMoneyAmount({
         moneyAmount: convertMoneyAmount(moneyAmount, "BTC"),

--- a/app/components/transaction-item/TxItem.tsx
+++ b/app/components/transaction-item/TxItem.tsx
@@ -85,7 +85,9 @@ export const TxItem: React.FC<Props> = React.memo(({ tx }) => {
 
     if (settlementDisplay && settlementDisplayCurrency) {
       // Use the locked-in display amount from settlement time
-      primaryAmount = `${settlementDisplayCurrency === "USD" ? "$" : ""}${settlementDisplay} ${settlementDisplayCurrency}`
+      const currencySymbol =
+        settlementDisplayCurrency === "USD" ? "$" : ""
+      primaryAmount = `${currencySymbol}${settlementDisplay} ${settlementDisplayCurrency}`
     } else {
       // Fallback: convert from settlement amount (already in cents)
       const moneyAmount = toUsdMoneyAmount(tx.transaction.settlementAmount ?? NaN)

--- a/app/hooks/use-price-conversion.ts
+++ b/app/hooks/use-price-conversion.ts
@@ -96,7 +96,9 @@ export const usePriceConversion = () => {
       let amount =
         moneyAmount.amount * priceOfCurrencyInCurrency(moneyAmount.currency, toCurrency)
 
-      if (toCurrency === "BTC") {
+      // Round all currency conversions to avoid sending floats to the API
+      // (API expects integer cents for USD, integer sats for BTC)
+      if (toCurrency === "BTC" || toCurrency === "USD") {
         amount = Math.round(amount)
       }
 

--- a/app/screens/receive-bitcoin-screen/payment/payment-request.ts
+++ b/app/screens/receive-bitcoin-screen/payment/payment-request.ts
@@ -118,12 +118,13 @@ export const createPaymentRequest = (
       // Handle USD payment requests
       if (pr.type === Invoice.Lightning) {
         if (pr.settlementAmount && pr.settlementAmount?.currency === WalletCurrency.Usd) {
-          console.log("Invoice create amount: ", pr.settlementAmount.amount)
+          const roundedAmount = Math.round(pr.settlementAmount.amount)
+          console.log("Invoice create amount: ", roundedAmount)
           const { data, errors } = await mutations.lnUsdInvoiceCreate({
             variables: {
               input: {
                 walletId: pr.receivingWalletDescriptor.id,
-                amount: pr.settlementAmount.amount,
+                amount: roundedAmount,
                 memo: pr.memo,
               },
             },

--- a/app/screens/send-bitcoin-screen/payment-details/intraledger.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/intraledger.ts
@@ -61,7 +61,7 @@ export const createIntraledgerPaymentDetails = <T extends WalletCurrency>(
           input: {
             walletId: sendingWalletDescriptor.id,
             recipientWalletId,
-            amount: settlementAmount.amount,
+            amount: Math.round(settlementAmount.amount),
             memo,
           },
         },
@@ -89,7 +89,7 @@ export const createIntraledgerPaymentDetails = <T extends WalletCurrency>(
           input: {
             walletId: sendingWalletDescriptor.id,
             recipientWalletId,
-            amount: settlementAmount.amount,
+            amount: Math.round(settlementAmount.amount),
             memo,
           },
         },

--- a/app/utils/transactions.ts
+++ b/app/utils/transactions.ts
@@ -2,7 +2,7 @@ import type { Payment } from "@breeztech/breez-sdk-spark-react-native"
 import { TranslationFunctions } from "@app/i18n/i18n-types"
 import { ConvertMoneyAmount } from "@app/screens/send-bitcoin-screen/payment-details"
 import { WalletCurrency } from "@app/graphql/generated"
-import { toBtcMoneyAmount } from "@app/types/amounts"
+import { DisplayCurrency, toBtcMoneyAmount } from "@app/types/amounts"
 import type { BreezTransaction } from "@app/types/transactions"
 
 const getUserTimezoneDate = (date: Date): Date => {
@@ -96,14 +96,15 @@ export const formatBreezPayment = ({
   payment: Payment
   convertMoneyAmount: ConvertMoneyAmount
 }): BreezTransaction => {
+  // Convert to the user's display currency (e.g. JMD), not hardcoded USD
   const displayAmount = convertMoneyAmount(
     toBtcMoneyAmount(Number(payment.amount)),
-    WalletCurrency.Usd,
+    DisplayCurrency,
   )
 
   const displayFee = convertMoneyAmount(
     toBtcMoneyAmount(Number(payment.fees)),
-    WalletCurrency.Usd,
+    DisplayCurrency,
   )
 
   return {


### PR DESCRIPTION
## Summary

Fixes the mobile portion of the JMD currency precision bugs described in lnflash/flash#282.

**Send/Receive Rounding** (`app/hooks/use-price-conversion.ts`)
- `convertMoneyAmount()` only called `Math.round()` for BTC target — USD conversions were left as floats
- Now rounds for both BTC and USD targets, preventing float values from reaching the GraphQL API

**Defensive Rounding at API Call Sites**
- `payment-request.ts`: `Math.round()` before `lnUsdInvoiceCreate` mutation
- `intraledger.ts`: `Math.round()` before `intraLedgerPaymentSend` and `intraLedgerUsdPaymentSend` mutations

**Transaction List** (`app/components/transaction-item/TxItem.tsx`)
- Was re-computing JMD amounts from live BTC price — now uses `settlementDisplayAmount` / `settlementDisplayCurrency` from the API (the historical amount locked at settlement time)
- Removed erroneous `settlementAmount * 100` — `settlementAmount` is already in cents

**Breez Payments** (`app/utils/transactions.ts`)
- `formatBreezPayment` converted to hardcoded `WalletCurrency.Usd` — now converts to `DisplayCurrency` (user's chosen currency, e.g. JMD)

## Test plan
- [ ] JMD user: send USD payment — verify amount matches what was entered (no rounding loss)
- [ ] JMD user: receive Lightning invoice — verify invoice amount is correct integer
- [ ] Transaction list: verify amounts don't change when BTC price moves
- [ ] Transaction list: verify USD wallet amounts are correct (not inflated 100x)
- [ ] BTC transactions via Breez: verify display in JMD (not USD)

Resolves lnflash/flash#282 (mobile portion — backend PR at lnflash/flash#304)