### PR TITLE
fix(contacts): skip overwrite prompt when no kind-3 contact list exists (ENG-302)

### DIFF
--- a/app/utils/nostr.ts
+++ b/app/utils/nostr.ts
@@ -228,7 +228,10 @@ export const addToContactList = async (
     return
   }
 
-  if (!contactsEvent) {
+  // ENG-302: If the user has no existing kind-3 contact list, create one silently
+  // instead of prompting — there is nothing to overwrite, so the modal is wrong here.
+  // The confirmOverwrite prompt is only appropriate when replacing an existing list.
+  if (contactsEvent) {
     const confirmed = await confirmOverwrite()
     if (!confirmed) return
   }


### PR DESCRIPTION
## Summary

Fixes **ENG-302** — after a successful payment/zap, Android shows a blocking "No Contacts Available" modal when the user has no existing kind-3 Nostr contact list.

## Root Cause

`addToContactList()` in `app/utils/nostr.ts` called `confirmOverwrite()` (which shows the modal) when `contactsEvent` was `undefined`. The intent of that check was to warn before replacing an existing contact list — but it was firing in the wrong case (no list at all).

## Fix

Flipped the condition: the `confirmOverwrite` prompt only fires when the user **has** an existing `contactsEvent`. When there's no existing list, we create a new kind-3 event silently — nothing to overwrite, no modal needed.

```ts
// Before (fires modal when no list exists — wrong)
if (!contactsEvent) {
  const confirmed = await confirmOverwrite()
  if (!confirmed) return
}

// After (only prompt when replacing existing list — correct)
if (contactsEvent) {
  const confirmed = await confirmOverwrite()
  if (!confirmed) return
}
```

## Platforms
- **Android:** modal no longer appears after successful payment/zap
- **iOS:** contact auto-add should now succeed silently (previously failed silently without the modal, still no contact added — this fixes the underlying issue)

## Related
- Linear: <https://linear.app/island-bitcoin/issue/ENG-302>
- Overlaps with PR #608 (zap-message) — if #608 merges first, this fix should be ported to that branch too