### PR TITLE
Fix JMD transaction display and rounding

### DIFF
--- a/__tests__/hooks/use-price-conversion.spec.ts
+++ b/__tests__/hooks/use-price-conversion.spec.ts
@@ -6,7 +6,7 @@ const mockUseRealtimePriceQuery = jest.fn<
   Parameters<typeof useRealtimePriceQuery>
 >()
 import { usePriceConversion } from "@app/hooks/use-price-conversion"
-import { useRealtimePriceQuery } from "@app/graphql/generated"
+import { useRealtimePriceQuery, WalletCurrency } from "@app/graphql/generated"
 import {
   BtcMoneyAmount,
   DisplayAmount,
@@ -115,6 +115,22 @@ describe("usePriceConversion", () => {
       amountsArray.forEach((amount) => {
         expect(convertMoneyAmount(amount, amount.currency)).toBe(amount)
       })
+    })
+
+    it("rounds converted amounts to integer minor units", () => {
+      const convertedAmount = convertMoneyAmount(toBtcMoneyAmount(1), DisplayCurrency)
+
+      expect(convertedAmount).toEqual({
+        amount: 10,
+        currency: DisplayCurrency,
+        currencyCode: "NGN",
+      })
+
+      const convertedUsdAmount = convertMoneyAmount(
+        oneThousandDollarsInNairaMinorUnits,
+        WalletCurrency.Usd,
+      )
+      expect(Number.isInteger(convertedUsdAmount.amount)).toBe(true)
     })
   })
 })

--- a/__tests__/payment-details/intraledger-payment-details.spec.ts
+++ b/__tests__/payment-details/intraledger-payment-details.spec.ts
@@ -88,6 +88,37 @@ describe("intraledger payment details", () => {
         },
       })
     })
+
+    it("rounds the mutation amount", async () => {
+      const paymentDetails = createIntraledgerPaymentDetails({
+        ...btcSendingWalletParams,
+        convertMoneyAmount: (_amount, currency) => ({
+          amount: 123.6,
+          currency,
+          currencyCode: currency,
+        }),
+      })
+      const sendPaymentMocks = createSendPaymentMocks()
+      if (!paymentDetails.canSendPayment) {
+        throw new Error("Cannot send payment")
+      }
+
+      try {
+        await paymentDetails.sendPaymentMutation(sendPaymentMocks)
+      } catch {
+        // do nothing as function is expected to throw since we are not mocking the send payment response
+      }
+
+      expect(sendPaymentMocks.intraLedgerPaymentSend).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            recipientWalletId: defaultParams.recipientWalletId,
+            amount: 124,
+            walletId: btcSendingWalletParams.sendingWalletDescriptor.id,
+          },
+        },
+      })
+    })
   })
 
   describe("sending from a usd wallet", () => {
@@ -119,6 +150,37 @@ describe("intraledger payment details", () => {
           input: {
             recipientWalletId: defaultParams.recipientWalletId,
             amount: settlementAmount.amount,
+            walletId: usdSendingWalletParams.sendingWalletDescriptor.id,
+          },
+        },
+      })
+    })
+
+    it("rounds the mutation amount", async () => {
+      const paymentDetails = createIntraledgerPaymentDetails({
+        ...usdSendingWalletParams,
+        convertMoneyAmount: (_amount, currency) => ({
+          amount: 123.4,
+          currency,
+          currencyCode: currency,
+        }),
+      })
+      const sendPaymentMocks = createSendPaymentMocks()
+      if (!paymentDetails.canSendPayment) {
+        throw new Error("Cannot send payment")
+      }
+
+      try {
+        await paymentDetails.sendPaymentMutation(sendPaymentMocks)
+      } catch {
+        // do nothing as function is expected to throw since we are not mocking the send payment response
+      }
+
+      expect(sendPaymentMocks.intraLedgerUsdPaymentSend).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            recipientWalletId: defaultParams.recipientWalletId,
+            amount: 123,
             walletId: usdSendingWalletParams.sendingWalletDescriptor.id,
           },
         },

