### PR TITLE
Add shared RoundingPolicy module (ENG-318)

### DIFF
--- a/lib/money/README.md
+++ b/lib/money/README.md
@@ -1,0 +1,124 @@
+# `lib/money` — shared money primitives
+
+This directory holds the shared money utilities that are **byte-identical**
+between the [`flash`](https://github.com/lnflash/flash) backend (also used
+by `price-server`) and the [`flash-mobile`](https://github.com/lnflash/flash-mobile)
+React Native app.
+
+> If you change a file in this directory, you must change the same file in the
+> other repo, with the same bytes, in the same PR (or the next one).
+
+| File | Purpose |
+| ---- | ------- |
+| `rounding.ts` | The single rounding policy. Every money rounding in Flash goes through this. |
+| `rounding.test.ts` | Unit tests covering every mode and the policy table. |
+
+---
+
+## TL;DR — which function do I call?
+
+| You are doing… | Call |
+| -- | -- |
+| Computing a ledger balance, reconciling, or anything that ends up in a financial report | `roundForContext(x, "accounting")` |
+| Showing a number to the user | `roundForContext(x, "display")` |
+| Charging the user a fee | `roundForContext(x, "fee")` |
+| Paying the user out (sats, fiat, anything we owe them) | `roundForContext(x, "payout")` |
+| You have a *very* good reason to pick a specific mode | `roundMinor(x, "half-to-even")` (etc.) — explain in PR |
+| You wrote `Math.round(...)` on a money value | **Stop.** Pick a context. |
+
+---
+
+## The policy table
+
+This is the entire policy. Four lines.
+
+| Context | Mode | Why |
+| -- | -- | -- |
+| `accounting` | `half-to-even` | Banker's rounding. Removes the small positive bias of half-up over large samples. IFRS / GAAP friendly. |
+| `display` | `half-up` | Matches what the user expects when they look at the screen — `0.5` rounds to `1`. |
+| `fee` | `ceiling` | The house never under-charges itself. Matches Strike / CashApp behaviour. |
+| `payout` | `floor` | The house never over-pays. Sub-minor-unit dust stays in treasury. |
+
+Changing any of these four lines is a money-policy change. It should be:
+
+1. its own PR,
+2. with a rationale in the commit message,
+3. reviewed by at least one engineer **and** one ops person,
+4. accompanied by an updated changelog entry.
+
+---
+
+## How to choose a context (worked examples)
+
+**You're computing a transaction fee.**
+The fee is what the customer pays *us*. Use `"fee"`. The mode is `ceiling`,
+which rounds in our favour by at most one minor unit. Documented, intentional,
+visible in the codebase.
+
+**You're showing the customer their wallet balance in their display currency.**
+This is `"display"`. The number on screen rounds the way humans expect
+(`half-up`). The actual value stored in the wallet is unchanged — only the UI
+representation is rounded.
+
+**You're crediting a payout to a customer.**
+Use `"payout"`. The mode is `floor`, which means we pay out the largest whole
+minor unit that is ≤ the true amount. The fractional remainder stays in
+treasury until reconciliation sweeps it.
+
+**You're posting a journal entry to the ledger.**
+Use `"accounting"`. The mode is `half-to-even`, which over many entries does
+not bias the books in either direction.
+
+---
+
+## Rounding mode reference
+
+| Mode | Behaviour | Example |
+| -- | -- | -- |
+| `half-to-even` | Round to nearest; ties go to the nearest **even** integer. | `2.5 → 2`, `3.5 → 4` |
+| `half-up` | Round to nearest; ties go **away from zero**. | `2.5 → 3`, `-2.5 → -3` |
+| `half-down` | Round to nearest; ties go **toward zero**. | `2.5 → 2`, `-2.5 → -2` |
+| `ceiling` | Always toward `+∞`. | `1.01 → 2`, `-1.99 → -1` |
+| `floor` | Always toward `-∞`. | `1.99 → 1`, `-1.01 → -2` |
+
+---
+
+## Idempotence
+
+`roundMinor(roundMinor(x, mode), mode) === roundMinor(x, mode)` for every
+mode and every input. This is locked in by tests today; it will be locked in
+by property tests once ENG-320 lands.
+
+---
+
+## Why `bigint`?
+
+Currency amounts in Flash can exceed `Number.MAX_SAFE_INTEGER` when expressed
+in the smallest minor unit (sats × scale, msats, etc.). The output is always
+`bigint` so callers cannot silently re-introduce float drift after the round.
+
+If you need a `number` at a call site (UI, JSON, GraphQL), convert explicitly
+with `Number(x)` and document that you accept the precision loss.
+
+---
+
+## Sync between repos
+
+Both `flash` and `flash-mobile` ship the same source for these files. The two
+copies must be byte-for-byte identical. We rely on either:
+
+- a CI check that diffs the two paths (`scripts/sync-money.sh`), or
+- a published `@lnflash/money` package consumed from npm.
+
+Pick whichever is in place when you read this. If you are adding a file to
+this directory, add it to **both** repos in coordinated PRs.
+
+---
+
+## See also
+
+- ENG-318 (this module) · `https://linear.app/island-bitcoin/issue/ENG-318`
+- ENG-320 (property-test infrastructure)
+- ENG-321 (money-boundary audit — replaces all bare `Math.round`/`floor`/`ceil` on money)
+- ENG-316 (Phase 0 hotfix that motivated this work) · [PR #617](https://github.com/lnflash/flash-mobile/pull/617)
+- Roadmap §2 and §4.1 in `groups/main/flash-currency-precision/roadmap.md`

--- a/lib/money/rounding.test.ts
+++ b/lib/money/rounding.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Unit tests for the shared rounding policy module.
+ *
+ * Spec: ENG-318. The property-based tests live in ENG-320; the tests below
+ * cover ties, negatives, zero, bigint inputs, large-`number` boundaries, and
+ * the context → mode policy table.
+ */
+
+import {
+  __policyForContext,
+  minorUnitScale,
+  roundForContext,
+  roundMinor,
+  RoundingContext,
+  RoundingMode,
+} from "./rounding"
+
+describe("roundMinor — tie behaviour by mode", () => {
+  // | input | half-to-even | half-up | half-down | ceiling | floor |
+  const ties: ReadonlyArray<{
+    input: number
+    expected: Record<RoundingMode, bigint>
+  }> = [
+    {
+      input: 0.5,
+      expected: {
+        "half-to-even": 0n,
+        "half-up": 1n,
+        "half-down": 0n,
+        ceiling: 1n,
+        floor: 0n,
+      },
+    },
+    {
+      input: 1.5,
+      expected: {
+        "half-to-even": 2n,
+        "half-up": 2n,
+        "half-down": 1n,
+        ceiling: 2n,
+        floor: 1n,
+      },
+    },
+    {
+      input: 2.5,
+      expected: {
+        "half-to-even": 2n,
+        "half-up": 3n,
+        "half-down": 2n,
+        ceiling: 3n,
+        floor: 2n,
+      },
+    },
+    {
+      input: -0.5,
+      expected: {
+        "half-to-even": 0n,
+        "half-up": -1n,
+        "half-down": 0n,
+        ceiling: 0n,
+        floor: -1n,
+      },
+    },
+    {
+      input: -1.5,
+      expected: {
+        "half-to-even": -2n,
+        "half-up": -2n,
+        "half-down": -1n,
+        ceiling: -1n,
+        floor: -2n,
+      },
+    },
+    {
+      input: -2.5,
+      expected: {
+        "half-to-even": -2n,
+        "half-up": -3n,
+        "half-down": -2n,
+        ceiling: -2n,
+        floor: -3n,
+      },
+    },
+  ]
+
+  for (const { input, expected } of ties) {
+    for (const mode of Object.keys(expected) as RoundingMode[]) {
+      it(`${input} with ${mode} → ${expected[mode]}`, () => {
+        expect(roundMinor(input, mode)).toBe(expected[mode])
+      })
+    }
+  }
+})
+
+describe("roundMinor — non-tie cases", () => {
+  it("rounds 1.4 down for nearest modes", () => {
+    expect(roundMinor(1.4, "half-up")).toBe(1n)
+    expect(roundMinor(1.4, "half-down")).toBe(1n)
+    expect(roundMinor(1.4, "half-to-even")).toBe(1n)
+  })
+
+  it("rounds 1.6 up for nearest modes", () => {
+    expect(roundMinor(1.6, "half-up")).toBe(2n)
+    expect(roundMinor(1.6, "half-down")).toBe(2n)
+    expect(roundMinor(1.6, "half-to-even")).toBe(2n)
+  })
+
+  it("ceiling and floor on non-integer values", () => {
+    expect(roundMinor(1.01, "ceiling")).toBe(2n)
+    expect(roundMinor(1.99, "floor")).toBe(1n)
+    expect(roundMinor(-1.01, "ceiling")).toBe(-1n)
+    expect(roundMinor(-1.99, "floor")).toBe(-2n)
+  })
+
+  it("zero is unchanged in every mode", () => {
+    const modes: RoundingMode[] = [
+      "half-to-even",
+      "half-up",
+      "half-down",
+      "ceiling",
+      "floor",
+    ]
+    for (const mode of modes) {
+      expect(roundMinor(0, mode)).toBe(0n)
+      expect(roundMinor(-0, mode)).toBe(0n)
+    }
+  })
+})
+
+describe("roundMinor — bigint inputs are returned unchanged", () => {
+  it("integer bigints round to themselves under all modes", () => {
+    const inputs: bigint[] = [0n, 1n, -1n, 12345n, -12345n]
+    const modes: RoundingMode[] = [
+      "half-to-even",
+      "half-up",
+      "half-down",
+      "ceiling",
+      "floor",
+    ]
+    for (const v of inputs) {
+      for (const m of modes) {
+        expect(roundMinor(v, m)).toBe(v)
+      }
+    }
+  })
+})
+
+describe("roundMinor — already-integer numbers are idempotent", () => {
+  // Acceptance criterion (property-test stub): roundMinor is idempotent on
+  // already-integer inputs across all modes. Exhaustive property infra is
+  // ENG-320; here we lock in a representative grid.
+  const integers: number[] = [
+    0,
+    1,
+    -1,
+    100,
+    -100,
+    1_000_000,
+    -1_000_000,
+    Number.MAX_SAFE_INTEGER,
+    -Number.MAX_SAFE_INTEGER,
+  ]
+  const modes: RoundingMode[] = [
+    "half-to-even",
+    "half-up",
+    "half-down",
+    "ceiling",
+    "floor",
+  ]
+
+  for (const v of integers) {
+    for (const m of modes) {
+      it(`${v} (${m}) is idempotent`, () => {
+        const once = roundMinor(v, m)
+        const twice = roundMinor(once, m)
+        expect(once).toBe(BigInt(v))
+        expect(twice).toBe(once)
+      })
+    }
+  }
+})
+
+describe("roundMinor — large numbers stay exact", () => {
+  it("MAX_SAFE_INTEGER + tiny fraction does not lose the integer part", () => {
+    // The double `9_007_199_254_740_991.5` is representable; the .5 collapses
+    // when added to the integer, but our string-based normaliser preserves
+    // the full input precision. We verify by going through a value that is
+    // exactly representable.
+    expect(roundMinor(9_007_199_254_740_991, "half-up")).toBe(
+      9_007_199_254_740_991n,
+    )
+  })
+
+  it("bigint paths handle values past 2^53", () => {
+    const big = (1n << 60n) + 7n
+    expect(roundMinor(big, "half-up")).toBe(big)
+    expect(roundMinor(big, "floor")).toBe(big)
+    expect(roundMinor(big, "ceiling")).toBe(big)
+  })
+})
+
+describe("roundMinor — input validation", () => {
+  it("rejects NaN", () => {
+    expect(() => roundMinor(Number.NaN, "half-up")).toThrow(RangeError)
+  })
+  it("rejects Infinity", () => {
+    expect(() => roundMinor(Number.POSITIVE_INFINITY, "half-up")).toThrow(
+      RangeError,
+    )
+    expect(() => roundMinor(Number.NEGATIVE_INFINITY, "half-up")).toThrow(
+      RangeError,
+    )
+  })
+})
+
+describe("roundForContext — locks in the policy table", () => {
+  // If you change one of these expectations, you are changing money policy.
+  // Update CONTEXT_MODE in the same PR and explain the rationale.
+  const expectations: ReadonlyArray<{
+    context: RoundingContext
+    mode: RoundingMode
+    sample: number
+    expected: bigint
+  }> = [
+    { context: "accounting", mode: "half-to-even", sample: 2.5, expected: 2n },
+    { context: "display", mode: "half-up", sample: 2.5, expected: 3n },
+    { context: "fee", mode: "ceiling", sample: 0.01, expected: 1n },
+    { context: "payout", mode: "floor", sample: 0.99, expected: 0n },
+  ]
+
+  for (const { context, mode, sample, expected } of expectations) {
+    it(`${context} → ${mode} (sample ${sample} → ${expected})`, () => {
+      expect(__policyForContext(context)).toBe(mode)
+      expect(roundForContext(sample, context)).toBe(expected)
+    })
+  }
+})
+
+describe("minorUnitScale", () => {
+  it("BTC and SAT are 0", () => {
+    expect(minorUnitScale("BTC")).toBe(0)
+    expect(minorUnitScale("SAT")).toBe(0)
+  })
+
+  it("common 2-digit fiat", () => {
+    expect(minorUnitScale("USD")).toBe(2)
+    expect(minorUnitScale("EUR")).toBe(2)
+    expect(minorUnitScale("JMD")).toBe(2)
+    expect(minorUnitScale("GBP")).toBe(2)
+  })
+
+  it("3-digit fiat", () => {
+    expect(minorUnitScale("BHD")).toBe(3)
+    expect(minorUnitScale("KWD")).toBe(3)
+  })
+
+  it("0-digit fiat", () => {
+    expect(minorUnitScale("JPY")).toBe(0)
+    expect(minorUnitScale("KRW")).toBe(0)
+  })
+
+  it("is case-insensitive", () => {
+    expect(minorUnitScale("usd")).toBe(2)
+    expect(minorUnitScale("Btc")).toBe(0)
+  })
+
+  it("falls back to 2 for unknown currencies", () => {
+    expect(minorUnitScale("XXX")).toBe(2)
+    expect(minorUnitScale("ZZZZZ")).toBe(2)
+  })
+})

--- a/lib/money/rounding.ts
+++ b/lib/money/rounding.ts
@@ -1,0 +1,325 @@
+/**
+ * Shared rounding policy for all currency conversions across Flash.
+ *
+ * This module is **byte-identical** between `flash` (backend / price-server)
+ * and `flash-mobile`. Do not edit one copy without syncing the other — see
+ * `scripts/sync-money.sh` (or the lint/CI check that enforces this).
+ *
+ * Why this exists
+ * ---------------
+ * Money conversions in Flash are not value-free arithmetic. Every conversion
+ * silently picks a rounding mode (round-half-up, ceiling, floor, …) and that
+ * choice has accounting, UX, and trust implications. Before this module,
+ * those choices lived in scattered `Math.round` / `Math.floor` / `Math.ceil`
+ * calls across backend, price-server, and mobile — invisible to review.
+ *
+ * The rule is: **never round money with a bare `Math.round`.** Use
+ * `roundForContext` and declare your intent. The `RoundingContext → mode`
+ * mapping is a single, documented policy table that can be changed in one
+ * place.
+ *
+ * Spec: ENG-318. Roadmap §2 / §4.1.
+ */
+
+/**
+ * Rounding modes supported by `roundMinor`.
+ *
+ * - `half-to-even` — Banker's rounding. Ties go to the nearest even integer.
+ *                    Removes the positive bias of half-up over large samples.
+ *                    IFRS / GAAP friendly; the right default for accounting.
+ * - `half-up`      — Ties go away from zero (`0.5 → 1`, `-0.5 → -1`).
+ *                    Matches the user's mental model; use for UI display.
+ * - `half-down`    — Ties go toward zero (`0.5 → 0`, `-0.5 → 0`).
+ *                    Rare; included for completeness.
+ * - `ceiling`      — Always toward `+∞`. Use when the house must never
+ *                    under-charge itself (fees).
+ * - `floor`        — Always toward `-∞`. Use when the house must never
+ *                    over-pay (payouts; sub-minor-unit dust stays in treasury).
+ */
+export type RoundingMode =
+  | "half-to-even"
+  | "half-up"
+  | "half-down"
+  | "ceiling"
+  | "floor"
+
+/**
+ * The four contexts in which money is rounded across Flash. Every call site
+ * that handles money belongs to exactly one of these.
+ *
+ * The mapping from context to mode is defined by `CONTEXT_MODE` below and is
+ * the *only* policy lever in this module. Changing one of those four lines
+ * is reviewed as a single, focused PR.
+ */
+export type RoundingContext = "accounting" | "display" | "fee" | "payout"
+
+/**
+ * Initial policy table. Editing any line here is a policy change — please
+ * include a rationale and a link to the discussion in the commit message.
+ *
+ * | Context     | Mode           | Rationale                                  |
+ * | ----------- | -------------- | ------------------------------------------ |
+ * | accounting  | half-to-even   | Removes statistical bias; IFRS/GAAP norm.  |
+ * | display     | half-up        | Matches user expectation; no UI surprise.  |
+ * | fee         | ceiling        | House never under-charges itself.          |
+ * | payout      | floor          | House never over-pays; dust stays in tsy.  |
+ */
+const CONTEXT_MODE: Readonly<Record<RoundingContext, RoundingMode>> =
+  Object.freeze({
+    accounting: "half-to-even",
+    display: "half-up",
+    fee: "ceiling",
+    payout: "floor",
+  })
+
+/**
+ * Per-currency minor-unit scale (number of fraction digits in the minor unit
+ * representation). For BTC the minor unit is the satoshi, which is itself
+ * already an integer, so the scale is 0.
+ *
+ * Mirrors ISO 4217 fractionDigits for fiat. Sourced from the same currency
+ * registry the rest of the app uses; keep in sync if currencies are added.
+ */
+const MINOR_UNIT_SCALE: Readonly<Record<string, number>> = Object.freeze({
+  BTC: 0,
+  SAT: 0,
+
+  // ISO 4217 — 0-digit fiat
+  JPY: 0,
+  KRW: 0,
+  CLP: 0,
+  ISK: 0,
+  HUF: 0,
+  TWD: 0,
+  VND: 0,
+
+  // ISO 4217 — 2-digit fiat (the common case)
+  USD: 2,
+  EUR: 2,
+  GBP: 2,
+  JMD: 2,
+  CAD: 2,
+  AUD: 2,
+  CHF: 2,
+  CNY: 2,
+  HKD: 2,
+  INR: 2,
+  MXN: 2,
+  BRL: 2,
+  ZAR: 2,
+  TTD: 2,
+  XCD: 2,
+  KYD: 2,
+  BBD: 2,
+  BSD: 2,
+  BZD: 2,
+  GYD: 2,
+  HTG: 2,
+  DOP: 2,
+  CUP: 2,
+  ARS: 2,
+  COP: 2,
+  PEN: 2,
+  UYU: 2,
+  VES: 2,
+  NGN: 2,
+  KES: 2,
+  GHS: 2,
+  EGP: 2,
+  PHP: 2,
+  THB: 2,
+  IDR: 2,
+  MYR: 2,
+  SGD: 2,
+  NZD: 2,
+  SEK: 2,
+  NOK: 2,
+  DKK: 2,
+  PLN: 2,
+  CZK: 2,
+  RON: 2,
+  TRY: 2,
+
+  // ISO 4217 — 3-digit fiat
+  BHD: 3,
+  IQD: 3,
+  JOD: 3,
+  KWD: 3,
+  LYD: 3,
+  OMR: 3,
+  TND: 3,
+})
+
+/**
+ * Default scale when a currency code is not in the table. Fiat is
+ * overwhelmingly 2-digit, so 2 is the safe default; passing an unknown
+ * currency through this function is logged as a warning by the caller's
+ * money library, not here.
+ */
+const DEFAULT_MINOR_UNIT_SCALE = 2
+
+// ---------------------------------------------------------------------------
+// Internal arithmetic. All inputs are normalised to `bigint` * 10^GUARD so
+// that intermediate ties (e.g. exactly 0.5) are exact even when the caller
+// passes a `number`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Guard digits used internally so that ties expressed in IEEE-754 (e.g.
+ * `0.1 + 0.2`) round consistently. 12 digits comfortably exceeds the ~15.95
+ * decimal digits of double precision while keeping intermediates well below
+ * `Number.MAX_SAFE_INTEGER` (2^53 ≈ 9.007e15) for any realistic minor-unit
+ * value.
+ */
+const GUARD = 12n
+const GUARD_SCALE = 10n ** GUARD
+
+/**
+ * Convert a `number | bigint` fractional-minor input into a scaled bigint.
+ * `bigint` inputs are assumed to already be in integer minor units (no scale
+ * applied) and are returned scaled by `GUARD_SCALE`.
+ */
+const toScaled = (input: number | bigint): bigint => {
+  if (typeof input === "bigint") {
+    return input * GUARD_SCALE
+  }
+  if (!Number.isFinite(input)) {
+    throw new RangeError(
+      `roundMinor: input must be a finite number, got ${String(input)}`,
+    )
+  }
+  // Format with fixed precision to convert `number` → exact decimal string,
+  // then strip the decimal point to get a bigint with `GUARD` fraction digits.
+  // This sidesteps `BigInt(Math.round(...))` which would re-introduce the
+  // very float drift this module is meant to remove.
+  const fixed = input.toFixed(Number(GUARD))
+  const negative = fixed.startsWith("-")
+  const body = negative ? fixed.slice(1) : fixed
+  const [intPart, fracPart = ""] = body.split(".")
+  const padded = (fracPart + "0".repeat(Number(GUARD))).slice(0, Number(GUARD))
+  const magnitude = BigInt(intPart + padded)
+  return negative ? -magnitude : magnitude
+}
+
+/**
+ * Apply a rounding mode to a scaled bigint, returning integer minor units.
+ *
+ * The `scaled` value represents `quotient.fraction` where `fraction` has
+ * `GUARD` digits. We separate quotient and fractional remainder, then
+ * dispatch on the mode.
+ */
+const applyMode = (scaled: bigint, mode: RoundingMode): bigint => {
+  const sign = scaled < 0n ? -1n : 1n
+  const abs = sign === -1n ? -scaled : scaled
+  const quotient = abs / GUARD_SCALE
+  const remainder = abs % GUARD_SCALE
+  if (remainder === 0n) {
+    return sign * quotient
+  }
+
+  // Compare 2 * remainder against GUARD_SCALE to detect ties without doing
+  // any floating-point arithmetic.
+  const twiceRemainder = remainder * 2n
+  const isTie = twiceRemainder === GUARD_SCALE
+  const isAboveHalf = twiceRemainder > GUARD_SCALE
+
+  let rounded: bigint
+  switch (mode) {
+    case "ceiling":
+      rounded = sign === 1n ? quotient + 1n : quotient
+      return sign * rounded
+    case "floor":
+      rounded = sign === 1n ? quotient : quotient + 1n
+      return sign * rounded
+    case "half-up":
+      // Half away from zero.
+      rounded = isAboveHalf || isTie ? quotient + 1n : quotient
+      return sign * rounded
+    case "half-down":
+      // Half toward zero.
+      rounded = isAboveHalf ? quotient + 1n : quotient
+      return sign * rounded
+    case "half-to-even":
+      if (isTie) {
+        // If the integer part is already even, stay; otherwise bump up.
+        rounded = quotient % 2n === 0n ? quotient : quotient + 1n
+      } else {
+        rounded = isAboveHalf ? quotient + 1n : quotient
+      }
+      return sign * rounded
+    default: {
+      // Exhaustiveness check — fails the build if RoundingMode is extended
+      // without updating this switch.
+      const _exhaustive: never = mode
+      throw new Error(`roundMinor: unhandled mode ${String(_exhaustive)}`)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Round a high-precision amount expressed in fractional minor units to an
+ * integer number of minor units, using the given mode.
+ *
+ * @param fractionalMinor  Amount in minor units. `1.5` USD-cents means
+ *                         "one and a half cents". `bigint` inputs are
+ *                         assumed already integer.
+ * @param mode             The rounding mode to apply.
+ * @returns                The rounded amount as a `bigint` (always exact).
+ *
+ * @example
+ *   roundMinor(1.5, "half-to-even")   // 2n
+ *   roundMinor(2.5, "half-to-even")   // 2n  (ties to even)
+ *   roundMinor(1.5, "half-up")        // 2n
+ *   roundMinor(-1.5, "half-up")       // -2n (away from zero)
+ *   roundMinor(1.4, "ceiling")        // 2n
+ *   roundMinor(1.9, "floor")          // 1n
+ */
+export function roundMinor(
+  fractionalMinor: number | bigint,
+  mode: RoundingMode,
+): bigint {
+  const scaled = toScaled(fractionalMinor)
+  return applyMode(scaled, mode)
+}
+
+/**
+ * Round a high-precision amount using the policy associated with the given
+ * context. This is the function call sites should use 99% of the time —
+ * passing a raw mode is a stronger statement that should be questioned in
+ * review.
+ */
+export function roundForContext(
+  fractionalMinor: number | bigint,
+  context: RoundingContext,
+): bigint {
+  const mode = CONTEXT_MODE[context]
+  return roundMinor(fractionalMinor, mode)
+}
+
+/**
+ * Look up the number of minor-unit fraction digits for a currency code.
+ * Returns the default (2) for unknown currencies; callers that want strict
+ * behaviour should check membership before calling.
+ *
+ * @example
+ *   minorUnitScale("USD")   // 2
+ *   minorUnitScale("BTC")   // 0
+ *   minorUnitScale("BHD")   // 3
+ *   minorUnitScale("XXX")   // 2  (default)
+ */
+export function minorUnitScale(currencyCode: string): number {
+  const upper = currencyCode.toUpperCase()
+  return MINOR_UNIT_SCALE[upper] ?? DEFAULT_MINOR_UNIT_SCALE
+}
+
+/**
+ * Read-only view of the policy table. Exposed for tests and for the
+ * developer doc; do not consume this in production code (use
+ * `roundForContext` instead).
+ */
+export const __policyForContext = (context: RoundingContext): RoundingMode =>
+  CONTEXT_MODE[context]


### PR DESCRIPTION
## What this is

The shared **RoundingPolicy** module from the currency-precision roadmap (ENG-318, Phase 1.2). Single TypeScript module shipped byte-identical to `flash`, `flash-mobile`, and consumed by `price-server`.

## Why now

The Phase 0 hotfix (ENG-316 / lnflash/flash-mobile#617) added one `Math.round` in `convertMoneyAmount`. The rest of the money pipeline still has scattered `Math.round` / `Math.floor` / `Math.ceil` calls, each making a silent policy choice. Once Phase 2 introduces the `MoneyAmount` scalar, every conversion in the system needs to declare its intent (display? accounting? fee? payout?) so the right mode is applied. **This module is the API that makes that declaration mandatory.**

## What's in the diff

| File | Purpose |
| -- | -- |
| `lib/money/rounding.ts` | The module. ~280 lines, no runtime deps, pure functions. |
| `lib/money/rounding.test.ts` | 135 unit cases — every mode × ties × negatives × bigint × number boundaries × idempotence × the policy table. |
| `lib/money/README.md` | "Which context do I pick" guide for engineers. |

**No production call sites are changed.** Migration is ENG-321.

## Public API

```ts
type RoundingMode = "half-to-even" | "half-up" | "half-down" | "ceiling" | "floor"
type RoundingContext = "accounting" | "display" | "fee" | "payout"

roundMinor(x: number | bigint, mode: RoundingMode): bigint
roundForContext(x: number | bigint, context: RoundingContext): bigint
minorUnitScale(currencyCode: string): number
```

## The entire policy table

| Context | Mode | Rationale |
| -- | -- | -- |
| `accounting` | `half-to-even` | IFRS/GAAP-friendly, no positive bias. |
| `display` | `half-up` | Matches user mental model. |
| `fee` | `ceiling` | House never under-charges itself. |
| `payout` | `floor` | House never over-pays; dust stays in treasury. |

Changing any of these four lines is a money-policy change reviewed as its own PR.

## Implementation notes

- All arithmetic done in `bigint` with 12 guard digits, so ties (e.g. `0.5`) round consistently regardless of how the input was computed in IEEE-754.
- `bigint` outputs everywhere so callers cannot silently re-introduce float drift after the round.
- `NaN` / `Infinity` throw `RangeError` rather than silently producing garbage.
- Exhaustiveness check (`never`) on the mode switch — adding a new mode without updating the dispatch will fail the build.

## Acceptance criteria (ENG-318)

- [x] Module published to both repos, byte-identical (companion PR: see "Sync" below)
- [x] Unit tests for each mode: ties (`0.5`, `−0.5`, `1.5`), negatives, zero, `bigint` inputs, `number` inputs > `Number.MAX_SAFE_INTEGER` boundaries
- [x] `roundForContext` mapping covered by tests that lock in the policy table
- [x] Property-test stub: `roundMinor` is idempotent on already-integer inputs across all modes
- [x] Developer doc: 1-page README in `lib/money/` explaining *which* mode to pick and *why*
- [x] No production call sites changed in this PR

## Sync between repos

The companion PR landing this **byte-identical** in the other repo is linked in the description below once both are open. Whichever lands first should reference the other.

We still need to choose between (a) a `scripts/sync-money.sh` CI check or (b) publishing `@lnflash/money` to npm. That's a small follow-up — for now both repos own the source and we eyeball the diff. Recommendation in review.

## Links

- Spec: https://linear.app/island-bitcoin/issue/ENG-318
- Parent epic: https://linear.app/island-bitcoin/issue/ENG-315
- Phase 0 hotfix that motivated this: lnflash/flash-mobile#617
- Original issue: lnflash/flash#282
