### PR TITLE
fix: USDT amount rendering in transaction UI

### DIFF
--- a/__tests__/components/currency-tag.spec.tsx
+++ b/__tests__/components/currency-tag.spec.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+import { render } from "@testing-library/react-native"
+import { ThemeProvider } from "@rneui/themed"
+
+import { CurrencyTag } from "@app/components/currency-tag"
+import { WalletCurrency } from "@app/graphql/generated"
+import theme from "@app/rne-theme/theme"
+
+const renderCurrencyTag = (walletCurrency: WalletCurrency) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <CurrencyTag walletCurrency={walletCurrency} />
+    </ThemeProvider>,
+  )
+
+describe("CurrencyTag", () => {
+  it.each([WalletCurrency.Btc, WalletCurrency.Usd, WalletCurrency.Usdt])(
+    "renders a %s tag",
+    (walletCurrency) => {
+      const { getByText } = renderCurrencyTag(walletCurrency)
+
+      expect(getByText(walletCurrency)).toBeTruthy()
+    },
+  )
+})

--- a/__tests__/hooks/use-display-currency.spec.tsx
+++ b/__tests__/hooks/use-display-currency.spec.tsx
@@ -5,7 +5,11 @@ import { MockedProvider } from "@apollo/client/testing"
 import { PropsWithChildren } from "react"
 import * as React from "react"
 import { IsAuthedContextProvider } from "@app/graphql/is-authed-context"
