### PR TITLE
fix: Fee row on payment confirmation — visual prominence

### DIFF
--- a/app/components/send-flow/ConfirmationWalletFee.tsx
+++ b/app/components/send-flow/ConfirmationWalletFee.tsx
@@ -5,12 +5,12 @@ import { makeStyles, Text } from "@rneui/themed"
 
 // hooks
 import useFee, { FeeType } from "@app/screens/send-bitcoin-screen/use-fee"
-import { useDisplayCurrency } from "@app/hooks/use-display-currency"
+import { useDisplayCurrency, usePriceConversion } from "@app/hooks"
 
 // types
 import { WalletCurrency } from "@app/graphql/generated"
 import { PaymentDetail } from "@app/screens/send-bitcoin-screen/payment-details"
-import { DisplayCurrency } from "@app/types/amounts"
+import { DisplayCurrency, toUsdMoneyAmount } from "@app/types/amounts"
 
 // utils
 import { testProps } from "@app/utils/testProps"
@@ -41,11 +41,21 @@ const ConfirmationWalletFee: React.FC<Props> = ({
   setFee,
   setPaymentError,
 }) => {
-  const { sendingWalletDescriptor, getFee, settlementAmount, paymentType } = paymentDetail
+  const { sendingWalletDescriptor, getFee, settlementAmount, paymentType, convertMoneyAmount } =
+    paymentDetail
   const { LL } = useI18nContext()
   const styles = useStyles()
   const getLightningFee = useFee(getFee ? getFee : null)
   const { formatDisplayAndWalletAmount } = useDisplayCurrency()
+  const { convertMoneyAmount: globalConvert } = usePriceConversion()
+
+  // Check if transfer exceeds $10 USD equivalent for WU comparison line
+  const showWuComparison = (() => {
+    if (!globalConvert) return false
+    const usdAmount = globalConvert(settlementAmount, WalletCurrency.Usd)
+    // settlementAmount for USD is in cents, so $10 = 1000 cents
+    return usdAmount.amount >= 1000
+  })()
 
   useEffect(() => {
     getSendingFee()
@@ -127,19 +137,34 @@ const ConfirmationWalletFee: React.FC<Props> = ({
           {LL.SendBitcoinConfirmationScreen.feeLabel()}
         </Text>
         <View style={styles.fieldBackground}>
-          {fee.status === "loading" && <ActivityIndicator />}
-          {fee.status === "set" && (
-            <Text {...testProps("Successful Fee")}>{feeDisplayText}</Text>
-          )}
-          {fee.status === "error" && Boolean(fee.amount) && (
-            <Text>{feeDisplayText} *</Text>
-          )}
-          {fee.status === "error" && !fee.amount && (
-            <Text>{LL.SendBitcoinConfirmationScreen.feeError()}</Text>
-          )}
-          {fee.status === "unset" && !fee.amount && (
-            <Text>{LL.SendBitcoinConfirmationScreen.breezFeeText()}</Text>
-          )}
+          <View style={styles.feeContentContainer}>
+            <View style={styles.feeValueRow}>
+              {fee.status === "loading" && <ActivityIndicator />}
+              {fee.status === "set" && (
+                <Text style={styles.feeValueText} {...testProps("Successful Fee")}>
+                  {feeDisplayText}
+                </Text>
+              )}
+              {fee.status === "error" && Boolean(fee.amount) && (
+                <Text style={styles.feeValueText}>{feeDisplayText} *</Text>
+              )}
+              {fee.status === "error" && !fee.amount && (
+                <Text style={styles.feeValueText}>
+                  {LL.SendBitcoinConfirmationScreen.feeError()}
+                </Text>
+              )}
+              {fee.status === "unset" && !fee.amount && (
+                <Text style={styles.feeValueText}>
+                  {LL.SendBitcoinConfirmationScreen.breezFeeText()}
+                </Text>
+              )}
+            </View>
+            {showWuComparison && (
+              <Text style={styles.wuComparisonText}>
+                Western Union charges ~J$1,800 for this transfer
+              </Text>
+            )}
+          </View>
         </View>
         {fee.status === "error" && Boolean(fee.amount) && (
           <Text style={styles.maxFeeWarningText}>
@@ -189,6 +214,25 @@ const useStyles = makeStyles(({ colors }) => ({
   walletSelectorBalanceContainer: {
     flex: 1,
     flexDirection: "row",
+  },
+  feeContentContainer: {
+    flex: 1,
+    flexDirection: "column",
+    justifyContent: "center",
+  },
+  feeValueRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  feeValueText: {
+    color: "#3ab54a",
+    fontWeight: "bold",
+    fontSize: 16,
+  },
+  wuComparisonText: {
+    color: colors.grey3,
+    fontSize: 12,
+    marginTop: 2,
   },
   maxFeeWarningText: {
     color: colors.warning,

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -701,7 +701,7 @@ const en: BaseTranslation = {
     confirmPayment: "Confirm payment",
     confirmPaymentQuestion: "Do you want to confirm this payment?",
     destinationLabel: "To:",
-    feeLabel: "Fee",
+    feeLabel: "Flash fee:",
     memoLabel: "Note:",
     paymentFinal: "Payments are final.",
     stalePrice:


### PR DESCRIPTION
## Summary

Addresses #561 — gives the fee row on the send confirmation screen visual prominence to highlight Flash's zero-fee advantage over traditional remittance services.

### Changes

**`app/components/send-flow/ConfirmationWalletFee.tsx`**
- Fee value styled in **brand green (`#3ab54a`)** with **bold** font weight to draw attention
- Added Western Union comparison line: *"Western Union charges ~J$1,800 for this transfer"* in small gray text below the fee value
- Comparison line only renders when the transfer amount exceeds **$10 USD equivalent** (per issue spec)
- Uses `usePriceConversion` to determine USD equivalent for the threshold check

**`app/i18n/en/index.ts`**
- Fee label changed from `"Fee"` → `"Flash fee:"`

### Before / After
- **Before:** Fee row has same visual weight as other data rows
- **After:** Fee value is green/bold, with a subtle WU comparison line that reinforces Flash's value proposition

## Test plan
- [ ] Send confirmation screen: verify "Flash fee:" label appears
- [ ] Fee value renders in green (#3ab54a) and bold
- [ ] Transfer > $10 USD: WU comparison line appears
- [ ] Transfer < $10 USD: WU comparison line is hidden
- [ ] BTC and USD wallet sends both show correct styling

Resolves #561