### PR TITLE
fix: emphasize flash fee on confirmation

### DIFF
--- a/app/components/send-flow/ConfirmationWalletFee.tsx
+++ b/app/components/send-flow/ConfirmationWalletFee.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react"
+import React, { useCallback, useEffect } from "react"
 import { ActivityIndicator, View } from "react-native"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { makeStyles, Text } from "@rneui/themed"
@@ -19,6 +19,9 @@ import { fetchBreezFee } from "@app/utils/breez-sdk"
 // assets
 import Cash from "@app/assets/icons/cash.svg"
 import Bitcoin from "@app/assets/icons/bitcoin.svg"
+
+const WESTERN_UNION_COMPARISON_THRESHOLD_CENTS = 1000
+const FLASH_FEE_GREEN = "#3ab54a"
 
 type Props = {
   flashUserAddress?: string
@@ -46,19 +49,21 @@ const ConfirmationWalletFee: React.FC<Props> = ({
   const styles = useStyles()
   const getLightningFee = useFee(getFee ? getFee : null)
   const { formatDisplayAndWalletAmount } = useDisplayCurrency()
+  const usdSettlementAmount = paymentDetail.convertMoneyAmount(
+    settlementAmount,
+    WalletCurrency.Usd,
+  )
+  const showWesternUnionComparison =
+    usdSettlementAmount.amount > WESTERN_UNION_COMPARISON_THRESHOLD_CENTS
 
-  useEffect(() => {
-    getSendingFee()
-  }, [getLightningFee])
-
-  const getSendingFee = async () => {
+  const getSendingFee = useCallback(async () => {
     setFee({ status: "loading", amount: undefined })
     if (sendingWalletDescriptor.currency === "USD") {
       setFee(getLightningFee)
     } else {
       const { fee, err } = await fetchBreezFee(
         paymentType,
-        !!flashUserAddress ? flashUserAddress : paymentDetail.destination,
+        flashUserAddress || paymentDetail.destination,
         settlementAmount.amount,
         selectedFeeType,
       )
@@ -80,7 +85,21 @@ const ConfirmationWalletFee: React.FC<Props> = ({
         setPaymentError(`${err}`)
       }
     }
-  }
+  }, [
+    flashUserAddress,
+    getLightningFee,
+    paymentDetail.destination,
+    paymentType,
+    selectedFeeType,
+    sendingWalletDescriptor.currency,
+    setFee,
+    setPaymentError,
+    settlementAmount.amount,
+  ])
+
+  useEffect(() => {
+    getSendingFee()
+  }, [getSendingFee])
 
   let feeDisplayText = ""
   if (fee.amount) {
@@ -129,10 +148,12 @@ const ConfirmationWalletFee: React.FC<Props> = ({
         <View style={styles.fieldBackground}>
           {fee.status === "loading" && <ActivityIndicator />}
           {fee.status === "set" && (
-            <Text {...testProps("Successful Fee")}>{feeDisplayText}</Text>
+            <Text style={styles.feeAmountText} {...testProps("Successful Fee")}>
+              {feeDisplayText}
+            </Text>
           )}
           {fee.status === "error" && Boolean(fee.amount) && (
-            <Text>{feeDisplayText} *</Text>
+            <Text style={styles.feeAmountText}>{feeDisplayText} *</Text>
           )}
           {fee.status === "error" && !fee.amount && (
             <Text>{LL.SendBitcoinConfirmationScreen.feeError()}</Text>
@@ -141,6 +162,11 @@ const ConfirmationWalletFee: React.FC<Props> = ({
             <Text>{LL.SendBitcoinConfirmationScreen.breezFeeText()}</Text>
           )}
         </View>
+        {showWesternUnionComparison && (
+          <Text style={styles.feeComparisonText}>
+            Western Union charges ~J$1,800 for this transfer
+          </Text>
+        )}
         {fee.status === "error" && Boolean(fee.amount) && (
           <Text style={styles.maxFeeWarningText}>
             {"*" + LL.SendBitcoinConfirmationScreen.maxFeeSelected()}
@@ -189,6 +215,15 @@ const useStyles = makeStyles(({ colors }) => ({
   walletSelectorBalanceContainer: {
     flex: 1,
     flexDirection: "row",
+  },
+  feeAmountText: {
+    color: FLASH_FEE_GREEN,
+    fontWeight: "bold",
+  },
+  feeComparisonText: {
+    color: colors.grey2,
+    fontSize: 12,
+    marginTop: 4,
   },
   maxFeeWarningText: {
     color: colors.warning,

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -704,7 +704,7 @@ const en: BaseTranslation = {
     confirmPayment: "Confirm payment",
     confirmPaymentQuestion: "Do you want to confirm this payment?",
     destinationLabel: "To:",
-    feeLabel: "Fee",
+    feeLabel: "Flash fee:",
     memoLabel: "Note:",
     paymentFinal: "Payments are final.",
     stalePrice:

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -664,7 +664,7 @@
         "confirmPayment": "Confirm payment",
         "confirmPaymentQuestion": "Do you want to confirm this payment?",
         "destinationLabel": "To:",
-        "feeLabel": "Fee",
+        "feeLabel": "Flash fee:",
         "memoLabel": "Note:",
         "paymentFinal": "Payments are final.",
         "stalePrice": "Your bitcoin price is old and was last updated {timePeriod} ago. Please restart the app before making a payment.",


### PR DESCRIPTION
Closes #561

## Summary
- change the confirmation fee label to "Flash fee:"
- render successful and max-fee fallback amounts in bold brand green (`#3ab54a`)
- show "Western Union charges ~J$1,800 for this transfer" only when the settlement amount is above $10 USD equivalent
- clean up the touched fee component's existing lint issues around `flashUserAddress` fallback and hook dependencies

Lightning address: npub1l0jg0upfzrzn3nm43stvqy2cvxf5wftupkj2qm8znshuzr76xrzs2tfxa8@npub.cash

## Verification
- `git diff --check`
- `./node_modules/.bin/prettier --write app/components/send-flow/ConfirmationWalletFee.tsx app/i18n/en/index.ts app/i18n/raw-i18n/source/en.json`
- `./node_modules/.bin/eslint app/components/send-flow/ConfirmationWalletFee.tsx --ext .js,.ts,.tsx`
- `./node_modules/.bin/tsc -p . --noEmit --module esnext --pretty false` (fails on existing repo-wide type errors; no errors reported for `app/components/send-flow/ConfirmationWalletFee.tsx`)

## Screenshots
I could not capture native iOS/Android screenshots from this Linux/aarch64 machine because it has no Android emulator/ADB or iOS simulator available. The change is limited to the existing confirmation fee row rendering.