-import { CurrencyListDocument, RealtimePriceDocument } from "@app/graphql/generated"
+import {
+  CurrencyListDocument,
+  RealtimePriceDocument,
+  WalletCurrency,
+} from "@app/graphql/generated"
 
 const mocksNgn = [
   {
@@ -135,6 +139,21 @@ const wrapWithMocks =
 
 describe("usePriceConversion", () => {
   describe("testing moneyAmountToMajorUnitOrSats", () => {
+    it("formats USDT micros as major units", async () => {
+      const { result } = renderHook(useDisplayCurrency, {
+        wrapper: wrapWithMocks([]),
+      })
+
+      const moneyAmount = {
+        amount: 179_554,
+        currency: WalletCurrency.Usdt,
+        currencyCode: "USDT",
+      }
+
+      expect(result.current.moneyAmountToMajorUnitOrSats(moneyAmount)).toBe(0.179554)
+      expect(result.current.formatMoneyAmount({ moneyAmount })).toBe("$0.179554 USDT")
+    })
+
     it("with 0 digits", async () => {
       const { result, waitForNextUpdate } = renderHook(useDisplayCurrency, {
         wrapper: wrapWithMocks(mocksJpy),
@@ -229,5 +248,30 @@ describe("usePriceConversion", () => {
       fiatSymbol: "₦",
       displayCurrency: "NGN",
     })
+  })
+
+  it("converts USDT micros to display currency using USD-cent price", async () => {
+    const { result, waitFor } = renderHook(useDisplayCurrency, {
+      wrapper: wrapWithMocks(mocksNgn),
+    })
+
+    await waitFor(
+      () => {
+        return result.current.displayCurrency === "NGN"
+      },
+      {
+        timeout: 4000,
+      },
+    )
+
+    const displayAmount = result.current.moneyAmountToDisplayCurrencyString({
+      moneyAmount: {
+        amount: 1_000_000,
+        currency: WalletCurrency.Usdt,
+        currencyCode: "USDT",
+      },
+    })
+
+    expect(displayAmount).toBe("₦100.00")
   })
 })

--- a/app/components/currency-tag/currency-tag.tsx
+++ b/app/components/currency-tag/currency-tag.tsx
@@ -3,55 +3,55 @@ import { makeStyles, useTheme } from "@rneui/themed"
 import React, { FC } from "react"
 import { Text, View } from "react-native"
 
-const useStyles = makeStyles(() => ({
+type CurrencyTagProps = {
+  walletCurrency: WalletCurrency
+}
+
+type CurrencyStyle = {
+  backgroundColor: string
+  textColor: string
+}
+
+export const CurrencyTag: FC<CurrencyTagProps> = ({ walletCurrency }) => {
+  const {
+    theme: { colors },
+  } = useTheme()
+
+  const currencyStyling: Record<WalletCurrency, CurrencyStyle> = {
+    [WalletCurrency.Btc]: {
+      textColor: colors.white,
+      backgroundColor: colors.primary,
+    },
+    [WalletCurrency.Usd]: {
+      textColor: colors.black,
+      backgroundColor: colors.green,
+    },
+    [WalletCurrency.Usdt]: {
+      textColor: colors.black,
+      backgroundColor: colors.green,
+    },
+  }
+
+  const styles = useStyles(currencyStyling[walletCurrency])
+
+  return (
+    <View style={styles.currencyTag}>
+      <Text style={styles.currencyText}>{walletCurrency}</Text>
+    </View>
+  )
+}
+
+const useStyles = makeStyles((_, currencyStyle: CurrencyStyle) => ({
   currencyTag: {
     borderRadius: 10,
     height: 30,
     width: 50,
     justifyContent: "center",
     alignItems: "center",
+    backgroundColor: currencyStyle.backgroundColor,
   },
   currencyText: {
     fontSize: 12,
+    color: currencyStyle.textColor,
   },
 }))
-
-type CurrencyTagProps = {
-  walletCurrency: WalletCurrency
-}
-
-export const CurrencyTag: FC<CurrencyTagProps> = ({ walletCurrency }) => {
-  const styles = useStyles()
-  const {
-    theme: { colors },
-  } = useTheme()
-
-  const currencyStyling = {
-    BTC: {
-      textColor: colors.white,
-      backgroundColor: colors.primary,
-    },
-    USD: {
-      textColor: colors.black,
-      backgroundColor: colors.green,
-    },
-  }
-
-  return (
-    <View
-      style={{
-        ...styles.currencyTag,
-        backgroundColor: currencyStyling[walletCurrency].backgroundColor,
-      }}
-    >
-      <Text
-        style={{
-          ...styles.currencyText,
-          color: currencyStyling[walletCurrency].textColor,
-        }}
-      >
-        {walletCurrency}
-      </Text>
-    </View>
-  )
-}

--- a/app/components/transaction-item/TxItem.tsx
+++ b/app/components/transaction-item/TxItem.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import moment from "moment"
 import styled from "styled-components/native"
 import { Text, useTheme } from "@rneui/themed"
-import { useHideBalanceQuery } from "@app/graphql/generated"
+import { useHideBalanceQuery, WalletCurrency } from "@app/graphql/generated"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
 import { PaymentType, PaymentStatus } from "@breeztech/breez-sdk-spark-react-native"
@@ -20,7 +20,7 @@ import ArrowDown from "@app/assets/icons/arrow-down.svg"
 import Icon from "react-native-vector-icons/Ionicons"
 
 // utils
-import { toBtcMoneyAmount, toUsdMoneyAmount } from "@app/types/amounts"
+import { toBtcMoneyAmount, toWalletAmount } from "@app/types/amounts"
 
 // types
 import {
@@ -40,11 +40,12 @@ const label = {
   SEND: "Sent",
 }
 
-export const TxItem: React.FC<Props> = React.memo(({ tx }) => {
+const TxItemComponent: React.FC<Props> = ({ tx }) => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>()
   const { colors } = useTheme().theme
 
-  const { formatMoneyAmount, moneyAmountToDisplayCurrencyString } = useDisplayCurrency()
+  const { formatMoneyAmount, moneyAmountToDisplayCurrencyString, formatCurrency } =
+    useDisplayCurrency()
   const { convertMoneyAmount } = usePriceConversion()
 
   const { data: { hideBalance = false } = {} } = useHideBalanceQuery()
@@ -67,6 +68,7 @@ export const TxItem: React.FC<Props> = React.memo(({ tx }) => {
   // Calculate display amounts
   let primaryAmount = null
   let secondaryAmount = null
+  let feeAmount = null
 
   if (isBreezTransaction(tx)) {
     // Breez transaction - always BTC
@@ -77,21 +79,34 @@ export const TxItem: React.FC<Props> = React.memo(({ tx }) => {
     })
     secondaryAmount = formatMoneyAmount({ moneyAmount })
   } else {
-    // Ibex transaction - always USD
-    const amount = tx.transaction.settlementAmount * 100
-    const moneyAmount = toUsdMoneyAmount(amount ?? NaN)
-    primaryAmount = moneyAmountToDisplayCurrencyString({
-      moneyAmount,
+    const moneyAmount = toWalletAmount({
+      amount: Math.abs(tx.transaction.settlementAmount),
+      currency: tx.transaction.settlementCurrency,
     })
-    if (convertMoneyAmount) {
+    primaryAmount = formatCurrency({
+      amountInMajorUnits: tx.transaction.settlementDisplayAmount,
+      currency: tx.transaction.settlementDisplayCurrency,
+    })
+
+    if (tx.transaction.settlementCurrency === WalletCurrency.Usd && convertMoneyAmount) {
       secondaryAmount = formatMoneyAmount({
         moneyAmount: convertMoneyAmount(moneyAmount, "BTC"),
+      })
+    } else {
+      secondaryAmount = formatMoneyAmount({ moneyAmount })
+    }
+
+    if (!isReceive && tx.transaction.settlementFee > 0) {
+      feeAmount = formatMoneyAmount({
+        moneyAmount: toWalletAmount({
+          amount: tx.transaction.settlementFee,
+          currency: tx.transaction.settlementCurrency,
+        }),
       })
     }
   }
 
-  // Get currency label - Breez is BTC, Ibex is USD
-  const currencyLabel = isBreezTransaction(tx) ? "BTC" : "USD"
+  const currencyLabel = isBreezTransaction(tx) ? "BTC" : tx.transaction.settlementCurrency
 
   const onPress = () => {
     if (isIbexTransaction(tx)) {
@@ -120,30 +135,39 @@ export const TxItem: React.FC<Props> = React.memo(({ tx }) => {
           )}
         </RowWrapper>
         {memo && (
-          <RowWrapper style={{ marginVertical: 2 }}>
+          <MetadataRowWrapper>
             <Icon name="document-text" size={14} color={colors.primary} />
             <Text type="caption" color={colors.primary} numberOfLines={1}>
               {memo}
             </Text>
-          </RowWrapper>
+          </MetadataRowWrapper>
+        )}
+        {feeAmount && (
+          <MetadataRowWrapper>
+            <Text type="caption" color={colors.text02}>
+              {`Fee ${feeAmount}`}
+            </Text>
+          </MetadataRowWrapper>
         )}
         <Text type="caption" color={colors.text02}>
           {moment(moment.unix(timestamp)).fromNow()}
         </Text>
       </ColumnWrapper>
       <HideableArea isContentVisible={hideBalance}>
-        <ColumnWrapper style={{ alignItems: "flex-end" }}>
+        <AmountColumnWrapper>
           <Text type="bl" color={isReceive ? colors.accent02 : colors.black}>
             {primaryAmount}
           </Text>
           <Text type="caption" color={colors.text02}>
             {secondaryAmount}
           </Text>
-        </ColumnWrapper>
+        </AmountColumnWrapper>
       </HideableArea>
     </Wrapper>
   )
-})
+}
+
+export const TxItem = React.memo(TxItemComponent)
 
 const Wrapper = styled.TouchableOpacity`
   flex-direction: row;
@@ -168,4 +192,12 @@ const ColumnWrapper = styled.View`
 const RowWrapper = styled.View`
   flex-direction: row;
   align-items: center;
+`
+
+const MetadataRowWrapper = styled(RowWrapper)`
+  margin-vertical: 2px;
+`
+
+const AmountColumnWrapper = styled(ColumnWrapper)`
+  align-items: flex-end;
 `

--- a/app/hooks/use-display-currency.ts
+++ b/app/hooks/use-display-currency.ts
@@ -1,14 +1,11 @@
 import { gql } from "@apollo/client"
 import { useCurrencyListQuery, WalletCurrency } from "@app/graphql/generated"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
-import { ConvertMoneyAmount } from "@app/screens/send-bitcoin-screen/payment-details"
 import {
   DisplayAmount,
   DisplayCurrency,
-  lessThan,
   MoneyAmount,
-  toBtcMoneyAmount,
-  toUsdMoneyAmount,
+  USDT_MICROS_PER_USDT,
   WalletAmount,
   WalletOrDisplayCurrency,
 } from "@app/types/amounts"
@@ -82,36 +79,6 @@ const formatCurrencyHelper = ({
   }${symbol}${amountStr}${currencyCode ? ` ${currencyCode}` : ""}`
 }
 
-const displayCurrencyHasSignificantMinorUnits = ({
-  convertMoneyAmount,
-  amountInMajorUnitOrSatsToMoneyAmount,
-}: {
-  convertMoneyAmount?: ConvertMoneyAmount
-  amountInMajorUnitOrSatsToMoneyAmount: (
-    amount: number,
-    currency: WalletOrDisplayCurrency,
-  ) => MoneyAmount<WalletOrDisplayCurrency>
-}) => {
-  if (!convertMoneyAmount) {
-    return true
-  }
-
-  const oneMajorUnitOfDisplayCurrency = amountInMajorUnitOrSatsToMoneyAmount(
-    1,
-    DisplayCurrency,
-  )
-
-  const oneUsdCentInDisplayCurrency = convertMoneyAmount(
-    toUsdMoneyAmount(1),
-    DisplayCurrency,
-  )
-
-  return lessThan({
-    value: oneUsdCentInDisplayCurrency,
-    lessThan: oneMajorUnitOfDisplayCurrency,
-  })
-}
-
 export const useDisplayCurrency = () => {
   const { LL } = useI18nContext()
   const isAuthed = useIsAuthed()
@@ -136,39 +103,15 @@ export const useDisplayCurrency = () => {
         case WalletCurrency.Btc:
           return moneyAmount.amount
         case WalletCurrency.Usd:
-        case WalletCurrency.Usdt:
           return moneyAmount.amount / 100
+        case WalletCurrency.Usdt:
+          return moneyAmount.amount / USDT_MICROS_PER_USDT
         case DisplayCurrency:
           return moneyAmount.amount / 10 ** displayCurrencyInfo.fractionDigits
       }
     },
     [displayCurrencyInfo],
   )
-
-  const amountInMajorUnitOrSatsToMoneyAmount = useCallback(
-    (
-      amount: number,
-      currency: WalletOrDisplayCurrency,
-    ): MoneyAmount<WalletOrDisplayCurrency> => {
-      switch (currency) {
-        case WalletCurrency.Btc:
-          return toBtcMoneyAmount(Math.round(amount))
-        case WalletCurrency.Usd:
-        case WalletCurrency.Usdt:
-          return toUsdMoneyAmount(Math.round(amount * 100))
-        case DisplayCurrency:
-          return toDisplayMoneyAmount(
-            Math.round(amount * 10 ** displayCurrencyInfo.fractionDigits),
-          )
-      }
-    },
-    [displayCurrencyInfo, toDisplayMoneyAmount],
-  )
-
-  const displayCurrencyShouldDisplayDecimals = displayCurrencyHasSignificantMinorUnits({
-    convertMoneyAmount,
-    amountInMajorUnitOrSatsToMoneyAmount,
-  })
 
   const currencyInfo: Record<WalletOrDisplayCurrency, CurrencyInfo> = useMemo(() => {
     return {
@@ -180,7 +123,7 @@ export const useDisplayCurrency = () => {
       },
       [WalletCurrency.Usdt]: {
         symbol: usdDisplayCurrency.symbol,
-        minorUnitToMajorUnitOffset: usdDisplayCurrency.fractionDigits,
+        minorUnitToMajorUnitOffset: 6,
         showFractionDigits: true,
         currencyCode: "USDT",
       },
@@ -260,7 +203,9 @@ export const useDisplayCurrency = () => {
         symbol: noSymbol ? "" : symbol,
         fractionDigits: showFractionDigits ? minorUnitToMajorUnitOffset : 0,
         currencyCode:
-          moneyAmount.currency === WalletCurrency.Btc && !noSuffix
+          (moneyAmount.currency === WalletCurrency.Btc ||
+            moneyAmount.currency === WalletCurrency.Usdt) &&
+          !noSuffix
             ? currencyCode
             : undefined,
       })

--- a/app/hooks/use-price-conversion.ts
+++ b/app/hooks/use-price-conversion.ts
@@ -5,6 +5,7 @@ import {
   DisplayCurrency,
   MoneyAmount,
   moneyAmountIsCurrencyType,
+  USDT_MICROS_PER_USD_CENT,
   WalletOrDisplayCurrency,
 } from "@app/types/amounts"
 import { useMemo } from "react"
@@ -62,25 +63,30 @@ export const usePriceConversion = () => {
         [WalletCurrency.Btc]: {
           [DisplayCurrency]: displayCurrencyPerSat,
           [WalletCurrency.Usd]: displayCurrencyPerSat * (1 / displayCurrencyPerCent),
-          [WalletCurrency.Usdt]: displayCurrencyPerSat * (1 / displayCurrencyPerCent),
+          [WalletCurrency.Usdt]:
+            displayCurrencyPerSat *
+            (1 / displayCurrencyPerCent) *
+            USDT_MICROS_PER_USD_CENT,
           [WalletCurrency.Btc]: 1,
         },
         [WalletCurrency.Usd]: {
           [DisplayCurrency]: displayCurrencyPerCent,
           [WalletCurrency.Btc]: displayCurrencyPerCent * (1 / displayCurrencyPerSat),
           [WalletCurrency.Usd]: 1,
-          [WalletCurrency.Usdt]: 1,
+          [WalletCurrency.Usdt]: USDT_MICROS_PER_USD_CENT,
         },
         [WalletCurrency.Usdt]: {
-          [DisplayCurrency]: displayCurrencyPerCent,
-          [WalletCurrency.Btc]: displayCurrencyPerCent * (1 / displayCurrencyPerSat),
-          [WalletCurrency.Usd]: 1,
+          [DisplayCurrency]: displayCurrencyPerCent / USDT_MICROS_PER_USD_CENT,
+          [WalletCurrency.Btc]:
+            (displayCurrencyPerCent / USDT_MICROS_PER_USD_CENT) *
+            (1 / displayCurrencyPerSat),
+          [WalletCurrency.Usd]: 1 / USDT_MICROS_PER_USD_CENT,
           [WalletCurrency.Usdt]: 1,
         },
         [DisplayCurrency]: {
           [WalletCurrency.Btc]: 1 / displayCurrencyPerSat,
           [WalletCurrency.Usd]: 1 / displayCurrencyPerCent,
-          [WalletCurrency.Usdt]: 1 / displayCurrencyPerCent,
+          [WalletCurrency.Usdt]: (1 / displayCurrencyPerCent) * USDT_MICROS_PER_USD_CENT,
           [DisplayCurrency]: 1,
         },
       }

--- a/app/types/amounts.ts
+++ b/app/types/amounts.ts
@@ -1,5 +1,9 @@
 import { WalletCurrency } from "@app/graphql/generated"
 
+export const CENTS_PER_USD = 100
+export const USDT_MICROS_PER_USDT = 1_000_000
+export const USDT_MICROS_PER_USD_CENT = USDT_MICROS_PER_USDT / CENTS_PER_USD
+
 export const DisplayCurrency = "DisplayCurrency" as const
 export type DisplayCurrency = typeof DisplayCurrency
 


### PR DESCRIPTION
## Summary
- Adds USDT micro-unit constants and conversion handling.
- Formats USDT amounts with six decimals and a USDT suffix.
- Updates transaction item display to use settlement currency/display amount and show send fees.
- Adds regression coverage for `CurrencyTag` and display-currency behavior.

## Verification
- `git diff --check origin/feat/fygaro..HEAD`
- Focused eslint passed for the changed USDT display files.
- Focused Jest was attempted for the new/updated tests, but this checkout cannot load `ttypescript`, which is required by the existing `ts-jest` config.