### PR TITLE
feat: add Bridge cashout confirmation and manual bank fallback

### DIFF
--- a/app/graphql/front-end-mutations.ts
+++ b/app/graphql/front-end-mutations.ts
@@ -284,4 +284,37 @@ gql`
       }
     }
   }
+
+  mutation BridgeCancelWithdrawalRequest($input: BridgeCancelWithdrawalRequestInput!) {
+    bridgeCancelWithdrawalRequest(input: $input) {
+      withdrawal {
+        amount
+        createdAt
+        currency
+        externalAccountId
+        failureReason
+        id
+        status
+      }
+      errors {
+        code
+        message
+      }
+    }
+  }
+
+  mutation BridgeCreateExternalAccount($input: BridgeCreateExternalAccountInput!) {
+    bridgeCreateExternalAccount(input: $input) {
+      externalAccount {
+        id
+        bankName
+        accountNumberLast4
+        status
+      }
+      errors {
+        code
+        message
+      }
+    }
+  }
 `

--- a/app/graphql/front-end-queries.ts
+++ b/app/graphql/front-end-queries.ts
@@ -373,6 +373,18 @@ gql`
     }
   }
 
+  query BridgeWithdrawalRequest($id: ID!) {
+    bridgeWithdrawalRequest(id: $id) {
+      amount
+      createdAt
+      currency
+      externalAccountId
+      failureReason
+      id
+      status
+    }
+  }
+
   query CashWalletCutover {
     cashWalletCutover {
       completedAt

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -358,6 +358,25 @@ export type BridgeExternalAccountLink = {
   readonly linkUrl: Scalars['String']['output'];
 };
 
+export type BridgeCreateExternalAccountInput = {
+  readonly accountNumber: Scalars['String']['input'];
+  readonly accountOwnerName: Scalars['String']['input'];
+  readonly bankName: Scalars['String']['input'];
+  readonly checkingOrSavings?: InputMaybe<Scalars['String']['input']>;
+  readonly city: Scalars['String']['input'];
+  readonly country: Scalars['String']['input'];
+  readonly postalCode: Scalars['String']['input'];
+  readonly routingNumber: Scalars['String']['input'];
+  readonly state: Scalars['String']['input'];
+  readonly streetLine1: Scalars['String']['input'];
+};
+
+export type BridgeCreateExternalAccountPayload = {
+  readonly __typename: 'BridgeCreateExternalAccountPayload';
+  readonly errors: ReadonlyArray<Error>;
+  readonly externalAccount?: Maybe<BridgeExternalAccount>;
+};
+
 export type BridgeInitiateKycInput = {
   readonly email?: InputMaybe<Scalars['String']['input']>;
   readonly full_name?: InputMaybe<Scalars['String']['input']>;
@@ -976,6 +995,7 @@ export type Mutation = {
   readonly accountUpdateDefaultWalletId: AccountUpdateDefaultWalletIdPayload;
   readonly accountUpdateDisplayCurrency: AccountUpdateDisplayCurrencyPayload;
   readonly bridgeAddExternalAccount: BridgeAddExternalAccountPayload;
+  readonly bridgeCreateExternalAccount?: Maybe<BridgeCreateExternalAccountPayload>;
   readonly bridgeCancelWithdrawalRequest: BridgeCancelWithdrawalRequestPayload;
   readonly bridgeCreateVirtualAccount: BridgeCreateVirtualAccountPayload;
   readonly bridgeInitiateKyc: BridgeInitiateKycPayload;
@@ -2582,12 +2602,33 @@ export type BridgeAddExternalAccountMutationVariables = Exact<{ [key: string]: n
 
 export type BridgeAddExternalAccountMutation = { readonly __typename: 'Mutation', readonly bridgeAddExternalAccount: { readonly __typename: 'BridgeAddExternalAccountPayload', readonly externalAccount?: { readonly __typename: 'BridgeExternalAccountLink', readonly expiresAt: string, readonly linkUrl: string } | null, readonly errors: ReadonlyArray<{ readonly __typename: 'GraphQLApplicationError', readonly code?: string | null, readonly message: string }> } };
 
+export type BridgeCreateExternalAccountMutationVariables = Exact<{
+  input: BridgeCreateExternalAccountInput;
+}>;
+
+
+export type BridgeCreateExternalAccountMutation = { readonly __typename: 'Mutation', readonly bridgeCreateExternalAccount?: { readonly __typename: 'BridgeCreateExternalAccountPayload', readonly externalAccount?: { readonly __typename: 'BridgeExternalAccount', readonly accountNumberLast4: string, readonly bankName: string, readonly id: string, readonly status: string } | null, readonly errors: ReadonlyArray<{ readonly __typename: 'GraphQLApplicationError', readonly code?: string | null, readonly message: string }> } | null };
+
 export type BridgeRequestWithdrawalMutationVariables = Exact<{
   input: BridgeRequestWithdrawalInput;
 }>;
 
 
 export type BridgeRequestWithdrawalMutation = { readonly __typename: 'Mutation', readonly bridgeRequestWithdrawal: { readonly __typename: 'BridgeRequestWithdrawalPayload', readonly withdrawal?: { readonly __typename: 'BridgeWithdrawal', readonly amount: string, readonly createdAt: string, readonly bridgeTransferId?: string | null, readonly currency: string, readonly externalAccountId?: string | null, readonly failureReason?: string | null, readonly id: string, readonly status: string } | null, readonly errors: ReadonlyArray<{ readonly __typename: 'GraphQLApplicationError', readonly code?: string | null, readonly message: string }> } };
+
+export type BridgeCancelWithdrawalRequestMutationVariables = Exact<{
+  input: BridgeCancelWithdrawalRequestInput;
+}>;
+
+
+export type BridgeCancelWithdrawalRequestMutation = { readonly __typename: 'Mutation', readonly bridgeCancelWithdrawalRequest: { readonly __typename: 'BridgeCancelWithdrawalRequestPayload', readonly withdrawal?: { readonly __typename: 'BridgeWithdrawal', readonly amount: string, readonly createdAt: string, readonly currency: string, readonly externalAccountId?: string | null, readonly failureReason?: string | null, readonly id: string, readonly status: string } | null, readonly errors: ReadonlyArray<{ readonly __typename: 'GraphQLApplicationError', readonly code?: string | null, readonly message: string }> } };
+
+export type BridgeWithdrawalRequestQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type BridgeWithdrawalRequestQuery = { readonly __typename: 'Query', readonly bridgeWithdrawalRequest?: { readonly __typename: 'BridgeWithdrawal', readonly amount: string, readonly createdAt: string, readonly currency: string, readonly externalAccountId?: string | null, readonly failureReason?: string | null, readonly id: string, readonly status: string } | null };
 
 export type BridgeInitiateWithdrawalMutationVariables = Exact<{
   input: BridgeInitiateWithdrawalInput;
@@ -4421,6 +4462,48 @@ export function useBridgeAddExternalAccountMutation(baseOptions?: Apollo.Mutatio
 export type BridgeAddExternalAccountMutationHookResult = ReturnType<typeof useBridgeAddExternalAccountMutation>;
 export type BridgeAddExternalAccountMutationResult = Apollo.MutationResult<BridgeAddExternalAccountMutation>;
 export type BridgeAddExternalAccountMutationOptions = Apollo.BaseMutationOptions<BridgeAddExternalAccountMutation, BridgeAddExternalAccountMutationVariables>;
+export const BridgeCreateExternalAccountDocument = gql`
+    mutation BridgeCreateExternalAccount($input: BridgeCreateExternalAccountInput!) {
+  bridgeCreateExternalAccount(input: $input) {
+    externalAccount {
+      id
+      bankName
+      accountNumberLast4
+      status
+    }
+    errors {
+      code
+      message
+    }
+  }
+}
+    `;
+export type BridgeCreateExternalAccountMutationFn = Apollo.MutationFunction<BridgeCreateExternalAccountMutation, BridgeCreateExternalAccountMutationVariables>;
+
+/**
+ * __useBridgeCreateExternalAccountMutation__
+ *
+ * To run a mutation, you first call `useBridgeCreateExternalAccountMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useBridgeCreateExternalAccountMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [bridgeCreateExternalAccountMutation, { data, loading, error }] = useBridgeCreateExternalAccountMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useBridgeCreateExternalAccountMutation(baseOptions?: Apollo.MutationHookOptions<BridgeCreateExternalAccountMutation, BridgeCreateExternalAccountMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<BridgeCreateExternalAccountMutation, BridgeCreateExternalAccountMutationVariables>(BridgeCreateExternalAccountDocument, options);
+      }
+export type BridgeCreateExternalAccountMutationHookResult = ReturnType<typeof useBridgeCreateExternalAccountMutation>;
+export type BridgeCreateExternalAccountMutationResult = Apollo.MutationResult<BridgeCreateExternalAccountMutation>;
+export type BridgeCreateExternalAccountMutationOptions = Apollo.BaseMutationOptions<BridgeCreateExternalAccountMutation, BridgeCreateExternalAccountMutationVariables>;
 export const BridgeRequestWithdrawalDocument = gql`
     mutation BridgeRequestWithdrawal($input: BridgeRequestWithdrawalInput!) {
   bridgeRequestWithdrawal(input: $input) {
@@ -4467,6 +4550,51 @@ export function useBridgeRequestWithdrawalMutation(baseOptions?: Apollo.Mutation
 export type BridgeRequestWithdrawalMutationHookResult = ReturnType<typeof useBridgeRequestWithdrawalMutation>;
 export type BridgeRequestWithdrawalMutationResult = Apollo.MutationResult<BridgeRequestWithdrawalMutation>;
 export type BridgeRequestWithdrawalMutationOptions = Apollo.BaseMutationOptions<BridgeRequestWithdrawalMutation, BridgeRequestWithdrawalMutationVariables>;
+export const BridgeCancelWithdrawalRequestDocument = gql`
+    mutation BridgeCancelWithdrawalRequest($input: BridgeCancelWithdrawalRequestInput!) {
+  bridgeCancelWithdrawalRequest(input: $input) {
+    withdrawal {
+      amount
+      createdAt
+      currency
+      externalAccountId
+      failureReason
+      id
+      status
+    }
+    errors {
+      code
+      message
+    }
+  }
+}
+    `;
+export type BridgeCancelWithdrawalRequestMutationFn = Apollo.MutationFunction<BridgeCancelWithdrawalRequestMutation, BridgeCancelWithdrawalRequestMutationVariables>;
+
+/**
+ * __useBridgeCancelWithdrawalRequestMutation__
+ *
+ * To run a mutation, you first call `useBridgeCancelWithdrawalRequestMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useBridgeCancelWithdrawalRequestMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [bridgeCancelWithdrawalRequestMutation, { data, loading, error }] = useBridgeCancelWithdrawalRequestMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useBridgeCancelWithdrawalRequestMutation(baseOptions?: Apollo.MutationHookOptions<BridgeCancelWithdrawalRequestMutation, BridgeCancelWithdrawalRequestMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<BridgeCancelWithdrawalRequestMutation, BridgeCancelWithdrawalRequestMutationVariables>(BridgeCancelWithdrawalRequestDocument, options);
+      }
+export type BridgeCancelWithdrawalRequestMutationHookResult = ReturnType<typeof useBridgeCancelWithdrawalRequestMutation>;
+export type BridgeCancelWithdrawalRequestMutationResult = Apollo.MutationResult<BridgeCancelWithdrawalRequestMutation>;
+export type BridgeCancelWithdrawalRequestMutationOptions = Apollo.BaseMutationOptions<BridgeCancelWithdrawalRequestMutation, BridgeCancelWithdrawalRequestMutationVariables>;
 export const BridgeInitiateWithdrawalDocument = gql`
     mutation BridgeInitiateWithdrawal($input: BridgeInitiateWithdrawalInput!) {
   bridgeInitiateWithdrawal(input: $input) {
@@ -5553,6 +5681,47 @@ export function useBridgeExternalAccountsLazyQuery(baseOptions?: Apollo.LazyQuer
 export type BridgeExternalAccountsQueryHookResult = ReturnType<typeof useBridgeExternalAccountsQuery>;
 export type BridgeExternalAccountsLazyQueryHookResult = ReturnType<typeof useBridgeExternalAccountsLazyQuery>;
 export type BridgeExternalAccountsQueryResult = Apollo.QueryResult<BridgeExternalAccountsQuery, BridgeExternalAccountsQueryVariables>;
+export const BridgeWithdrawalRequestDocument = gql`
+    query BridgeWithdrawalRequest($id: ID!) {
+  bridgeWithdrawalRequest(id: $id) {
+    amount
+    createdAt
+    currency
+    externalAccountId
+    failureReason
+    id
+    status
+  }
+}
+    `;
+
+/**
+ * __useBridgeWithdrawalRequestQuery__
+ *
+ * To run a query within a React component, call `useBridgeWithdrawalRequestQuery` and pass it any options that fit your needs.
+ * When your component renders, `useBridgeWithdrawalRequestQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useBridgeWithdrawalRequestQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useBridgeWithdrawalRequestQuery(baseOptions: Apollo.QueryHookOptions<BridgeWithdrawalRequestQuery, BridgeWithdrawalRequestQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<BridgeWithdrawalRequestQuery, BridgeWithdrawalRequestQueryVariables>(BridgeWithdrawalRequestDocument, options);
+      }
+export function useBridgeWithdrawalRequestLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<BridgeWithdrawalRequestQuery, BridgeWithdrawalRequestQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<BridgeWithdrawalRequestQuery, BridgeWithdrawalRequestQueryVariables>(BridgeWithdrawalRequestDocument, options);
+        }
+export type BridgeWithdrawalRequestQueryHookResult = ReturnType<typeof useBridgeWithdrawalRequestQuery>;
+export type BridgeWithdrawalRequestLazyQueryHookResult = ReturnType<typeof useBridgeWithdrawalRequestLazyQuery>;
+export type BridgeWithdrawalRequestQueryResult = Apollo.QueryResult<BridgeWithdrawalRequestQuery, BridgeWithdrawalRequestQueryVariables>;
 export const CashWalletCutoverDocument = gql`
     query CashWalletCutover {
   cashWalletCutover {

--- a/app/navigation/root-navigator.tsx
+++ b/app/navigation/root-navigator.tsx
@@ -14,7 +14,6 @@ import { ContactsDetailScreen, ContactsScreen } from "../screens/contacts-screen
 import { CardScreen, FlashcardTopup } from "../screens/card-screen"
 import { ChatList } from "@app/screens/chat"
 import { DeveloperScreen } from "../screens/developer-screen"
-import { EarnMapScreen } from "../screens/earns-map-screen"
 import { EarnQuiz, EarnSection } from "../screens/earns-screen"
 import { SectionCompleted } from "../screens/earns-screen/section-completed"
 import { GetStartedScreen } from "../screens/get-started-screen"
@@ -61,7 +60,6 @@ import {
   TotpRegistrationInitiateScreen,
   TotpRegistrationValidateScreen,
 } from "@app/screens/totp-screen"
-import { testProps } from "@app/utils/testProps"
 import { makeStyles, useTheme } from "@rneui/themed"
 import { ScanningQRCodeScreen } from "../screens/send-bitcoin-screen"
 import { SettingsScreen } from "../screens/settings-screen"
@@ -128,6 +126,7 @@ import {
   BankTransfer,
   BridgeKycWebView,
   BridgeExternalAccountWebView,
+  BridgeAddExternalAccount,
   TopupDetails,
   TopupSuccess,
   TopupCashout,
@@ -681,6 +680,14 @@ export const RootStack = () => {
         <RootNavigator.Screen
           name="BridgeExternalAccountWebView"
           component={BridgeExternalAccountWebView}
+          options={{
+            headerShown: false,
+            cardStyleInterpolator: CardStyleInterpolators.forModalPresentationIOS,
+          }}
+        />
+        <RootNavigator.Screen
+          name="BridgeAddExternalAccount"
+          component={BridgeAddExternalAccount}
           options={{
             headerShown: false,
             cardStyleInterpolator: CardStyleInterpolators.forModalPresentationIOS,

--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -144,7 +144,12 @@ export type RootStackParamList = {
   UnclaimedDepositDetails: { deposit: DepositInfo }
   RefundDeposit: { deposit: DepositInfo }
   CashoutDetails: { type: "local" | "bridge" }
-  CashoutConfirmation: { offer: CashoutOffer }
+  CashoutConfirmation:
+    | { offer: CashoutOffer }
+    | {
+        bridgeWithdrawalId: string
+        bridgeAccountLabel?: string
+      }
   CashoutSuccess: undefined
   EditNostrProfile: undefined
   NostrSettingsScreen: undefined
@@ -169,6 +174,7 @@ export type RootStackParamList = {
   BridgeExternalAccountWebView: {
     linkUrl: string
   }
+  BridgeAddExternalAccount: undefined
   TopupCashout: undefined
   TopupDetails: { paymentType: "card" | "bankTransfer" | "bridge" }
   BankTransfer: {

--- a/app/screens/topup-cashout-flow/BankTransfer.tsx
+++ b/app/screens/topup-cashout-flow/BankTransfer.tsx
@@ -21,15 +21,19 @@ const BankTransfer: React.FC<Props> = ({ navigation, route }) => {
   const styles = useStyles()
   const { bottom } = useSafeAreaInsets()
   const { LL } = useI18nContext()
+  const backHomeButtonStyle = React.useMemo(
+    () => [styles.backHomeButton, { marginBottom: bottom + 20 }],
+    [bottom, styles.backHomeButton],
+  )
 
   const { data } = useBridgeVirtualAccountQuery()
 
-  const { amount, wallet, paymentType } = route.params
+  const { amount, paymentType } = route.params
   const fee = amount * 0.02
 
   if (paymentType === "bridge") {
     return (
-      <Screen preset="scroll" style={{ paddingHorizontal: 20 }}>
+      <Screen preset="scroll" style={styles.container}>
         <Text type="h02" bold style={styles.title}>
           {LL.BankTransfer.virtualBankTransfer()}
         </Text>
@@ -54,12 +58,17 @@ const BankTransfer: React.FC<Props> = ({ navigation, route }) => {
             {data?.bridgeVirtualAccount?.routingNumber}
           </Text>
         </View>
+        <PrimaryBtn
+          label={LL.BankTransfer.backHome()}
+          onPress={() => navigation.reset({ index: 0, routes: [{ name: "Primary" }] })}
+          btnStyle={backHomeButtonStyle}
+        />
       </Screen>
     )
   }
 
   return (
-    <Screen preset="scroll" style={{ paddingHorizontal: 20 }}>
+    <Screen preset="scroll" style={styles.container}>
       <Text type="h02" bold style={styles.title}>
         {LL.BankTransfer.title()}
       </Text>
@@ -70,7 +79,7 @@ const BankTransfer: React.FC<Props> = ({ navigation, route }) => {
         {LL.BankTransfer.desc2({ code: "UUM7MJRD" })}
       </Text>
       <Text type="p1" style={styles.desc}>
-        {LL.BankTransfer.desc3({ amount: amount, fee: fee })}
+        {LL.BankTransfer.desc3({ amount, fee })}
       </Text>
       <View style={styles.bankDetails}>
         <View style={styles.fieldContainer}>
@@ -137,7 +146,7 @@ const BankTransfer: React.FC<Props> = ({ navigation, route }) => {
       <PrimaryBtn
         label={LL.BankTransfer.backHome()}
         onPress={() => navigation.reset({ index: 0, routes: [{ name: "Primary" }] })}
-        btnStyle={{ marginBottom: bottom + 20, marginTop: 20 }}
+        btnStyle={backHomeButtonStyle}
       />
     </Screen>
   )
@@ -181,5 +190,8 @@ const useStyles = makeStyles(({ colors }) => ({
   },
   buttonGroup: {
     marginTop: 8,
+  },
+  backHomeButton: {
+    marginTop: 20,
   },
 }))

--- a/app/screens/topup-cashout-flow/BridgeAddExternalAccount.tsx
+++ b/app/screens/topup-cashout-flow/BridgeAddExternalAccount.tsx
@@ -1,0 +1,372 @@
+import React, { useState } from "react"
+import {
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native"
+import { StackScreenProps } from "@react-navigation/stack"
+import { RootStackParamList } from "@app/navigation/stack-param-lists"
+import { Text, makeStyles, useTheme } from "@rneui/themed"
+import { Screen } from "@app/components/screen"
+import { useBridgeCreateExternalAccountMutation } from "@app/graphql/generated"
+import { useActivityIndicator } from "@app/hooks"
+
+type Props = StackScreenProps<RootStackParamList, "BridgeAddExternalAccount">
+
+const BridgeAddExternalAccount: React.FC<Props> = ({ navigation }) => {
+  const styles = useStyles()
+  const { theme } = useTheme()
+  const { toggleActivityIndicator } = useActivityIndicator()
+
+  const [createExternalAccount] = useBridgeCreateExternalAccountMutation()
+
+  const [bankName, setBankName] = useState("")
+  const [accountOwnerName, setAccountOwnerName] = useState("")
+  const [routingNumber, setRoutingNumber] = useState("")
+  const [accountNumber, setAccountNumber] = useState("")
+  const [checkingOrSavings, setCheckingOrSavings] = useState<"checking" | "savings">(
+    "checking",
+  )
+  const [streetLine1, setStreetLine1] = useState("")
+  const [city, setCity] = useState("")
+  const [state, setState] = useState("")
+  const [postalCode, setPostalCode] = useState("")
+  const [country, setCountry] = useState("USA")
+
+  const handleSubmit = async () => {
+    if (!bankName || !accountOwnerName || !routingNumber || !accountNumber) {
+      Alert.alert("Error", "Please fill in all required fields")
+      return
+    }
+
+    if (!streetLine1 || !city || !state || !postalCode || !country) {
+      Alert.alert("Error", "Please fill in your address details")
+      return
+    }
+
+    toggleActivityIndicator(true)
+    try {
+      const res = await createExternalAccount({
+        variables: {
+          input: {
+            bankName,
+            accountOwnerName,
+            routingNumber,
+            accountNumber,
+            checkingOrSavings,
+            streetLine1,
+            city,
+            state,
+            postalCode,
+            country,
+          },
+        },
+      })
+
+      toggleActivityIndicator(false)
+
+      const errors = res.data?.bridgeCreateExternalAccount?.errors
+      if (errors && errors.length > 0) {
+        Alert.alert("Error", errors[0].message)
+        return
+      }
+
+      const externalAccount = res.data?.bridgeCreateExternalAccount?.externalAccount
+      if (externalAccount) {
+        Alert.alert(
+          "Bank Account Added",
+          `Your ${externalAccount.bankName} account (ending in ${externalAccount.accountNumberLast4}) has been linked successfully.`,
+          [
+            {
+              text: "Continue",
+              onPress: () => navigation.navigate("CashoutDetails", { type: "bridge" }),
+            },
+          ],
+        )
+      } else {
+        Alert.alert("Error", "Failed to add bank account. Please try again.")
+      }
+    } catch (error) {
+      toggleActivityIndicator(false)
+      Alert.alert("Error", "Something went wrong. Please try again.")
+    }
+  }
+
+  return (
+    <Screen>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        style={styles.container}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+        >
+          <Text type="h1" style={styles.title}>
+            Add Bank Account
+          </Text>
+          <Text style={styles.subtitle}>
+            Enter your US bank account details below to link it for withdrawals.
+          </Text>
+
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>Bank Name</Text>
+            <TextInput
+              style={styles.input}
+              value={bankName}
+              onChangeText={setBankName}
+              placeholder="e.g. Bank of America"
+              placeholderTextColor={theme.colors.grey3}
+            />
+          </View>
+
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>Account Owner Name</Text>
+            <TextInput
+              style={styles.input}
+              value={accountOwnerName}
+              onChangeText={setAccountOwnerName}
+              placeholder="Full name on account"
+              placeholderTextColor={theme.colors.grey3}
+            />
+          </View>
+
+          <View style={styles.fieldRow}>
+            <View style={styles.fieldRowLeft}>
+              <Text style={styles.label}>Routing Number</Text>
+              <TextInput
+                style={styles.input}
+                value={routingNumber}
+                onChangeText={setRoutingNumber}
+                placeholder="9-digit routing"
+                placeholderTextColor={theme.colors.grey3}
+                keyboardType="number-pad"
+                maxLength={9}
+              />
+            </View>
+            <View style={styles.fieldRowRight}>
+              <Text style={styles.label}>Account Number</Text>
+              <TextInput
+                style={styles.input}
+                value={accountNumber}
+                onChangeText={setAccountNumber}
+                placeholder="Account number"
+                placeholderTextColor={theme.colors.grey3}
+                keyboardType="number-pad"
+              />
+            </View>
+          </View>
+
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>Account Type</Text>
+            <View style={styles.segmentRow}>
+              <TouchableOpacity
+                style={[
+                  styles.segmentButton,
+                  checkingOrSavings === "checking" && styles.segmentButtonActive,
+                ]}
+                onPress={() => setCheckingOrSavings("checking")}
+              >
+                <Text
+                  style={[
+                    styles.segmentText,
+                    checkingOrSavings === "checking" && styles.segmentTextActive,
+                  ]}
+                >
+                  Checking
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[
+                  styles.segmentButton,
+                  checkingOrSavings === "savings" && styles.segmentButtonActive,
+                ]}
+                onPress={() => setCheckingOrSavings("savings")}
+              >
+                <Text
+                  style={[
+                    styles.segmentText,
+                    checkingOrSavings === "savings" && styles.segmentTextActive,
+                  ]}
+                >
+                  Savings
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+
+          <Text type="h2" style={styles.sectionTitle}>
+            Your Address
+          </Text>
+
+          <View style={styles.fieldGroup}>
+            <Text style={styles.label}>Street Address</Text>
+            <TextInput
+              style={styles.input}
+              value={streetLine1}
+              onChangeText={setStreetLine1}
+              placeholder="123 Main St"
+              placeholderTextColor={theme.colors.grey3}
+            />
+          </View>
+
+          <View style={styles.fieldRow}>
+            <View style={styles.fieldRowCity}>
+              <Text style={styles.label}>City</Text>
+              <TextInput
+                style={styles.input}
+                value={city}
+                onChangeText={setCity}
+                placeholder="City"
+                placeholderTextColor={theme.colors.grey3}
+              />
+            </View>
+            <View style={styles.fieldRowState}>
+              <Text style={styles.label}>State</Text>
+              <TextInput
+                style={styles.input}
+                value={state}
+                onChangeText={setState}
+                placeholder="FL"
+                placeholderTextColor={theme.colors.grey3}
+                maxLength={2}
+              />
+            </View>
+          </View>
+
+          <View style={styles.fieldRow}>
+            <View style={styles.fieldRowLeft}>
+              <Text style={styles.label}>ZIP Code</Text>
+              <TextInput
+                style={styles.input}
+                value={postalCode}
+                onChangeText={setPostalCode}
+                placeholder="33101"
+                placeholderTextColor={theme.colors.grey3}
+                keyboardType="number-pad"
+                maxLength={5}
+              />
+            </View>
+            <View style={styles.fieldRowRight}>
+              <Text style={styles.label}>Country</Text>
+              <TextInput
+                style={styles.input}
+                value={country}
+                onChangeText={setCountry}
+                placeholder="USA"
+                placeholderTextColor={theme.colors.grey3}
+                maxLength={3}
+              />
+            </View>
+          </View>
+
+          <TouchableOpacity style={styles.submitButton} onPress={handleSubmit}>
+            <Text style={styles.submitText}>Link Bank Account</Text>
+          </TouchableOpacity>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </Screen>
+  )
+}
+
+const useStyles = makeStyles(({ colors }) => ({
+  container: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 20,
+  },
+  title: {
+    marginBottom: 8,
+  },
+  subtitle: {
+    color: colors.grey2,
+    marginBottom: 24,
+  },
+  fieldGroup: {
+    marginBottom: 16,
+  },
+  fieldRow: {
+    flexDirection: "row",
+    marginBottom: 0,
+  },
+  fieldRowLeft: {
+    flex: 1,
+    marginRight: 8,
+  },
+  fieldRowRight: {
+    flex: 1,
+    marginLeft: 8,
+  },
+  fieldRowCity: {
+    flex: 2,
+    marginRight: 8,
+  },
+  fieldRowState: {
+    flex: 1,
+    marginLeft: 8,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: "600",
+    marginBottom: 6,
+    color: colors.grey0,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: colors.grey3,
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    color: colors.grey0,
+    backgroundColor: colors.white,
+  },
+  segmentRow: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  segmentButton: {
+    flex: 1,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.grey3,
+    alignItems: "center",
+  },
+  segmentButtonActive: {
+    backgroundColor: colors.primary,
+    borderColor: colors.primary,
+  },
+  segmentText: {
+    fontSize: 15,
+    fontWeight: "500",
+    color: colors.grey1,
+  },
+  segmentTextActive: {
+    color: colors.white,
+  },
+  sectionTitle: {
+    marginTop: 8,
+    marginBottom: 16,
+  },
+  submitButton: {
+    backgroundColor: colors.primary,
+    paddingVertical: 16,
+    borderRadius: 12,
+    alignItems: "center",
+    marginTop: 24,
+    marginBottom: 40,
+  },
+  submitText: {
+    color: colors.white,
+    fontSize: 17,
+    fontWeight: "600",
+  },
+}))
+
+export default BridgeAddExternalAccount

--- a/app/screens/topup-cashout-flow/CashoutConfirmation.tsx
+++ b/app/screens/topup-cashout-flow/CashoutConfirmation.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react"
-import { ScrollView } from "react-native"
-import { makeStyles } from "@rneui/themed"
-import { Text, useTheme } from "@rneui/themed"
+import { ScrollView, View } from "react-native"
+import { makeStyles, Text, useTheme } from "@rneui/themed"
 import moment from "moment"
 
 // components
@@ -17,9 +16,15 @@ import {
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { useActivityIndicator, useDisplayCurrency } from "@app/hooks"
-import { useCashoutScreenQuery, useInitiateCashoutMutation } from "@app/graphql/generated"
+import {
+  useBridgeCancelWithdrawalRequestMutation,
+  useBridgeInitiateWithdrawalMutation,
+  useBridgeWithdrawalRequestQuery,
+  useCashoutScreenQuery,
+  useInitiateCashoutMutation,
+} from "@app/graphql/generated"
 
-//utils
+// utils
 import { getCashWallet } from "@app/graphql/wallets-utils"
 import { toUsdMoneyAmount } from "@app/types/amounts"
 import { StackScreenProps } from "@react-navigation/stack"
@@ -27,13 +32,29 @@ import { RootStackParamList } from "@app/navigation/stack-param-lists"
 
 type Props = StackScreenProps<RootStackParamList, "CashoutConfirmation">
 
-const CashoutConfirmation: React.FC<Props> = ({ navigation, route }) => {
+// The Bridge service fee charged by Flash (0.5%), included in the withdrawal amount.
+const FLASH_BRIDGE_FEE_RATE = 0.005
+
+const CashoutConfirmation: React.FC<Props> = (props) => {
+  if ("bridgeWithdrawalId" in props.route.params) {
+    return <BridgeCashoutConfirmation {...props} />
+  }
+  return <LocalCashoutConfirmation {...props} />
+}
+
+export default CashoutConfirmation
+
+const LocalCashoutConfirmation: React.FC<Props> = ({ navigation, route }) => {
   const styles = useStyles()
   const { colors } = useTheme().theme
   const { bottom } = useSafeAreaInsets()
   const { LL } = useI18nContext()
-  const { moneyAmountToDisplayCurrencyString, displayCurrency } = useDisplayCurrency()
+  const { moneyAmountToDisplayCurrencyString } = useDisplayCurrency()
   const { toggleActivityIndicator } = useActivityIndicator()
+  const confirmButtonStyle = React.useMemo(
+    () => [styles.confirmButton, { marginBottom: bottom + 10 }],
+    [bottom, styles.confirmButton],
+  )
 
   const [errorMsg, setErrorMsg] = useState<string>()
 
@@ -47,6 +68,8 @@ const CashoutConfirmation: React.FC<Props> = ({ navigation, route }) => {
   const usdWallet = getCashWallet(data?.me?.defaultAccount?.wallets)
   const usdBalance = toUsdMoneyAmount(usdWallet?.balance ?? NaN)
 
+  // Narrowed by the dispatcher: this component only renders for the offer variant.
+  const params = route.params as Extract<typeof route.params, { offer: unknown }>
   const {
     walletId,
     offerId,
@@ -56,7 +79,7 @@ const CashoutConfirmation: React.FC<Props> = ({ navigation, route }) => {
     receiveUsd,
     receiveJmd,
     flashFee,
-  } = route.params?.offer
+  } = params.offer
 
   const onConfirm = async () => {
     toggleActivityIndicator(true)
@@ -83,7 +106,7 @@ const CashoutConfirmation: React.FC<Props> = ({ navigation, route }) => {
 
   return (
     <Screen>
-      <ScrollView style={{ padding: 20 }}>
+      <ScrollView style={styles.scrollView}>
         <Text type="caption" color={colors.placeholder} style={styles.valid}>
           {LL.Cashout.valid({ time: moment(expiresAt).fromNow(true) })}
         </Text>
@@ -103,7 +126,7 @@ const CashoutConfirmation: React.FC<Props> = ({ navigation, route }) => {
         )}
         <CashoutCard title={LL.Cashout.fee()} detail={formattedFeeAmount} />
         <CashoutWithdrawTo />
-        {!!errorMsg && (
+        {Boolean(errorMsg) && (
           <Text type="bm" color={colors.red}>
             {errorMsg}
           </Text>
@@ -111,18 +134,138 @@ const CashoutConfirmation: React.FC<Props> = ({ navigation, route }) => {
       </ScrollView>
       <PrimaryBtn
         label={LL.common.confirm()}
-        btnStyle={{ marginHorizontal: 20, marginBottom: bottom + 10 }}
+        btnStyle={confirmButtonStyle}
         onPress={onConfirm}
       />
     </Screen>
   )
 }
 
-export default CashoutConfirmation
+const BridgeCashoutConfirmation: React.FC<Props> = ({ navigation, route }) => {
+  const styles = useStyles()
+  const { colors } = useTheme().theme
+  const { bottom } = useSafeAreaInsets()
+  const { LL } = useI18nContext()
+  const { moneyAmountToDisplayCurrencyString } = useDisplayCurrency()
+  const { toggleActivityIndicator } = useActivityIndicator()
+  const actionButtonsStyle = React.useMemo(
+    () => [styles.actionButtons, { marginBottom: bottom + 10 }],
+    [bottom, styles.actionButtons],
+  )
+
+  const [errorMsg, setErrorMsg] = useState<string>()
+
+  // Narrowed by the dispatcher: this component only renders for the bridge variant.
+  const params = route.params as Extract<
+    typeof route.params,
+    { bridgeWithdrawalId: string }
+  >
+  const { bridgeWithdrawalId, bridgeAccountLabel } = params
+
+  const [initiateWithdrawal] = useBridgeInitiateWithdrawalMutation()
+  const [cancelWithdrawal] = useBridgeCancelWithdrawalRequestMutation()
+
+  const { data: cashoutData } = useCashoutScreenQuery({
+    fetchPolicy: "cache-first",
+    returnPartialData: true,
+  })
+  const usdWallet = getCashWallet(cashoutData?.me?.defaultAccount?.wallets)
+  const usdBalance = toUsdMoneyAmount(usdWallet?.balance ?? NaN)
+
+  const { data, loading } = useBridgeWithdrawalRequestQuery({
+    variables: { id: bridgeWithdrawalId },
+    fetchPolicy: "network-only",
+  })
+
+  const withdrawal = data?.bridgeWithdrawalRequest
+  // Backend amount is a decimal USD-dollar string (e.g. "10.50"); convert to cents.
+  const amountCents = Math.round(parseFloat(withdrawal?.amount ?? "0") * 100)
+  const feeCents = Math.round(amountCents * FLASH_BRIDGE_FEE_RATE)
+
+  const formattedAmount = moneyAmountToDisplayCurrencyString({
+    moneyAmount: toUsdMoneyAmount(amountCents),
+  })
+  const formattedFee = moneyAmountToDisplayCurrencyString({
+    moneyAmount: toUsdMoneyAmount(feeCents),
+  })
+
+  const onConfirm = async () => {
+    setErrorMsg(undefined)
+    toggleActivityIndicator(true)
+    try {
+      const res = await initiateWithdrawal({
+        variables: { input: { withdrawalId: bridgeWithdrawalId } },
+      })
+      const errors = res.data?.bridgeInitiateWithdrawal.errors
+      if (errors?.length) {
+        setErrorMsg(errors[0].message)
+        return
+      }
+      navigation.navigate("CashoutSuccess")
+    } finally {
+      toggleActivityIndicator(false)
+    }
+  }
+
+  const onCancel = async () => {
+    setErrorMsg(undefined)
+    toggleActivityIndicator(true)
+    try {
+      await cancelWithdrawal({
+        variables: { input: { withdrawalId: bridgeWithdrawalId } },
+      })
+    } finally {
+      toggleActivityIndicator(false)
+      navigation.goBack()
+    }
+  }
+
+  return (
+    <Screen>
+      <ScrollView style={styles.scrollView}>
+        <CashoutFromWallet usdBalance={usdBalance} />
+        <CashoutCard
+          title={LL.Cashout.sendAmount()}
+          detail={loading ? "…" : formattedAmount}
+        />
+        <CashoutCard
+          title={LL.Cashout.fee()}
+          detail={loading ? "…" : `${formattedFee} (0.5%)`}
+        />
+        {Boolean(bridgeAccountLabel) && (
+          <CashoutCard title={LL.Cashout.withdrawTo()} detail={bridgeAccountLabel} />
+        )}
+        {Boolean(errorMsg) && (
+          <Text type="bm" color={colors.red}>
+            {errorMsg}
+          </Text>
+        )}
+      </ScrollView>
+      <View style={actionButtonsStyle}>
+        <PrimaryBtn
+          label={LL.common.confirm()}
+          disabled={loading || !withdrawal}
+          onPress={onConfirm}
+        />
+        <PrimaryBtn type="outline" label={LL.common.cancel()} onPress={onCancel} />
+      </View>
+    </Screen>
+  )
+}
 
 const useStyles = makeStyles(() => ({
+  scrollView: {
+    padding: 20,
+  },
   valid: {
     alignSelf: "center",
     marginBottom: 10,
+  },
+  confirmButton: {
+    marginHorizontal: 20,
+  },
+  actionButtons: {
+    marginHorizontal: 20,
+    rowGap: 10,
   },
 }))

--- a/app/screens/topup-cashout-flow/CashoutDetails.tsx
+++ b/app/screens/topup-cashout-flow/CashoutDetails.tsx
@@ -12,6 +12,8 @@ import { CashoutFromWallet, CashoutPercentage } from "@app/components/topup-cash
 // hooks
 import {
   useBankAccountsQuery,
+  useBridgeExternalAccountsQuery,
+  useBridgeRequestWithdrawalMutation,
   useCashoutScreenQuery,
   useRequestCashoutMutation,
 } from "@app/graphql/generated"
@@ -32,24 +34,39 @@ import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 type Props = StackScreenProps<RootStackParamList, "CashoutDetails">
 
-const CashoutDetails = ({ navigation }: Props) => {
+const CashoutDetails = ({ navigation, route }: Props) => {
   const styles = useStyles()
   const { colors } = useTheme().theme
   const { bottom } = useSafeAreaInsets()
+  const nextButtonStyle = React.useMemo(
+    () => [styles.nextButton, { marginBottom: bottom + 10 }],
+    [bottom, styles.nextButton],
+  )
   const { LL } = useI18nContext()
   const { zeroDisplayAmount } = useDisplayCurrency()
   const { convertMoneyAmount } = usePriceConversion()
   const { toggleActivityIndicator } = useActivityIndicator()
+
+  const { type } = route.params
+  const isBridge = type === "bridge"
 
   const [errorMsg, setErrorMsg] = useState<string>()
   const [moneyAmount, setMoneyAmount] =
     useState<MoneyAmount<WalletOrDisplayCurrency>>(zeroDisplayAmount)
 
   const [requestCashout] = useRequestCashoutMutation()
+  const [bridgeRequestWithdrawal] = useBridgeRequestWithdrawalMutation()
 
-  const { data: bankAccountsData, loading } = useBankAccountsQuery({
+  const { data: bankAccountsData, loading: bankLoading } = useBankAccountsQuery({
     fetchPolicy: "network-only",
+    skip: isBridge,
   })
+
+  const { data: externalAccountsData, loading: bridgeLoading } =
+    useBridgeExternalAccountsQuery({
+      fetchPolicy: "network-only",
+      skip: !isBridge,
+    })
 
   const { data } = useCashoutScreenQuery({
     fetchPolicy: "cache-first",
@@ -63,36 +80,89 @@ const CashoutDetails = ({ navigation }: Props) => {
   const usdWallet = getCashWallet(data?.me?.defaultAccount?.wallets)
   const usdBalance = toUsdMoneyAmount(usdWallet?.balance ?? NaN)
   const settlementSendAmount = convertMoneyAmount(moneyAmount, "USD")
+  const accountsLoading = isBridge ? bridgeLoading : bankLoading
   const isValidAmount =
     settlementSendAmount.amount > 0 &&
     settlementSendAmount.amount <= usdBalance.amount &&
-    !loading
+    !accountsLoading
 
   const onNext = async () => {
+    setErrorMsg(undefined)
+
+    if (!usdWallet) {
+      setErrorMsg(LL.common.error())
+      return
+    }
+
+    if (isBridge) {
+      await onBridgeWithdraw()
+      return
+    }
+
     const defaultBankAccount =
       bankAccountsData?.me?.bankAccounts.find((el) => el.isDefault) ||
       bankAccountsData?.me?.bankAccounts[0]
 
-    if (usdWallet && defaultBankAccount?.id) {
-      toggleActivityIndicator(true)
-      const res = await requestCashout({
-        variables: {
-          input: {
-            bankAccountId: defaultBankAccount.id,
-            walletId: usdWallet.id,
-            amount: settlementSendAmount.amount,
-          },
+    if (!defaultBankAccount?.id) {
+      setErrorMsg("No bank account found. Please add a bank account first.")
+      return
+    }
+
+    toggleActivityIndicator(true)
+    const res = await requestCashout({
+      variables: {
+        input: {
+          bankAccountId: defaultBankAccount.id,
+          walletId: usdWallet.id,
+          amount: settlementSendAmount.amount,
         },
+      },
+    })
+    if (res.data?.requestCashout.offer) {
+      navigation.navigate("CashoutConfirmation", {
+        offer: res.data.requestCashout.offer,
       })
-      console.log("Response: ", res.data?.requestCashout)
-      if (res.data?.requestCashout.offer) {
-        navigation.navigate("CashoutConfirmation", {
-          offer: res.data.requestCashout.offer,
-        })
-      } else {
-        setErrorMsg(res.data?.requestCashout.errors[0].message)
+    } else {
+      setErrorMsg(res.data?.requestCashout.errors[0].message)
+    }
+
+    toggleActivityIndicator(false)
+  }
+
+  const onBridgeWithdraw = async () => {
+    const externalAccount = externalAccountsData?.bridgeExternalAccounts?.find(Boolean)
+
+    if (!externalAccount?.id) {
+      setErrorMsg("No external account found. Please add an external account first.")
+      return
+    }
+
+    toggleActivityIndicator(true)
+    try {
+      // Backend expects a decimal USD-dollar string (e.g. "10.50"), max 6 decimals.
+      const amount = (settlementSendAmount.amount / 100).toFixed(2)
+      const requestRes = await bridgeRequestWithdrawal({
+        variables: { input: { externalAccountId: externalAccount.id, amount } },
+      })
+
+      const requestErrors = requestRes.data?.bridgeRequestWithdrawal.errors
+      const withdrawalId = requestRes.data?.bridgeRequestWithdrawal.withdrawal?.id
+      if (requestErrors?.length) {
+        setErrorMsg(requestErrors[0].message)
+        return
+      }
+      if (!withdrawalId) {
+        setErrorMsg(LL.common.error())
+        return
       }
 
+      // bridgeRequestWithdrawal only stores a pending record; the user reviews and
+      // confirms (bridgeInitiateWithdrawal) on the confirmation screen.
+      navigation.navigate("CashoutConfirmation", {
+        bridgeWithdrawalId: withdrawalId,
+        bridgeAccountLabel: `${externalAccount.bankName} ••${externalAccount.accountNumberLast4}`,
+      })
+    } finally {
       toggleActivityIndicator(false)
     }
   }
@@ -111,7 +181,7 @@ const CashoutDetails = ({ navigation }: Props) => {
       <ScrollView style={styles.scrollViewContainer}>
         <CashoutFromWallet usdBalance={usdBalance} />
         <View>
-          <Text type="bl" bold style={{ marginBottom: 5 }}>
+          <Text type="bl" bold style={styles.amountLabel}>
             {LL.SendBitcoinScreen.amount()}
           </Text>
           <AmountInput
@@ -128,7 +198,7 @@ const CashoutDetails = ({ navigation }: Props) => {
           />
         </View>
         <CashoutPercentage setAmountToBalancePercentage={setAmountToBalancePercentage} />
-        {!!errorMsg && (
+        {Boolean(errorMsg) && (
           <Text type="bm" color={colors.red}>
             {errorMsg}
           </Text>
@@ -136,7 +206,7 @@ const CashoutDetails = ({ navigation }: Props) => {
       </ScrollView>
       <PrimaryBtn
         label={LL.common.next()}
-        btnStyle={{ marginHorizontal: 20, marginBottom: bottom + 10 }}
+        btnStyle={nextButtonStyle}
         disabled={!isValidAmount}
         onPress={onNext}
       />
@@ -151,5 +221,11 @@ const useStyles = makeStyles(() => ({
     flex: 1,
     flexDirection: "column",
     margin: 20,
+  },
+  amountLabel: {
+    marginBottom: 5,
+  },
+  nextButton: {
+    marginHorizontal: 20,
   },
 }))

--- a/app/screens/topup-cashout-flow/TopupCashout.tsx
+++ b/app/screens/topup-cashout-flow/TopupCashout.tsx
@@ -8,8 +8,11 @@ import { useFocusEffect } from "@react-navigation/native"
 
 // components
 import { Screen } from "@app/components/screen"
-import { TransferOptionModal, BridgeKycModal } from "@app/components/topup-cashout-flow"
-import type { TransferOption } from "@app/components/topup-cashout-flow"
+import {
+  BridgeKycModal,
+  type TransferOption,
+  TransferOptionModal,
+} from "@app/components/topup-cashout-flow"
 
 // assets
 import ArrowDown from "@app/assets/icons/arrow-down-to-bracket.svg"
@@ -17,6 +20,7 @@ import ArrowUp from "@app/assets/icons/arrow-up-from-bracket.svg"
 
 // hooks
 import {
+  AccountLevel,
   useBridgeAddExternalAccountMutation,
   useBridgeExternalAccountsQuery,
   useBridgeInitiateKycMutation,
@@ -24,9 +28,6 @@ import {
 } from "@app/graphql/generated"
 import { useActivityIndicator } from "@app/hooks"
 import { useLevel } from "@app/graphql/level-context"
-
-// utils
-import { AccountLevel } from "@app/graphql/generated"
 
 type Props = StackScreenProps<RootStackParamList, "TopupCashout">
 
@@ -67,6 +68,79 @@ const TopupCashout: React.FC<Props> = ({ navigation }) => {
     setRefreshing(false)
   }, [refetchKycStatus, refetchExternalAccounts])
 
+  const checkAccountLevel = useCallback(
+    (type: "card" | "bankTransfer" | "cashout") => {
+      if (type === "card") {
+        navigation.navigate("TopupDetails", { paymentType: type })
+      } else if (currentLevel === AccountLevel.One) {
+        Alert.alert(
+          "Account upgrade required",
+          "You should upgrade your account to use this feature",
+          [
+            { text: "Continue", onPress: () => navigation.navigate("AccountType") },
+            { text: "Cancel", style: "cancel" },
+          ],
+        )
+      } else if (type === "cashout") {
+        navigation.navigate("CashoutDetails", { type: "local" })
+      } else {
+        navigation.navigate("TopupDetails", { paymentType: type })
+      }
+    },
+    [currentLevel, navigation],
+  )
+
+  const checkBridgeKyc = useCallback(
+    async (type: "topup" | "settle") => {
+      if (kycStatusData?.bridgeKycStatus === "pending") {
+        Alert.alert(
+          "KYC Pending",
+          "Your KYC status is pending. Please wait for approval.",
+        )
+      } else if (kycStatusData?.bridgeKycStatus === "approved") {
+        if (type === "topup") {
+          navigation.navigate("TopupDetails", { paymentType: "bridge" })
+        } else if (
+          externalAccountsData?.bridgeExternalAccounts &&
+          externalAccountsData.bridgeExternalAccounts.length > 0
+        ) {
+          navigation.navigate("CashoutDetails", { type: "bridge" })
+        } else {
+          toggleActivityIndicator(true)
+          const res = await addExternalAccount()
+          toggleActivityIndicator(false)
+
+          const errors = res.data?.bridgeAddExternalAccount?.errors
+          if (errors && errors.length > 0) {
+            // If Plaid Link is unavailable, offer manual bank entry as fallback
+            if (errors[0].code === "BRIDGE_PLAID_NOT_AVAILABLE") {
+              navigation.navigate("BridgeAddExternalAccount")
+              return
+            }
+            Alert.alert("Error", errors[0].message)
+            return
+          }
+
+          const linkUrl = res.data?.bridgeAddExternalAccount?.externalAccount?.linkUrl
+          if (linkUrl) {
+            navigation.navigate("BridgeExternalAccountWebView", { linkUrl })
+          } else {
+            Alert.alert("Error", "Failed to get external account link. Please try again.")
+          }
+        }
+      } else {
+        setBridgeKycModalVisible(true)
+      }
+    },
+    [
+      addExternalAccount,
+      externalAccountsData?.bridgeExternalAccounts,
+      kycStatusData?.bridgeKycStatus,
+      navigation,
+      toggleActivityIndicator,
+    ],
+  )
+
   const topupOptions: TransferOption[] = useMemo(
     () => [
       {
@@ -98,7 +172,7 @@ const TopupCashout: React.FC<Props> = ({ navigation }) => {
         },
       },
     ],
-    [LL, navigation, kycStatusData?.bridgeKycStatus],
+    [LL, checkAccountLevel, checkBridgeKyc, kycStatusData?.bridgeKycStatus],
   )
 
   const settleOptions: TransferOption[] = useMemo(
@@ -123,67 +197,8 @@ const TopupCashout: React.FC<Props> = ({ navigation }) => {
         },
       },
     ],
-    [LL, navigation, kycStatusData?.bridgeKycStatus],
+    [LL, checkAccountLevel, checkBridgeKyc, kycStatusData?.bridgeKycStatus],
   )
-
-  const checkAccountLevel = (type: "card" | "bankTransfer" | "cashout") => {
-    if (type === "card") {
-      navigation.navigate("TopupDetails", { paymentType: type })
-    } else {
-      if (currentLevel === AccountLevel.One) {
-        Alert.alert(
-          "Account upgrade required",
-          "You should upgrade your account to use this feature",
-          [
-            { text: "Continue", onPress: () => navigation.navigate("AccountType") },
-            { text: "Cancel", style: "cancel" },
-          ],
-        )
-      } else {
-        if (type === "cashout") {
-          navigation.navigate("CashoutDetails", { type: "local" })
-        } else {
-          navigation.navigate("TopupDetails", { paymentType: type })
-        }
-      }
-    }
-  }
-
-  const checkBridgeKyc = async (type: "topup" | "settle") => {
-    if (kycStatusData?.bridgeKycStatus === "pending") {
-      Alert.alert("KYC Pending", "Your KYC status is pending. Please wait for approval.")
-    } else if (kycStatusData?.bridgeKycStatus === "approved") {
-      if (type === "topup") {
-        navigation.navigate("TopupDetails", { paymentType: "bridge" })
-      } else {
-        if (
-          externalAccountsData?.bridgeExternalAccounts &&
-          externalAccountsData.bridgeExternalAccounts.length > 0
-        ) {
-          navigation.navigate("CashoutDetails", { type: "bridge" })
-        } else {
-          toggleActivityIndicator(true)
-          const res = await addExternalAccount()
-          toggleActivityIndicator(false)
-
-          const errors = res.data?.bridgeAddExternalAccount?.errors
-          if (errors && errors.length > 0) {
-            Alert.alert("Error", errors[0].message)
-            return
-          }
-
-          const linkUrl = res.data?.bridgeAddExternalAccount?.externalAccount?.linkUrl
-          if (linkUrl) {
-            navigation.navigate("BridgeExternalAccountWebView", { linkUrl })
-          } else {
-            Alert.alert("Error", "Failed to get external account link. Please try again.")
-          }
-        }
-      }
-    } else {
-      setBridgeKycModalVisible(true)
-    }
-  }
 
   const getBridgeKycLink = async (data: {
     fullName: string
@@ -195,6 +210,7 @@ const TopupCashout: React.FC<Props> = ({ navigation }) => {
       const res = await initiateBridgeKyc({
         variables: {
           input: {
+            // eslint-disable-next-line camelcase
             full_name: data.fullName,
             email: data.email,
             type: data.kycType,

--- a/app/screens/topup-cashout-flow/TopupDetails.tsx
+++ b/app/screens/topup-cashout-flow/TopupDetails.tsx
@@ -14,7 +14,15 @@
  */
 
 import React, { useState } from "react"
-import { View, TextInput, Alert } from "react-native"
+import {
+  View,
+  TextInput,
+  Alert,
+  InputAccessoryView,
+  Keyboard,
+  TouchableOpacity,
+  Platform,
+} from "react-native"
 import { Text, makeStyles, useTheme } from "@rneui/themed"
 import { StackScreenProps } from "@react-navigation/stack"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
@@ -142,7 +150,7 @@ const TopupDetails: React.FC<Props> = ({ navigation, route }) => {
   }
 
   return (
-    <Screen>
+    <Screen keyboardShouldPersistTaps="handled">
       <View style={styles.container}>
         <Text type="h02" bold style={styles.title}>
           {route.params.paymentType === "card"
@@ -175,7 +183,17 @@ const TopupDetails: React.FC<Props> = ({ navigation, route }) => {
             value={amount}
             onChangeText={setAmount}
             keyboardType="numeric"
+            inputAccessoryViewID="topupAmountAccessory"
           />
+          {Platform.OS === "ios" && (
+            <InputAccessoryView nativeID="topupAmountAccessory">
+              <View style={styles.keyboardAccessory}>
+                <TouchableOpacity onPress={Keyboard.dismiss}>
+                  <Text style={styles.doneButton}>Done</Text>
+                </TouchableOpacity>
+              </View>
+            </InputAccessoryView>
+          )}
         </View>
       </View>
       <PrimaryBtn
@@ -189,6 +207,23 @@ const TopupDetails: React.FC<Props> = ({ navigation, route }) => {
 }
 
 const useStyles = makeStyles(({ colors }) => (props: { bottom: number }) => ({
+  keyboardAccessory: {
+    flexDirection: "row" as const,
+    justifyContent: "flex-end" as const,
+    alignItems: "center" as const,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    backgroundColor: colors.white,
+    borderTopWidth: 1,
+    borderTopColor: colors.grey3,
+  },
+  doneButton: {
+    fontSize: 16,
+    fontWeight: "600" as const,
+    color: colors.primary,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+  },
   container: {
     flex: 1,
     paddingHorizontal: 20,

--- a/app/screens/topup-cashout-flow/index.ts
+++ b/app/screens/topup-cashout-flow/index.ts
@@ -1,5 +1,6 @@
 import BridgeKycWebView from "./BridgeKycWebView"
 import BridgeExternalAccountWebView from "./BridgeExternalAccountWebView"
+import BridgeAddExternalAccount from "./BridgeAddExternalAccount"
 import TopupCashout from "./TopupCashout"
 import TopupDetails from "./TopupDetails"
 import BankTransfer from "./BankTransfer"
@@ -13,6 +14,7 @@ import PaymentSuccessScreen from "./payment-success-screen"
 export {
   BridgeKycWebView,
   BridgeExternalAccountWebView,
+  BridgeAddExternalAccount,
   TopupCashout,
   TopupDetails,
   BankTransfer,


### PR DESCRIPTION
## Summary
- Adds Bridge withdrawal request, initiation, and cancellation GraphQL documents/generated types.
- Adds the Bridge cashout confirmation path for pending withdrawal requests.
- Adds manual external bank-account entry as a fallback when Plaid Link is unavailable.
- Adds a Back Home action on Bridge bank-transfer details and cleans lint in the touched cashout flow files.

## Verification
- `git diff --check origin/feat/fygaro..HEAD`
- Focused eslint passed for the changed Bridge cashout files.