### PR TITLE
fix: Round USD amounts in price conversion to prevent precision loss

### DIFF
--- a/app/hooks/use-price-conversion.ts
+++ b/app/hooks/use-price-conversion.ts
@@ -96,7 +96,7 @@ export const usePriceConversion = () => {
       let amount =
         moneyAmount.amount * priceOfCurrencyInCurrency(moneyAmount.currency, toCurrency)
 
-      if (toCurrency === "BTC") {
+      if (toCurrency === WalletCurrency.Btc || toCurrency === WalletCurrency.Usd) {
         amount = Math.round(amount)
       }
 


### PR DESCRIPTION
Fixes #282 (mobile portion)

## Problem

`convertMoneyAmount()` only called `Math.round()` when converting TO BTC. USD conversions were left as JavaScript floats (e.g., 625.78...) which were sent directly to the GraphQL API expecting integers. The API truncated the value (→ 625), causing users to lose money on every JMD→USD conversion.

## Root Cause

```typescript
// use-price-conversion.ts (line 99)
if (toCurrency === "BTC") {
  amount = Math.round(amount)
}
// USD amounts left as floats!
```

## Fix

```diff
- if (toCurrency === "BTC") {
+ if (toCurrency === WalletCurrency.Btc || toCurrency === WalletCurrency.Usd) {
    amount = Math.round(amount)
  }
```

## Impact

- JMD$1,000 → USD conversion now correctly produces integer cents
- No more truncation loss on every transaction
- Transaction history amounts remain consistent

## File Changed
- `app/hooks/use-price-conversion.ts` (1 line)