### PR TITLE
feat: add featured Nostr profile view

### DIFF
--- a/app/components/version/version.tsx
+++ b/app/components/version/version.tsx
@@ -7,6 +7,11 @@ import type { StackNavigationProp } from "@react-navigation/stack"
 import type { RootStackParamList } from "../../navigation/stack-param-lists"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { testProps } from "../../utils/testProps"
+import ReactNativeHapticFeedback from "react-native-haptic-feedback"
+
+// Featured profile entry point (long-press on version)
+import { FEATURED_PROFILE } from "@app/constants/featured-profile"
+import { logFeaturedProfileSelected } from "@app/utils/analytics"
 
 type VersionComponentNavigationProp = StackNavigationProp<
   RootStackParamList,
@@ -18,6 +23,14 @@ export const VersionComponent = () => {
   const { navigate } = useNavigation<VersionComponentNavigationProp>()
   const { LL } = useI18nContext()
   const [secretMenuCounter, setSecretMenuCounter] = React.useState(0)
+
+  // Long-press featured-profile entry
+  const longPressTimer = React.useRef<NodeJS.Timeout | null>(null)
+  const progressInterval = React.useRef<NodeJS.Timeout | null>(null)
+  const progressAnim = React.useRef(new Animated.Value(0)).current
+  const [isPressing, setIsPressing] = React.useState(false)
+
+  // Existing developer screen behavior
   React.useEffect(() => {
     if (secretMenuCounter > 2) {
       navigate("developerScreen")
@@ -26,6 +39,77 @@ export const VersionComponent = () => {
   }, [navigate, secretMenuCounter])
 
   const readableVersion = DeviceInfo.getReadableVersion()
+
+  // Long-press handlers for featured-profile entry
+  const handlePressIn = () => {
+    setIsPressing(true)
+    let progress = 0
+    
+    // Progressive haptic feedback during hold
+    progressInterval.current = setInterval(() => {
+      progress += 0.04 // 5 seconds = 125 intervals at 40ms
+      
+      // Light haptic every 1 second (25 intervals)
+      if (Math.floor(progress * 25) > Math.floor((progress - 0.04) * 25)) {
+        ReactNativeHapticFeedback.trigger('impactLight', {
+          enableVibrateFallback: true,
+          ignoreAndroidSystemSettings: false,
+        })
+      }
+      
+      // Animate progress
+      Animated.timing(progressAnim, {
+        toValue: progress,
+        duration: 40,
+        useNativeDriver: false,
+      }).start()
+      
+      if (progress >= 1) {
+        // Success — open the featured profile view
+        clearInterval(progressInterval.current!)
+        progressInterval.current = null
+        setIsPressing(false)
+
+        // Strong haptic on success
+        ReactNativeHapticFeedback.trigger('notificationSuccess', {
+          enableVibrateFallback: true,
+          ignoreAndroidSystemSettings: false,
+        })
+
+        // Analytics
+        logFeaturedProfileSelected({ discoveryMethod: 'long_press' })
+
+        // Navigate
+        navigate("FeaturedProfileView", { entryPoint: 'long_press' })
+
+        // Reset progress
+        progressAnim.setValue(0)
+      }
+    }, 40)
+  }
+
+  const handlePressOut = () => {
+    setIsPressing(false)
+    
+    // Clear the interval
+    if (progressInterval.current) {
+      clearInterval(progressInterval.current)
+      progressInterval.current = null
+    }
+    
+    // Animate progress back to 0
+    Animated.timing(progressAnim, {
+      toValue: 0,
+      duration: 200,
+      useNativeDriver: false,
+    }).start()
+  }
+
+  // Calculate progress ring circumference
+  const size = 80
+  const strokeWidth = 3
+  const radius = (size - strokeWidth) / 2
+  const circumference = radius * 2 * Math.PI
 
   return (
     <Pressable

--- a/app/components/version/version.tsx
+++ b/app/components/version/version.tsx
@@ -18,9 +18,12 @@ type VersionComponentNavigationProp = StackNavigationProp<
   "getStarted" | "settings"
 >
 
-// Tick cadence for the long-press progress animation.
-const PROGRESS_TICK_MS = 40
-const PROGRESS_INCREMENT = PROGRESS_TICK_MS / FEATURED_PROFILE.LONG_PRESS_DURATION_MS
+// Number of haptic pulses across the full hold (light "ticks" at each 1/N of the
+// duration, giving the user a sense of progress).
+const HAPTIC_PULSE_COUNT = 5
+
+// Reset animation duration when the user lifts their finger early.
+const RESET_ANIM_MS = 200
 
 export const VersionComponent = () => {
   const styles = useStyles()
@@ -31,9 +34,14 @@ export const VersionComponent = () => {
   const [secretMenuCounter, setSecretMenuCounter] = React.useState(0)
 
   // Long-press featured-profile entry
-  const progressInterval = React.useRef<NodeJS.Timeout | null>(null)
   const progressAnim = React.useRef(new Animated.Value(0)).current
   const [isPressing, setIsPressing] = React.useState(false)
+
+  // Track the last haptic-pulse bucket so we only fire each pulse once per hold.
+  const lastPulseBucket = React.useRef(-1)
+  // Track whether the current hold has already completed (to avoid firing the
+  // completion path twice if the animation and a late `onPressOut` race).
+  const hasCompleted = React.useRef(false)
 
   // Existing developer screen behavior
   React.useEffect(() => {
@@ -43,33 +51,22 @@ export const VersionComponent = () => {
     }
   }, [navigate, secretMenuCounter])
 
-  const readableVersion = DeviceInfo.getReadableVersion()
-
-  const handlePressIn = () => {
-    setIsPressing(true)
-    let progress = 0
-
-    progressInterval.current = setInterval(() => {
-      const prev = progress
-      progress += PROGRESS_INCREMENT
-
-      // Light haptic at each ~1/5 of the hold (5 pulses across the full duration).
-      if (Math.floor(progress * 5) > Math.floor(prev * 5)) {
+  // Drive haptic pulses and completion off the animation engine instead of a
+  // setInterval. This removes the manual tick loop (and with it the unmount
+  // leak) while keeping the progress-ring / haptic UX unchanged.
+  React.useEffect(() => {
+    const id = progressAnim.addListener(({ value }) => {
+      const bucket = Math.floor(value * HAPTIC_PULSE_COUNT)
+      if (bucket > lastPulseBucket.current && bucket < HAPTIC_PULSE_COUNT) {
+        lastPulseBucket.current = bucket
         ReactNativeHapticFeedback.trigger("impactLight", {
           enableVibrateFallback: true,
           ignoreAndroidSystemSettings: false,
         })
       }
 
-      Animated.timing(progressAnim, {
-        toValue: progress,
-        duration: PROGRESS_TICK_MS,
-        useNativeDriver: false,
-      }).start()
-
-      if (progress >= 1) {
-        clearInterval(progressInterval.current!)
-        progressInterval.current = null
+      if (value >= 1 && !hasCompleted.current) {
+        hasCompleted.current = true
         setIsPressing(false)
 
         ReactNativeHapticFeedback.trigger("notificationSuccess", {
@@ -81,23 +78,46 @@ export const VersionComponent = () => {
         navigate("FeaturedProfileView", { entryPoint: "long_press" })
 
         progressAnim.setValue(0)
+        lastPulseBucket.current = -1
       }
-    }, PROGRESS_TICK_MS)
+    })
+
+    return () => {
+      progressAnim.removeListener(id)
+      progressAnim.stopAnimation()
+    }
+  }, [progressAnim, navigate])
+
+  const readableVersion = DeviceInfo.getReadableVersion()
+
+  const handlePressIn = () => {
+    // Reset per-hold state.
+    lastPulseBucket.current = -1
+    hasCompleted.current = false
+    setIsPressing(true)
+
+    Animated.timing(progressAnim, {
+      toValue: 1,
+      duration: FEATURED_PROFILE.LONG_PRESS_DURATION_MS,
+      useNativeDriver: false,
+    }).start()
   }
 
   const handlePressOut = () => {
     setIsPressing(false)
 
-    if (progressInterval.current) {
-      clearInterval(progressInterval.current)
-      progressInterval.current = null
-    }
+    // If the hold already completed, the listener above has already reset
+    // progressAnim to 0 and navigated away — nothing to do here.
+    if (hasCompleted.current) return
 
+    progressAnim.stopAnimation()
     Animated.timing(progressAnim, {
       toValue: 0,
-      duration: 200,
+      duration: RESET_ANIM_MS,
       useNativeDriver: false,
-    }).start()
+    }).start(() => {
+      lastPulseBucket.current = -1
+    })
   }
 
   return (

--- a/app/components/version/version.tsx
+++ b/app/components/version/version.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Pressable } from "react-native"
+import { Pressable, View, StyleSheet, Animated } from "react-native"
 import { Text, makeStyles } from "@rneui/themed"
 import DeviceInfo from "react-native-device-info"
 import { useNavigation } from "@react-navigation/native"
@@ -18,14 +18,19 @@ type VersionComponentNavigationProp = StackNavigationProp<
   "getStarted" | "settings"
 >
 
+// Tick cadence for the long-press progress animation.
+const PROGRESS_TICK_MS = 40
+const PROGRESS_INCREMENT = PROGRESS_TICK_MS / FEATURED_PROFILE.LONG_PRESS_DURATION_MS
+
 export const VersionComponent = () => {
   const styles = useStyles()
   const { navigate } = useNavigation<VersionComponentNavigationProp>()
   const { LL } = useI18nContext()
+
+  // Developer screen tap counter (existing behavior)
   const [secretMenuCounter, setSecretMenuCounter] = React.useState(0)
 
   // Long-press featured-profile entry
-  const longPressTimer = React.useRef<NodeJS.Timeout | null>(null)
   const progressInterval = React.useRef<NodeJS.Timeout | null>(null)
   const progressAnim = React.useRef(new Animated.Value(0)).current
   const [isPressing, setIsPressing] = React.useState(false)
@@ -40,64 +45,54 @@ export const VersionComponent = () => {
 
   const readableVersion = DeviceInfo.getReadableVersion()
 
-  // Long-press handlers for featured-profile entry
   const handlePressIn = () => {
     setIsPressing(true)
     let progress = 0
-    
-    // Progressive haptic feedback during hold
+
     progressInterval.current = setInterval(() => {
-      progress += 0.04 // 5 seconds = 125 intervals at 40ms
-      
-      // Light haptic every 1 second (25 intervals)
-      if (Math.floor(progress * 25) > Math.floor((progress - 0.04) * 25)) {
-        ReactNativeHapticFeedback.trigger('impactLight', {
+      const prev = progress
+      progress += PROGRESS_INCREMENT
+
+      // Light haptic at each ~1/5 of the hold (5 pulses across the full duration).
+      if (Math.floor(progress * 5) > Math.floor(prev * 5)) {
+        ReactNativeHapticFeedback.trigger("impactLight", {
           enableVibrateFallback: true,
           ignoreAndroidSystemSettings: false,
         })
       }
-      
-      // Animate progress
+
       Animated.timing(progressAnim, {
         toValue: progress,
-        duration: 40,
+        duration: PROGRESS_TICK_MS,
         useNativeDriver: false,
       }).start()
-      
+
       if (progress >= 1) {
-        // Success — open the featured profile view
         clearInterval(progressInterval.current!)
         progressInterval.current = null
         setIsPressing(false)
 
-        // Strong haptic on success
-        ReactNativeHapticFeedback.trigger('notificationSuccess', {
+        ReactNativeHapticFeedback.trigger("notificationSuccess", {
           enableVibrateFallback: true,
           ignoreAndroidSystemSettings: false,
         })
 
-        // Analytics
-        logFeaturedProfileSelected({ discoveryMethod: 'long_press' })
+        logFeaturedProfileSelected({ discoveryMethod: "long_press" })
+        navigate("FeaturedProfileView", { entryPoint: "long_press" })
 
-        // Navigate
-        navigate("FeaturedProfileView", { entryPoint: 'long_press' })
-
-        // Reset progress
         progressAnim.setValue(0)
       }
-    }, 40)
+    }, PROGRESS_TICK_MS)
   }
 
   const handlePressOut = () => {
     setIsPressing(false)
-    
-    // Clear the interval
+
     if (progressInterval.current) {
       clearInterval(progressInterval.current)
       progressInterval.current = null
     }
-    
-    // Animate progress back to 0
+
     Animated.timing(progressAnim, {
       toValue: 0,
       duration: 200,
@@ -105,22 +100,48 @@ export const VersionComponent = () => {
     }).start()
   }
 
-  // Calculate progress ring circumference
-  const size = 80
-  const strokeWidth = 3
-  const radius = (size - strokeWidth) / 2
-  const circumference = radius * 2 * Math.PI
-
   return (
     <Pressable
       style={styles.wrapper}
       onPress={() => setSecretMenuCounter(secretMenuCounter + 1)}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
+      delayLongPress={100}
     >
-      <Text {...testProps("Version Build Text")} style={styles.version}>
-        {readableVersion}
-        {"\n"}
-        {LL.GetStartedScreen.headline()}
-      </Text>
+      <View style={styles.textBox}>
+        {isPressing && (
+          <View style={styles.progressContainer}>
+            <Animated.View
+              style={[
+                styles.progressRing,
+                {
+                  borderColor: progressAnim.interpolate({
+                    inputRange: [0, 0.5, 1],
+                    outputRange: [
+                      "rgba(0, 255, 0, 0.2)",
+                      "rgba(0, 255, 0, 0.5)",
+                      "rgba(0, 255, 0, 1)",
+                    ],
+                  }),
+                  transform: [
+                    {
+                      scale: progressAnim.interpolate({
+                        inputRange: [0, 1],
+                        outputRange: [1, 1.1],
+                      }),
+                    },
+                  ],
+                },
+              ]}
+            />
+          </View>
+        )}
+        <Text {...testProps("Version Build Text")} style={styles.version}>
+          {readableVersion}
+          {"\n"}
+          {LL.GetStartedScreen.headline()}
+        </Text>
+      </View>
     </Pressable>
   )
 }
@@ -131,10 +152,25 @@ const useStyles = makeStyles(({ colors }) => ({
     justifyContent: "flex-end",
     marginBottom: 40,
   },
+  textBox: {
+    alignSelf: "center",
+  },
   version: {
     color: colors.grey0,
     fontSize: 18,
     marginTop: 18,
     textAlign: "center",
+  },
+  progressContainer: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  progressRing: {
+    width: 100,
+    height: 100,
+    borderRadius: 50,
+    borderWidth: 3,
+    backgroundColor: "transparent",
   },
 }))

--- a/app/constants/featured-profile.ts
+++ b/app/constants/featured-profile.ts
@@ -1,0 +1,41 @@
+/**
+ * Featured Profile Configuration
+ *
+ * Configuration for the in-app WebView flow that opens when a featured
+ * Nostr profile is matched in chat search or via the long-press entry
+ * on the version component.
+ */
+
+export const FEATURED_PROFILE = {
+  // Featured profile pubkey (hex)
+  PUBKEY: 'fc8c4bbff8c314791e82fe928bc96e1ca88dfb1ffe9da3552b3587fe4d33e543',
+
+  // NIP-05 identifier for the featured profile
+  NIP05: 'satoshin@flashapp.me',
+
+  // Search aliases that should match (with or without the domain)
+  NIP05_ALIASES: ['satoshin', 'satoshi'],
+
+  // Destination URL loaded in the WebView
+  DESTINATION_URL: 'https://kotc.islandbitcoin.com/terminal/',
+
+  // Long-press duration for the version-component entry (milliseconds)
+  LONG_PRESS_DURATION_MS: 5000,
+
+  // Transition animation duration (milliseconds)
+  TRANSITION_DURATION_MS: 800,
+
+  // User-facing copy — centralized so screen files stay neutral
+  UI_TEXT: {
+    HEADER_TITLE: 'Key Terminal',
+    OVERLAY_TEXT: 'Entering the Terminal...',
+    LOADING: 'Loading Terminal...',
+    OFFLINE_TITLE: "You're offline",
+    ERROR_TITLE: 'Connection Error',
+    OFFLINE_MSG: 'Check your internet connection and try again.',
+    ERROR_MSG: 'Unable to connect to the Key Terminal.',
+    RETRY: 'Retry',
+  },
+} as const
+
+export type FeaturedProfileEntryPoint = 'search' | 'long_press' | 'profile'

--- a/app/constants/featured-profile.ts
+++ b/app/constants/featured-profile.ts
@@ -4,17 +4,19 @@
  * Configuration for the in-app WebView flow that opens when a featured
  * Nostr profile is matched in chat search or via the long-press entry
  * on the version component.
+ *
+ * Chat-search matching happens at the pubkey level: when the user types
+ * either the NIP-05 (e.g. `satoshin@flashapp.me`) or a bare alias (e.g.
+ * `satoshin`, which the search bar auto-appends with the configured
+ * hostname), the existing NIP-05 resolver in `UserSearchBar` returns
+ * the pubkey, and `isFeaturedPubkey(pubkey)` catches it against
+ * `FEATURED_PROFILE.PUBKEY`. No alias list is needed on the client.
  */
 
 export const FEATURED_PROFILE = {
-  // Featured profile pubkey (hex)
+  // Featured profile pubkey (hex). This is the only identity field the
+  // client reads — NIP-05 strings are resolved externally.
   PUBKEY: 'fc8c4bbff8c314791e82fe928bc96e1ca88dfb1ffe9da3552b3587fe4d33e543',
-
-  // NIP-05 identifier for the featured profile
-  NIP05: 'satoshin@flashapp.me',
-
-  // Search aliases that should match (with or without the domain)
-  NIP05_ALIASES: ['satoshin', 'satoshi'],
 
   // Destination URL loaded in the WebView
   DESTINATION_URL: 'https://kotc.islandbitcoin.com/terminal/',

--- a/app/navigation/root-navigator.tsx
+++ b/app/navigation/root-navigator.tsx
@@ -128,6 +128,7 @@ import {
   Validation,
   Success,
 } from "@app/screens/account-upgrade-flow"
+import { FeaturedProfileView } from "@app/screens/featured-profile-view"
 
 const useStyles = makeStyles(({ colors }) => ({
   bottomNavigatorStyle: {
@@ -643,6 +644,16 @@ export const RootStack = () => {
         name="AccountUpgradeSuccess"
         component={Success}
         options={{ headerShown: false }}
+      />
+      {/* Featured profile WebView entry */}
+      <RootNavigator.Screen
+        name="FeaturedProfileView"
+        component={FeaturedProfileView}
+        options={{
+          headerShown: false,
+          cardStyleInterpolator: CardStyleInterpolators.forFadeFromBottomAndroid,
+          gestureEnabled: false,
+        }}
       />
     </RootNavigator.Navigator>
   )

--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -161,6 +161,8 @@ export type RootStackParamList = {
     channel: PhoneCodeChannelType
   }
   AccountUpgradeSuccess: undefined
+  // Featured profile WebView entry
+  FeaturedProfileView: { entryPoint: 'search' | 'long_press' | 'profile' }
 }
 
 export type ChatStackParamList = {

--- a/app/screens/chat/searchListItem.tsx
+++ b/app/screens/chat/searchListItem.tsx
@@ -13,6 +13,10 @@ import { useState } from "react"
 import { ActivityIndicator } from "react-native"
 import { getSigner } from "@app/nostr/signer"
 
+// Featured profile detection
+import { isFeaturedPubkey } from "@app/utils/featured-profile"
+import { logFeaturedProfileSelected } from "@app/utils/analytics"
+
 interface SearchListItemProps {
   item: Chat
 }
@@ -30,7 +34,12 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({ item }) => {
   const {
     theme: { colors },
   } = useTheme()
-  const navigation = useNavigation<StackNavigationProp<ChatStackParamList, "chatList">>()
+  
+  // Use any for navigation to support both Chat and Root navigators
+  const navigation = useNavigation<any>()
+
+  // Is this the featured profile?
+  const isFeaturedProfile = isFeaturedPubkey(item.id)
 
   const getIcon = () => {
     const itemPubkey = item.groupId
@@ -62,27 +71,56 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({ item }) => {
     }
   }
 
+  const handlePress = () => {
+    if (isFeaturedProfile) {
+      // Log the selection
+      logFeaturedProfileSelected({ discoveryMethod: 'search' })
+      // Dispatch up to the root navigator to open the featured view
+      navigation.dispatch(
+        CommonActions.navigate({
+          name: 'FeaturedProfileView',
+          params: { entryPoint: 'search' },
+        })
+      )
+    } else {
+      // Normal flow - navigate to messages
+      navigation.navigate("messages", {
+        groupId: item.groupId,
+      })
+    }
+  }
+
   return (
     <ListItem
       key={item.id}
       style={styles.item}
-      containerStyle={styles.itemContainer}
-      onPress={() => {
-        navigation.navigate("messages", {
-          groupId: item.groupId,
-        })
-      }}
+      containerStyle={[
+        styles.itemContainer,
+        isFeaturedProfile && localStyles.featuredItemContainer,
+      ]}
+      onPress={handlePress}
     >
-      <Image
-        source={{
-          uri:
-            item.picture ||
-            "https://pfp.nostr.build/520649f789e06c2a3912765c0081584951e91e3b5f3366d2ae08501162a5083b.jpg",
-        }}
-        style={styles.profilePicture}
-      />
+      <View style={localStyles.avatarContainer}>
+        <Image
+          source={{
+            uri:
+              item.picture ||
+              "https://pfp.nostr.build/520649f789e06c2a3912765c0081584951e91e3b5f3366d2ae08501162a5083b.jpg",
+          }}
+          style={styles.profilePicture}
+        />
+        {/* Featured profile badge */}
+        {isFeaturedProfile && (
+          <View style={localStyles.featuredBadge}>
+            <Icon name="key" size={12} color="#000" />
+          </View>
+        )}
+      </View>
       <ListItem.Content>
-        <ListItem.Title style={styles.itemText}>
+        <ListItem.Title style={[
+          styles.itemText,
+          isFeaturedProfile && localStyles.featuredItemText,
+        ]}>
           {item.alias ||
             item.username ||
             item.name ||
@@ -91,7 +129,10 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({ item }) => {
         </ListItem.Title>
       </ListItem.Content>
 
-      {isLoading ? (
+      {isFeaturedProfile ? (
+        // Forward arrow for the featured profile row (no add-contact affordance)
+        <Icon name="arrow-forward" size={24} color="#FFD700" />
+      ) : isLoading ? (
         <ActivityIndicator size="small" color={colors.primary} />
       ) : (
         <TouchableOpacity onPress={handleAddContact}>
@@ -100,4 +141,32 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({ item }) => {
       )}
     </ListItem>
   )
+}
+
+const useLocalStyles = () => {
+  return StyleSheet.create({
+    avatarContainer: {
+      position: 'relative',
+    },
+    featuredItemContainer: {
+      borderLeftWidth: 3,
+      borderLeftColor: '#FFD700',
+    },
+    featuredItemText: {
+      fontWeight: '600',
+    },
+    featuredBadge: {
+      position: 'absolute',
+      bottom: -2,
+      right: -2,
+      backgroundColor: '#FFD700',
+      borderRadius: 10,
+      width: 20,
+      height: 20,
+      justifyContent: 'center',
+      alignItems: 'center',
+      borderWidth: 2,
+      borderColor: '#FFF',
+    },
+  })
 }

--- a/app/screens/chat/searchListItem.tsx
+++ b/app/screens/chat/searchListItem.tsx
@@ -1,7 +1,7 @@
 import { ListItem, useTheme } from "@rneui/themed"
 import { useStyles } from "./style"
-import { Image, TouchableOpacity } from "react-native"
-import { useNavigation } from "@react-navigation/native"
+import { Image, TouchableOpacity, View, StyleSheet } from "react-native"
+import { useNavigation, CommonActions } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { ChatStackParamList } from "@app/navigation/stack-param-lists"
 import { nip19 } from "nostr-tools"
@@ -34,9 +34,7 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({ item }) => {
   const {
     theme: { colors },
   } = useTheme()
-  
-  // Use any for navigation to support both Chat and Root navigators
-  const navigation = useNavigation<any>()
+  const navigation = useNavigation<StackNavigationProp<ChatStackParamList, "chatList">>()
 
   // Is this the featured profile?
   const isFeaturedProfile = isFeaturedPubkey(item.id)
@@ -73,22 +71,25 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({ item }) => {
 
   const handlePress = () => {
     if (isFeaturedProfile) {
-      // Log the selection
-      logFeaturedProfileSelected({ discoveryMethod: 'search' })
-      // Dispatch up to the root navigator to open the featured view
-      navigation.dispatch(
+      logFeaturedProfileSelected({ discoveryMethod: "search" })
+      // FeaturedProfileView is registered on the root navigator — dispatch upward
+      // so the chat stack's typing stays intact for the normal messages flow.
+      navigation.getParent()?.dispatch(
         CommonActions.navigate({
-          name: 'FeaturedProfileView',
-          params: { entryPoint: 'search' },
-        })
+          name: "FeaturedProfileView",
+          params: { entryPoint: "search" },
+        }),
       )
-    } else {
-      // Normal flow - navigate to messages
-      navigation.navigate("messages", {
-        groupId: item.groupId,
-      })
+      return
     }
+    navigation.navigate("messages", {
+      groupId: item.groupId,
+    })
   }
+
+  const avatarUri =
+    item.picture ||
+    "https://pfp.nostr.build/520649f789e06c2a3912765c0081584951e91e3b5f3366d2ae08501162a5083b.jpg"
 
   return (
     <ListItem
@@ -100,27 +101,20 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({ item }) => {
       ]}
       onPress={handlePress}
     >
-      <View style={localStyles.avatarContainer}>
-        <Image
-          source={{
-            uri:
-              item.picture ||
-              "https://pfp.nostr.build/520649f789e06c2a3912765c0081584951e91e3b5f3366d2ae08501162a5083b.jpg",
-          }}
-          style={styles.profilePicture}
-        />
-        {/* Featured profile badge */}
-        {isFeaturedProfile && (
+      {isFeaturedProfile ? (
+        <View style={localStyles.avatarContainer}>
+          <Image source={{ uri: avatarUri }} style={styles.profilePicture} />
           <View style={localStyles.featuredBadge}>
             <Icon name="key" size={12} color="#000" />
           </View>
-        )}
-      </View>
+        </View>
+      ) : (
+        <Image source={{ uri: avatarUri }} style={styles.profilePicture} />
+      )}
       <ListItem.Content>
-        <ListItem.Title style={[
-          styles.itemText,
-          isFeaturedProfile && localStyles.featuredItemText,
-        ]}>
+        <ListItem.Title
+          style={[styles.itemText, isFeaturedProfile && localStyles.featuredItemText]}
+        >
           {item.alias ||
             item.username ||
             item.name ||
@@ -130,7 +124,6 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({ item }) => {
       </ListItem.Content>
 
       {isFeaturedProfile ? (
-        // Forward arrow for the featured profile row (no add-contact affordance)
         <Icon name="arrow-forward" size={24} color="#FFD700" />
       ) : isLoading ? (
         <ActivityIndicator size="small" color={colors.primary} />
@@ -143,30 +136,28 @@ export const SearchListItem: React.FC<SearchListItemProps> = ({ item }) => {
   )
 }
 
-const useLocalStyles = () => {
-  return StyleSheet.create({
-    avatarContainer: {
-      position: 'relative',
-    },
-    featuredItemContainer: {
-      borderLeftWidth: 3,
-      borderLeftColor: '#FFD700',
-    },
-    featuredItemText: {
-      fontWeight: '600',
-    },
-    featuredBadge: {
-      position: 'absolute',
-      bottom: -2,
-      right: -2,
-      backgroundColor: '#FFD700',
-      borderRadius: 10,
-      width: 20,
-      height: 20,
-      justifyContent: 'center',
-      alignItems: 'center',
-      borderWidth: 2,
-      borderColor: '#FFF',
-    },
-  })
-}
+const localStyles = StyleSheet.create({
+  avatarContainer: {
+    position: "relative",
+  },
+  featuredItemContainer: {
+    borderLeftWidth: 3,
+    borderLeftColor: "#FFD700",
+  },
+  featuredItemText: {
+    fontWeight: "600",
+  },
+  featuredBadge: {
+    position: "absolute",
+    bottom: -2,
+    right: -2,
+    backgroundColor: "#FFD700",
+    borderRadius: 10,
+    width: 20,
+    height: 20,
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 2,
+    borderColor: "#FFF",
+  },
+})

--- a/app/screens/featured-profile-view/FeaturedProfileView.tsx
+++ b/app/screens/featured-profile-view/FeaturedProfileView.tsx
@@ -1,0 +1,343 @@
+/**
+ * Featured Profile View
+ *
+ * WebView-backed screen that loads the configured destination URL when a
+ * featured Nostr profile is matched in chat search or reached via the
+ * long-press entry on the version component. Includes a short fade-in
+ * intro, offline/error handling, and persisted view tracking.
+ */
+
+import React, { useEffect, useRef, useState } from 'react'
+import {
+  View,
+  Text,
+  StyleSheet,
+  Animated,
+  TouchableOpacity,
+  SafeAreaView,
+  Platform,
+  StatusBar,
+  ActivityIndicator,
+} from 'react-native'
+import { WebView } from 'react-native-webview'
+import { useNavigation, useRoute, RouteProp } from '@react-navigation/native'
+import { StackNavigationProp } from '@react-navigation/stack'
+import NetInfo from '@react-native-community/netinfo'
+import ReactNativeHapticFeedback from 'react-native-haptic-feedback'
+import Icon from 'react-native-vector-icons/Ionicons'
+
+import { RootStackParamList } from '@app/navigation/stack-param-lists'
+import { FEATURED_PROFILE } from '@app/constants/featured-profile'
+import { logFeaturedViewOpened } from '@app/utils/analytics'
+import { usePersistentStateContext } from '@app/store/persistent-state'
+
+type FeaturedProfileViewRouteProp = RouteProp<RootStackParamList, 'FeaturedProfileView'>
+type FeaturedProfileViewNavigationProp = StackNavigationProp<
+  RootStackParamList,
+  'FeaturedProfileView'
+>
+
+// View theme colors
+const VIEW_COLORS = {
+  background: '#0a0a0a',
+  text: '#00ff00',
+  textSecondary: '#33ff33',
+  textDim: '#006600',
+  headerBackground: 'rgba(10, 10, 10, 0.95)',
+  overlayBackground: '#000000',
+}
+
+const FeaturedProfileView: React.FC = () => {
+  const navigation = useNavigation<FeaturedProfileViewNavigationProp>()
+  const route = useRoute<FeaturedProfileViewRouteProp>()
+  const { entryPoint } = route.params
+
+  const { persistentState, updateState } = usePersistentStateContext()
+
+  // Animation states
+  const overlayOpacity = useRef(new Animated.Value(1)).current
+  const textOpacity = useRef(new Animated.Value(0)).current
+  const [showOverlay, setShowOverlay] = useState(true)
+  const [showWebView, setShowWebView] = useState(false)
+
+  // WebView states
+  const webViewRef = useRef<WebView>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isOffline, setIsOffline] = useState(false)
+  const [hasError, setHasError] = useState(false)
+
+  // Check network status
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener((state) => {
+      setIsOffline(!state.isConnected)
+    })
+    return () => unsubscribe()
+  }, [])
+
+  // Track analytics and update persistent state
+  useEffect(() => {
+    const isFirstAccess = !persistentState?.featuredProfile?.hasViewedProfile
+
+    logFeaturedViewOpened({
+      entryPoint,
+      isFirstAccess,
+    })
+
+    updateState((currentState) => {
+      if (!currentState) return currentState
+      return {
+        ...currentState,
+        featuredProfile: {
+          hasViewedProfile: true,
+          firstViewedAt:
+            currentState.featuredProfile?.firstViewedAt || new Date().toISOString(),
+          viewCount: (currentState.featuredProfile?.viewCount || 0) + 1,
+        },
+      }
+    })
+  }, [])
+
+  // Run entry animation
+  useEffect(() => {
+    ReactNativeHapticFeedback.trigger('notificationSuccess', {
+      enableVibrateFallback: true,
+      ignoreAndroidSystemSettings: false,
+    })
+
+    Animated.timing(textOpacity, {
+      toValue: 1,
+      duration: 400,
+      useNativeDriver: true,
+    }).start()
+
+    const timer = setTimeout(() => {
+      setShowWebView(true)
+
+      Animated.timing(overlayOpacity, {
+        toValue: 0,
+        duration: FEATURED_PROFILE.TRANSITION_DURATION_MS,
+        useNativeDriver: true,
+      }).start(() => {
+        setShowOverlay(false)
+      })
+    }, 1000)
+
+    return () => clearTimeout(timer)
+  }, [])
+
+  const handleGoBack = () => {
+    navigation.goBack()
+  }
+
+  const handleRetry = () => {
+    setHasError(false)
+    setIsLoading(true)
+    webViewRef.current?.reload()
+  }
+
+  const handleWebViewError = () => {
+    setHasError(true)
+    setIsLoading(false)
+  }
+
+  return (
+    <View style={styles.container}>
+      <StatusBar barStyle="light-content" backgroundColor={VIEW_COLORS.background} />
+
+      {/* WebView - rendered behind overlay */}
+      {showWebView && !isOffline && !hasError && (
+        <WebView
+          ref={webViewRef}
+          source={{ uri: FEATURED_PROFILE.DESTINATION_URL }}
+          style={styles.webView}
+          onLoadStart={() => setIsLoading(true)}
+          onLoadEnd={() => setIsLoading(false)}
+          onError={handleWebViewError}
+          javaScriptEnabled={true}
+          domStorageEnabled={true}
+          startInLoadingState={false}
+          allowsBackForwardNavigationGestures={false}
+        />
+      )}
+
+      {/* Loading indicator */}
+      {isLoading && showWebView && !isOffline && !hasError && (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={VIEW_COLORS.text} />
+          <Text style={styles.loadingText}>{FEATURED_PROFILE.UI_TEXT.LOADING}</Text>
+        </View>
+      )}
+
+      {/* Offline / Error View */}
+      {(isOffline || hasError) && showWebView && (
+        <View style={styles.offlineContainer}>
+          <Icon name="cloud-offline-outline" size={64} color={VIEW_COLORS.textDim} />
+          <Text style={styles.offlineTitle}>
+            {isOffline
+              ? FEATURED_PROFILE.UI_TEXT.OFFLINE_TITLE
+              : FEATURED_PROFILE.UI_TEXT.ERROR_TITLE}
+          </Text>
+          <Text style={styles.offlineText}>
+            {isOffline
+              ? FEATURED_PROFILE.UI_TEXT.OFFLINE_MSG
+              : FEATURED_PROFILE.UI_TEXT.ERROR_MSG}
+          </Text>
+          <TouchableOpacity style={styles.retryButton} onPress={handleRetry}>
+            <Icon name="refresh" size={20} color={VIEW_COLORS.background} />
+            <Text style={styles.retryButtonText}>{FEATURED_PROFILE.UI_TEXT.RETRY}</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {/* Custom Header */}
+      <SafeAreaView style={styles.headerContainer}>
+        <View style={styles.header}>
+          <TouchableOpacity style={styles.backButton} onPress={handleGoBack}>
+            <Icon name="arrow-back" size={24} color={VIEW_COLORS.text} />
+          </TouchableOpacity>
+          <View style={styles.headerTitleContainer}>
+            <Icon name="key" size={18} color={VIEW_COLORS.text} style={styles.keyIcon} />
+            <Text style={styles.headerTitle}>{FEATURED_PROFILE.UI_TEXT.HEADER_TITLE}</Text>
+          </View>
+          <View style={styles.headerSpacer} />
+        </View>
+      </SafeAreaView>
+
+      {/* Transition Overlay */}
+      {showOverlay && (
+        <Animated.View style={[styles.overlay, { opacity: overlayOpacity }]}>
+          <Animated.View style={[styles.overlayContent, { opacity: textOpacity }]}>
+            <Icon name="key" size={48} color={VIEW_COLORS.text} />
+            <Text style={styles.overlayText}>{FEATURED_PROFILE.UI_TEXT.OVERLAY_TEXT}</Text>
+            <View style={styles.cursorContainer}>
+              <Text style={styles.cursor}>_</Text>
+            </View>
+          </Animated.View>
+        </Animated.View>
+      )}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: VIEW_COLORS.background,
+  },
+  webView: {
+    flex: 1,
+    backgroundColor: VIEW_COLORS.background,
+  },
+  headerContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: VIEW_COLORS.headerBackground,
+    zIndex: 10,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    paddingTop: Platform.OS === 'android' ? (StatusBar.currentHeight || 0) + 12 : 12,
+  },
+  backButton: {
+    padding: 8,
+    marginLeft: -8,
+  },
+  headerTitleContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  keyIcon: {
+    marginRight: 8,
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: VIEW_COLORS.text,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  headerSpacer: {
+    width: 40,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: VIEW_COLORS.overlayBackground,
+    justifyContent: 'center',
+    alignItems: 'center',
+    zIndex: 100,
+  },
+  overlayContent: {
+    alignItems: 'center',
+  },
+  overlayText: {
+    fontSize: 18,
+    color: VIEW_COLORS.text,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+    marginTop: 24,
+    letterSpacing: 2,
+  },
+  cursorContainer: {
+    marginTop: 8,
+  },
+  cursor: {
+    fontSize: 18,
+    color: VIEW_COLORS.text,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  loadingContainer: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: VIEW_COLORS.background,
+    paddingTop: 100,
+  },
+  loadingText: {
+    marginTop: 16,
+    fontSize: 14,
+    color: VIEW_COLORS.textDim,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  offlineContainer: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: VIEW_COLORS.background,
+    paddingHorizontal: 40,
+  },
+  offlineTitle: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: VIEW_COLORS.text,
+    marginTop: 24,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  offlineText: {
+    fontSize: 14,
+    color: VIEW_COLORS.textDim,
+    textAlign: 'center',
+    marginTop: 12,
+    lineHeight: 20,
+  },
+  retryButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: VIEW_COLORS.text,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+    marginTop: 32,
+  },
+  retryButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: VIEW_COLORS.background,
+    marginLeft: 8,
+  },
+})
+
+export default FeaturedProfileView

--- a/app/screens/featured-profile-view/FeaturedProfileView.tsx
+++ b/app/screens/featured-profile-view/FeaturedProfileView.tsx
@@ -54,6 +54,13 @@ const FeaturedProfileView: React.FC = () => {
 
   const { persistentState, updateState } = usePersistentStateContext()
 
+  // Capture first-access detection at mount time so the log effect doesn't
+  // depend on persistentState (which would re-fire on every state update).
+  const isFirstAccessRef = useRef(
+    !persistentState?.featuredProfile?.hasViewedProfile,
+  )
+  const hasLoggedRef = useRef(false)
+
   // Animation states
   const overlayOpacity = useRef(new Animated.Value(1)).current
   const textOpacity = useRef(new Animated.Value(0)).current
@@ -74,13 +81,14 @@ const FeaturedProfileView: React.FC = () => {
     return () => unsubscribe()
   }, [])
 
-  // Track analytics and update persistent state
+  // Track analytics and update persistent state (mount-only).
   useEffect(() => {
-    const isFirstAccess = !persistentState?.featuredProfile?.hasViewedProfile
+    if (hasLoggedRef.current) return
+    hasLoggedRef.current = true
 
     logFeaturedViewOpened({
       entryPoint,
-      isFirstAccess,
+      isFirstAccess: isFirstAccessRef.current,
     })
 
     updateState((currentState) => {
@@ -95,9 +103,9 @@ const FeaturedProfileView: React.FC = () => {
         },
       }
     })
-  }, [])
+  }, [entryPoint, updateState])
 
-  // Run entry animation
+  // Run entry animation (mount-only; refs hold the Animated.Values).
   useEffect(() => {
     ReactNativeHapticFeedback.trigger('notificationSuccess', {
       enableVibrateFallback: true,
@@ -123,6 +131,7 @@ const FeaturedProfileView: React.FC = () => {
     }, 1000)
 
     return () => clearTimeout(timer)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const handleGoBack = () => {

--- a/app/screens/featured-profile-view/index.ts
+++ b/app/screens/featured-profile-view/index.ts
@@ -1,0 +1,1 @@
+export { default as FeaturedProfileView } from './FeaturedProfileView'

--- a/app/store/persistent-state/state-migrations.ts
+++ b/app/store/persistent-state/state-migrations.ts
@@ -80,6 +80,12 @@ type PersistentState_7 = {
   flashcardHtml?: string
   hasPostedToNostr?: boolean // true if user has made at least one Nostr post
   sparkMigrationCompleted?: boolean
+  // Featured profile view tracking
+  featuredProfile?: {
+    hasViewedProfile: boolean
+    firstViewedAt?: string
+    viewCount: number
+  }
 }
 
 type JwtPayload = {

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -186,3 +186,29 @@ export const logAppFeedback = (params: LogAppFeedbackParams) => {
     is_enjoying_app: params.isEnjoingApp,
   })
 }
+
+// ============================================
+// Featured profile events
+// ============================================
+
+type LogFeaturedProfileSelectedParams = {
+  discoveryMethod: 'search' | 'long_press' | 'profile'
+}
+
+export const logFeaturedProfileSelected = (params: LogFeaturedProfileSelectedParams) => {
+  getAnalytics().logEvent('featured_profile_selected', {
+    discovery_method: params.discoveryMethod,
+  })
+}
+
+type LogFeaturedViewOpenedParams = {
+  entryPoint: 'search' | 'long_press' | 'profile'
+  isFirstAccess: boolean
+}
+
+export const logFeaturedViewOpened = (params: LogFeaturedViewOpenedParams) => {
+  getAnalytics().logEvent('featured_view_opened', {
+    entry_point: params.entryPoint,
+    is_first_access: params.isFirstAccess,
+  })
+}

--- a/app/utils/featured-profile.ts
+++ b/app/utils/featured-profile.ts
@@ -1,51 +1,10 @@
 /**
  * Featured Profile Utilities
  *
- * Detection helpers for matching the featured Nostr profile in chat
- * search and profile lookups.
+ * Detection helper for matching the featured Nostr profile by pubkey.
  */
 
 import { FEATURED_PROFILE } from '@app/constants/featured-profile'
-
-/**
- * Check if a profile matches the featured profile by pubkey or NIP-05.
- */
-export const isFeaturedNostrProfile = (
-  pubkey: string,
-  nip05?: string | null,
-): boolean => {
-  if (pubkey.toLowerCase() === FEATURED_PROFILE.PUBKEY.toLowerCase()) {
-    return true
-  }
-
-  if (nip05 && nip05.toLowerCase() === FEATURED_PROFILE.NIP05.toLowerCase()) {
-    return true
-  }
-
-  return false
-}
-
-/**
- * Check if a NIP-05 search query matches the featured profile.
- */
-export const isFeaturedNip05 = (identifier: string): boolean => {
-  const lower = identifier.toLowerCase().trim()
-
-  if (lower === FEATURED_PROFILE.NIP05.toLowerCase()) {
-    return true
-  }
-
-  for (const alias of FEATURED_PROFILE.NIP05_ALIASES) {
-    if (lower === alias.toLowerCase()) {
-      return true
-    }
-    if (lower === `${alias.toLowerCase()}@flashapp.me`) {
-      return true
-    }
-  }
-
-  return false
-}
 
 /**
  * Check if a pubkey matches the featured profile.

--- a/app/utils/featured-profile.ts
+++ b/app/utils/featured-profile.ts
@@ -1,0 +1,55 @@
+/**
+ * Featured Profile Utilities
+ *
+ * Detection helpers for matching the featured Nostr profile in chat
+ * search and profile lookups.
+ */
+
+import { FEATURED_PROFILE } from '@app/constants/featured-profile'
+
+/**
+ * Check if a profile matches the featured profile by pubkey or NIP-05.
+ */
+export const isFeaturedNostrProfile = (
+  pubkey: string,
+  nip05?: string | null,
+): boolean => {
+  if (pubkey.toLowerCase() === FEATURED_PROFILE.PUBKEY.toLowerCase()) {
+    return true
+  }
+
+  if (nip05 && nip05.toLowerCase() === FEATURED_PROFILE.NIP05.toLowerCase()) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Check if a NIP-05 search query matches the featured profile.
+ */
+export const isFeaturedNip05 = (identifier: string): boolean => {
+  const lower = identifier.toLowerCase().trim()
+
+  if (lower === FEATURED_PROFILE.NIP05.toLowerCase()) {
+    return true
+  }
+
+  for (const alias of FEATURED_PROFILE.NIP05_ALIASES) {
+    if (lower === alias.toLowerCase()) {
+      return true
+    }
+    if (lower === `${alias.toLowerCase()}@flashapp.me`) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
+ * Check if a pubkey matches the featured profile.
+ */
+export const isFeaturedPubkey = (pubkey: string): boolean => {
+  return pubkey.toLowerCase() === FEATURED_PROFILE.PUBKEY.toLowerCase()
+}


### PR DESCRIPTION
## Summary
Adds an optional **featured Nostr profile** entry. When a specific hardcoded pubkey (set in `app/constants/featured-profile.ts`) matches in chat search, or is reached via a 5-second long-press on the version component, the app navigates to a WebView-backed screen that loads a configured destination URL.

Behavior:
- Entry points: chat search (featured-pubkey match, resolved via the existing NIP-05 search path) and version-component long-press (5s)
- Screen: WebView over the configured `DESTINATION_URL` with fade-in intro, offline detection, and retry on error
- Persists a small `featuredProfile` object in app state (`hasViewedProfile`, `firstViewedAt`, `viewCount`) — all fields optional, no `schemaVersion` bump required
- Analytics: `featured_profile_selected` (on selection) and `featured_view_opened` (on screen open)

## Files
- `app/constants/featured-profile.ts` — config (featured pubkey, destination URL, UI strings, timings)
- `app/utils/featured-profile.ts` — pubkey match helper
- `app/screens/featured-profile-view/FeaturedProfileView.tsx` — WebView screen
- `app/navigation/root-navigator.tsx` + `stack-param-lists.ts` — route wiring
- `app/components/version/version.tsx` — long-press handler (Animated.timing driven; progress ring + 5-pulse haptic ladder)
- `app/screens/chat/searchListItem.tsx` — search-hit interception
- `app/store/persistent-state/state-migrations.ts` — optional `featuredProfile` field
- `app/utils/analytics.ts` — two new events

## Test plan
- [ ] Chat-search for `satoshin` — hostname is auto-appended, NIP-05 resolves to the featured pubkey, row appears with forward-arrow affordance → tap routes to `FeaturedProfileView`
- [ ] Chat-search for `satoshin@flashapp.me` — NIP-05 resolves directly → same outcome
- [ ] Long-press version text for 5s on getStarted/settings → progress ring fills, haptics pulse, routes to `FeaturedProfileView` with `entryPoint: 'long_press'`
- [ ] Long-press lifted early (~2s) → ring animates back to 0, no navigate, no unmount leak
- [ ] Open view online → WebView loads destination URL after ~1s intro
- [ ] Open view offline → offline state shows with retry button
- [ ] Re-open after first view → `viewCount` increments, `firstViewedAt` preserved
- [ ] Regression: normal chat search for non-featured pubkey still routes to messages
- [ ] Regression: 3-tap on version still opens developer screen

## Notes
- No `schemaVersion` bump — the new `featuredProfile` field is optional and additive.
- User-facing strings are centralized in `FEATURED_PROFILE.UI_TEXT` for easy localization later.
- Chat-search match is pubkey-on-pubkey: the existing NIP-05 resolver in `UserSearchBar` reduces both alias and full-address inputs to a pubkey, which `isFeaturedPubkey` catches against `FEATURED_PROFILE.PUBKEY`.