### PR TITLE
fix: show error when source wallet is empty in swap flow

### DIFF
--- a/app/components/swap-flow/ConversionAmountError.tsx
+++ b/app/components/swap-flow/ConversionAmountError.tsx
@@ -51,10 +51,19 @@ const ConversionAmountError: React.FC<Props> = ({
 
   useEffect(() => {
     checkErrorMessage()
-  }, [fromWalletCurrency, settlementSendAmount.amount])
+  }, [fromWalletCurrency, settlementSendAmount.amount, btcBalance.amount, usdBalance.amount])
 
   const checkErrorMessage = () => {
     if (!convertMoneyAmount) return null
+
+    // Check if source wallet has zero balance - show error immediately
+    const sourceBalance = fromWalletCurrency === "BTC" ? btcBalance.amount : usdBalance.amount
+    if (sourceBalance === 0 || Number.isNaN(sourceBalance)) {
+      const balanceText = fromWalletCurrency === "BTC" ? formattedBtcBalance : formattedUsdBalance
+      setErrorMsg(LL.SendBitcoinScreen.amountExceed({ balance: balanceText || "0" }))
+      return
+    }
+
     let amountFieldError: string | undefined = undefined
     if (
       lessThan({


### PR DESCRIPTION
## Summary

Fixes #527

When a user taps the swap button and the source wallet has zero balance, a red error message is now displayed immediately.

## Changes

- Modified \ConversionAmountError.tsx\ to check if source wallet balance is 0 or NaN
- Added immediate error display when entering swap flow with empty wallet
- Added dependency on balance amounts in useEffect to trigger re-check

## Testing

- [ ] Error shows when BTC wallet is empty and user tries to swap BTC to USD
- [ ] Error shows when USD wallet is empty and user tries to swap USD to BTC  
- [ ] Error message is clear: shows balance (0) exceeds amount
- [ ] Normal swap flow unaffected when wallets have balance

## Screenshot

Will add before/after screenshots showing the red error message on empty wallet.

## Lightning Address

[待提供]