### PR TITLE
chore: update cutover and international upgrade copy

### DIFF
--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -99,7 +99,7 @@ const en: BaseTranslation = {
   },
   CashWalletCutover: {
     title: "Cash Wallet Updated",
-    body: "Your Cash Wallet has been upgraded from USD to USDT. Your balance has been automatically migrated. No action is needed on your part.",
+    body: "Your Cash Wallet has been automatically upgraded and now has additional capabilities. No action is needed on your part.",
     dismissButton: "Got it",
   },
   ConversionDetailsScreen: {
@@ -1660,7 +1660,7 @@ const en: BaseTranslation = {
       merchant: "Merchant",
       merchantDesc: "Give rewards, appear on the map, and settle to your bank. ID and bank info required.",
       international: "International",
-      internationalDesc: "Set up international transfers with Bridge KYC.",
+      internationalDesc: "Get an international account and routing number for bank transfers. ID required.",
       personalInfo: "Personal Information",
       fullName: "Full name",
       phoneNumber: "Phone Number",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -342,7 +342,7 @@ type RootTranslation = {
 		 */
 		title: string
 		/**
-		 * Y​o​u​r​ ​C​a​s​h​ ​W​a​l​l​e​t​ ​h​a​s​ ​b​e​e​n​ ​u​p​g​r​a​d​e​d​ ​f​r​o​m​ ​U​S​D​ ​t​o​ ​U​S​D​T​.​ ​Y​o​u​r​ ​b​a​l​a​n​c​e​ ​h​a​s​ ​b​e​e​n​ ​a​u​t​o​m​a​t​i​c​a​l​l​y​ ​m​i​g​r​a​t​e​d​.​ ​N​o​ ​a​c​t​i​o​n​ ​i​s​ ​n​e​e​d​e​d​ ​o​n​ ​y​o​u​r​ ​p​a​r​t​.
+		 * Y​o​u​r​ ​C​a​s​h​ ​W​a​l​l​e​t​ ​h​a​s​ ​b​e​e​n​ ​a​u​t​o​m​a​t​i​c​a​l​l​y​ ​u​p​g​r​a​d​e​d​ ​a​n​d​ ​n​o​w​ ​h​a​s​ ​a​d​d​i​t​i​o​n​a​l​ ​c​a​p​a​b​i​l​i​t​i​e​s​.​ ​N​o​ ​a​c​t​i​o​n​ ​i​s​ ​n​e​e​d​e​d​ ​o​n​ ​y​o​u​r​ ​p​a​r​t​.
 		 */
 		body: string
 		/**
@@ -5518,7 +5518,7 @@ type RootTranslation = {
 		 */
 		international: string
 		/**
-		 * S​e​t​ ​u​p​ ​i​n​t​e​r​n​a​t​i​o​n​a​l​ ​t​r​a​n​s​f​e​r​s​ ​w​i​t​h​ ​B​r​i​d​g​e​ ​K​Y​C​.
+		 * G​e​t​ ​a​n​ ​i​n​t​e​r​n​a​t​i​o​n​a​l​ ​a​c​c​o​u​n​t​ ​a​n​d​ ​r​o​u​t​i​n​g​ ​n​u​m​b​e​r​ ​f​o​r​ ​b​a​n​k​ ​t​r​a​n​s​f​e​r​s​.​ ​I​D​ ​r​e​q​u​i​r​e​d​.
 		 */
 		internationalDesc: string
 		/**
@@ -5940,7 +5940,7 @@ export type TranslationFunctions = {
 		 */
 		title: () => LocalizedString
 		/**
-		 * Your Cash Wallet has been upgraded from USD to USDT. Your balance has been automatically migrated. No action is needed on your part.
+		 * Your Cash Wallet has been automatically upgraded and now has additional capabilities. No action is needed on your part.
 		 */
 		body: () => LocalizedString
 		/**
@@ -11028,7 +11028,7 @@ export type TranslationFunctions = {
 		 */
 		international: () => LocalizedString
 		/**
-		 * Set up international transfers with Bridge KYC.
+		 * Get an international account and routing number for bank transfers. ID required.
 		 */
 		internationalDesc: () => LocalizedString
 		/**

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -87,7 +87,7 @@
     },
     "CashWalletCutover": {
         "title": "Cash Wallet Updated",
-        "body": "Your Cash Wallet has been upgraded from USD to USDT. Your balance has been automatically migrated. No action is needed on your part.",
+        "body": "Your Cash Wallet has been automatically upgraded and now has additional capabilities. No action is needed on your part.",
         "dismissButton": "Got it"
     },
     "ConversionDetailsScreen": {
@@ -1561,7 +1561,7 @@
         "merchant": "Merchant",
         "merchantDesc": "Give rewards, appear on the map, and settle to your bank. ID and bank info required.",
         "international": "International",
-        "internationalDesc": "Set up international transfers with Bridge KYC.",
+        "internationalDesc": "Get an international account and routing number for bank transfers. ID required.",
         "personalInfo": "Personal Information",
         "fullName": "Full name",
         "phoneNumber": "Phone Number",


### PR DESCRIPTION
## Summary
- Updates Cash Wallet cutover modal copy to avoid USD-to-USDT-specific phrasing.
- Clarifies the international account upgrade option copy.
- Regenerates i18n types for the updated strings.

## Verification
- `git diff --check origin/feat/fygaro..HEAD`
- Focused eslint was run on the changed i18n files. It still reports two pre-existing `no-template-curly-in-string` errors in `app/i18n/en/index.ts` at lines 631 and 633.