### PR TITLE
ENG-386: Android CSV export fix

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -58,6 +58,16 @@
        <!-- You will also only need to add this uses-library tag -->
       <uses-library android:name="org.apache.http.legacy" android:required="false"/>
 
+      <provider
+        android:name="androidx.core.content.FileProvider"
+        android:authorities="com.lnflash.rnshare.fileprovider"
+        android:exported="false"
+        android:grantUriPermissions="true">
+        <meta-data
+          android:name="android.support.FILE_PROVIDER_PATHS"
+          android:resource="@xml/file_paths" />
+      </provider>
+
     </application>
 
 </manifest>

--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+  <cache-path name="shared-files" path="." />
+  <external-cache-path name="shared-files-ext" path="." />
+</paths>

--- a/app/screens/settings-screen/settings/advanced-export-csv.tsx
+++ b/app/screens/settings-screen/settings/advanced-export-csv.tsx
@@ -42,10 +42,15 @@ export const ExportCsvSetting: React.FC = () => {
 
   const shareCsvFile = async (filePath: string) => {
     try {
-      const fileUrl = Platform.OS === "ios" ? filePath : `file://${filePath}`
+      let shareUrl = filePath
+      if (Platform.OS === "android") {
+        const cachePath = `${RNFS.CachesDirectoryPath}/flash-transactions.csv`
+        await RNFS.copyFile(filePath, cachePath)
+        shareUrl = `file://${cachePath}`
+      }
       await Share.open({
         title: "flash-transactions",
-        url: fileUrl,
+        url: shareUrl,
         type: "text/csv",
         failOnCancel: false,
       })

--- a/app/screens/settings-screen/settings/advanced-export-csv.tsx
+++ b/app/screens/settings-screen/settings/advanced-export-csv.tsx
@@ -1,4 +1,6 @@
+import { Alert, Platform } from "react-native"
 import Share from "react-native-share"
+import RNFS from "react-native-fs"
 
 import { gql } from "@apollo/client"
 import {
@@ -38,6 +40,23 @@ export const ExportCsvSetting: React.FC = () => {
       fetchPolicy: "network-only",
     })
 
+  const shareCsvFile = async (filePath: string) => {
+    try {
+      const fileUrl = Platform.OS === "ios" ? filePath : `file://${filePath}`
+      await Share.open({
+        title: "flash-transactions",
+        url: fileUrl,
+        type: "text/csv",
+        failOnCancel: false,
+      })
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        getCrashlytics().recordError(err)
+      }
+      console.error(err)
+    }
+  }
+
   const fetchCsvTransactions = async () => {
     const walletIds: string[] = []
     // if (btcWalletId) walletIds.push(btcWalletId)
@@ -48,18 +67,39 @@ export const ExportCsvSetting: React.FC = () => {
     })
 
     const csvEncoded = data?.me?.defaultAccount?.csvTransactions
+    if (!csvEncoded) return
+
     try {
-      await Share.open({
-        title: "flash-transactions",
-        filename: "flash-transactions",
-        url: `data:text/comma-separated-values;base64,${csvEncoded}`,
-        type: "text/comma-separated-values",
-      })
+      const csvContent = atob(csvEncoded)
+      const dirPath =
+        Platform.OS === "ios"
+          ? RNFS.DocumentDirectoryPath
+          : RNFS.DownloadDirectoryPath
+      const filePath = `${dirPath}/flash-transactions.csv`
+
+      await RNFS.writeFile(filePath, csvContent, "utf8")
+
+      Alert.alert(
+        "CSV Exported",
+        `Saved to ${
+          Platform.OS === "ios"
+            ? "Documents"
+            : "Downloads"
+        }/flash-transactions.csv`,
+        [
+          {
+            text: "Share",
+            onPress: () => shareCsvFile(filePath),
+          },
+          { text: "OK", style: "cancel" },
+        ],
+      )
     } catch (err: unknown) {
       if (err instanceof Error) {
         getCrashlytics().recordError(err)
       }
       console.error(err)
+      Alert.alert("Error", "Failed to export CSV")
     }
   }
 

--- a/app/screens/settings-screen/settings/advanced-export-csv.tsx
+++ b/app/screens/settings-screen/settings/advanced-export-csv.tsx
@@ -75,30 +75,33 @@ export const ExportCsvSetting: React.FC = () => {
     if (!csvEncoded) return
 
     try {
-      const csvContent = atob(csvEncoded)
-      const dirPath =
-        Platform.OS === "ios"
-          ? RNFS.DocumentDirectoryPath
-          : RNFS.DownloadDirectoryPath
-      const filePath = `${dirPath}/flash-transactions.csv`
+      if (Platform.OS === "ios") {
+        // iOS: share directly via base64 data URI so the file appears in the share sheet
+        await Share.open({
+          title: "flash-transactions",
+          filename: "flash-transactions",
+          url: `data:text/comma-separated-values;base64,${csvEncoded}`,
+          type: "text/comma-separated-values",
+          failOnCancel: false,
+        })
+      } else {
+        // Android: save to Downloads, then offer Share button
+        const csvContent = atob(csvEncoded)
+        const filePath = `${RNFS.DownloadDirectoryPath}/flash-transactions.csv`
+        await RNFS.writeFile(filePath, csvContent, "utf8")
 
-      await RNFS.writeFile(filePath, csvContent, "utf8")
-
-      Alert.alert(
-        "CSV Exported",
-        `Saved to ${
-          Platform.OS === "ios"
-            ? "Documents"
-            : "Downloads"
-        }/flash-transactions.csv`,
-        [
-          {
-            text: "Share",
-            onPress: () => shareCsvFile(filePath),
-          },
-          { text: "OK", style: "cancel" },
-        ],
-      )
+        Alert.alert(
+          "CSV Exported",
+          `Saved to Downloads/flash-transactions.csv`,
+          [
+            {
+              text: "Share",
+              onPress: () => shareCsvFile(filePath),
+            },
+            { text: "OK", style: "cancel" },
+          ],
+        )
+      }
     } catch (err: unknown) {
       if (err instanceof Error) {
         getCrashlytics().recordError(err)


### PR DESCRIPTION
## Summary
Fix Android CSV export — silent failure on share sheet + save-to-downloads flow.

## Changes
1. **AndroidManifest.xml** — Added FileProvider for react-native-share compatibility
2. **file_paths.xml** (new) — Cache paths for internal + external storage
3. **advanced-export-csv.tsx** — Rewrote to save CSV to Downloads first, then offer Share as secondary action

## Testing
- [x] Android: saves CSV to Downloads folder
- [x] Android: tapping Share opens share sheet with file attachment
- [x] iOS: retains existing save + share behavior
- [x] Filename: `flash-transactions.csv`

Closes ENG-386