--- a/app/components/transaction-item/TxItem.tsx
+++ b/app/components/transaction-item/TxItem.tsx
@@ -12,7 +12,7 @@ import HideableArea from "../hideable-area/hideable-area"
 
 // hooks
 import { useNavigation } from "@react-navigation/native"
-import { useDisplayCurrency, usePriceConversion } from "@app/hooks"
+import { useDisplayCurrency } from "@app/hooks"
 
 // assets
 import ArrowUp from "@app/assets/icons/arrow-up.svg"
@@ -20,7 +20,7 @@ import ArrowDown from "@app/assets/icons/arrow-down.svg"
 import Icon from "react-native-vector-icons/Ionicons"
 
 // utils
-import { toBtcMoneyAmount, toUsdMoneyAmount } from "@app/types/amounts"
+import { toBtcMoneyAmount, toWalletAmount } from "@app/types/amounts"
 
 // types
 import {
@@ -44,8 +44,8 @@ export const TxItem: React.FC<Props> = React.memo(({ tx }) => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>()
   const { colors } = useTheme().theme
 
-  const { formatMoneyAmount, moneyAmountToDisplayCurrencyString } = useDisplayCurrency()
-  const { convertMoneyAmount } = usePriceConversion()
+  const { formatCurrency, formatMoneyAmount, moneyAmountToDisplayCurrencyString } =
+    useDisplayCurrency()
 
   const { data: { hideBalance = false } = {} } = useHideBalanceQuery()
 
@@ -77,21 +77,24 @@ export const TxItem: React.FC<Props> = React.memo(({ tx }) => {
     })
     secondaryAmount = formatMoneyAmount({ moneyAmount })
   } else {
-    // Ibex transaction - always USD
-    const amount = tx.transaction.settlementAmount * 100
-    const moneyAmount = toUsdMoneyAmount(amount ?? NaN)
-    primaryAmount = moneyAmountToDisplayCurrencyString({
-      moneyAmount,
+    const { transaction } = tx
+    primaryAmount = formatCurrency({
+      amountInMajorUnits: transaction.settlementDisplayAmount,
+      currency: transaction.settlementDisplayCurrency,
     })
-    if (convertMoneyAmount) {
+    if (transaction.settlementDisplayCurrency !== transaction.settlementCurrency) {
       secondaryAmount = formatMoneyAmount({
-        moneyAmount: convertMoneyAmount(moneyAmount, "BTC"),
+        moneyAmount: toWalletAmount({
+          amount: transaction.settlementAmount,
+          currency: transaction.settlementCurrency,
+        }),
       })
     }
   }
 
-  // Get currency label - Breez is BTC, Ibex is USD
-  const currencyLabel = isBreezTransaction(tx) ? "BTC" : "USD"
+  const currencyLabel = isBreezTransaction(tx)
+    ? "BTC"
+    : tx.transaction.settlementDisplayCurrency
 
   const onPress = () => {
     if (isIbexTransaction(tx)) {

--- a/app/hooks/use-price-conversion.ts
+++ b/app/hooks/use-price-conversion.ts
@@ -93,12 +93,9 @@ export const usePriceConversion = () => {
         return moneyAmount
       }
 
-      let amount =
-        moneyAmount.amount * priceOfCurrencyInCurrency(moneyAmount.currency, toCurrency)
-
-      if (toCurrency === "BTC") {
-        amount = Math.round(amount)
-      }
+      const amount = Math.round(
+        moneyAmount.amount * priceOfCurrencyInCurrency(moneyAmount.currency, toCurrency),
+      )
 
       if (
         moneyAmountIsCurrencyType(moneyAmount, DisplayCurrency) &&

--- a/app/screens/receive-bitcoin-screen/payment/payment-request.ts
+++ b/app/screens/receive-bitcoin-screen/payment/payment-request.ts
@@ -118,12 +118,13 @@ export const createPaymentRequest = (
       // Handle USD payment requests
       if (pr.type === Invoice.Lightning) {
         if (pr.settlementAmount && pr.settlementAmount?.currency === WalletCurrency.Usd) {
-          console.log("Invoice create amount: ", pr.settlementAmount.amount)
+          const roundedAmount = Math.round(pr.settlementAmount.amount)
+          console.log("Invoice create amount: ", roundedAmount)
           const { data, errors } = await mutations.lnUsdInvoiceCreate({
             variables: {
               input: {
                 walletId: pr.receivingWalletDescriptor.id,
-                amount: pr.settlementAmount.amount,
+                amount: roundedAmount,
                 memo: pr.memo,
               },
             },

--- a/app/screens/send-bitcoin-screen/payment-details/intraledger.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/intraledger.ts
@@ -37,6 +37,7 @@ export const createIntraledgerPaymentDetails = <T extends WalletCurrency>(
     unitOfAccountAmount,
     sendingWalletDescriptor.currency,
   )
+  const mutationAmount = Math.round(settlementAmount.amount)
 
   const getFee: GetFee<T> = (_) => {
     return Promise.resolve({
@@ -61,7 +62,7 @@ export const createIntraledgerPaymentDetails = <T extends WalletCurrency>(
           input: {
             walletId: sendingWalletDescriptor.id,
             recipientWalletId,
-            amount: settlementAmount.amount,
+            amount: mutationAmount,
             memo,
           },
         },
@@ -89,7 +90,7 @@ export const createIntraledgerPaymentDetails = <T extends WalletCurrency>(
           input: {
             walletId: sendingWalletDescriptor.id,
             recipientWalletId,
-            amount: settlementAmount.amount,
+            amount: mutationAmount,
             memo,
           },
         },

--- a/app/utils/transactions.ts
+++ b/app/utils/transactions.ts
@@ -1,8 +1,7 @@
 import type { Payment } from "@breeztech/breez-sdk-spark-react-native"
 import { TranslationFunctions } from "@app/i18n/i18n-types"
 import { ConvertMoneyAmount } from "@app/screens/send-bitcoin-screen/payment-details"
-import { WalletCurrency } from "@app/graphql/generated"
-import { toBtcMoneyAmount } from "@app/types/amounts"
+import { DisplayCurrency, toBtcMoneyAmount } from "@app/types/amounts"
 import type { BreezTransaction } from "@app/types/transactions"
 
 const getUserTimezoneDate = (date: Date): Date => {
@@ -98,12 +97,12 @@ export const formatBreezPayment = ({
 }): BreezTransaction => {
   const displayAmount = convertMoneyAmount(
     toBtcMoneyAmount(Number(payment.amount)),
-    WalletCurrency.Usd,
+    DisplayCurrency,
   )
 
   const displayFee = convertMoneyAmount(
     toBtcMoneyAmount(Number(payment.fees)),
-    WalletCurrency.Usd,
+    DisplayCurrency,
   )
 
   return {


### PR DESCRIPTION
## Summary

Mobile side of lnflash/flash#282 / #284 / #267.

This updates the app-side transaction and payment flow behavior for JMD users:

- rounds `convertMoneyAmount()` results for every target currency, not only BTC
- rounds USD invoice and intraledger mutation amounts before API submission
- makes `TxItem` display the transaction API's `settlementDisplayAmount` / `settlementDisplayCurrency`, matching the detail screen
- removes the transaction-list USD `settlementAmount * 100` recomputation path
- converts Breez/Spark BTC payments into the user's `DisplayCurrency` instead of hardcoded USD
- adds focused tests for rounded conversions and rounded intraledger mutation amounts

## Tests

- Ran `prettier --check` on changed files.

I could not run the Jest suite locally because this checkout has no `node_modules`; the changed tests are included for CI.
