### PR TITLE
ci: run checks on the feat/fygaro integration branch

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -1,7 +1,9 @@
 name: "Check code"
 on:
+  push:
+    branches: [feat/fygaro]
   pull_request:
-    branches: [main]
+    branches: [main, feat/fygaro]
 jobs:
   check-code:
     name: Check Code

--- a/.github/workflows/conventional.yaml
+++ b/.github/workflows/conventional.yaml
@@ -1,7 +1,7 @@
 name: "Conventional commits"
 on:
   pull_request:
-    branches: [main]
+    branches: [main, feat/fygaro]
 jobs:
   conventional:
     name: "Conventional commits"

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,7 +1,7 @@
 name: Spelling
 on:
   pull_request:
-    branches: [main]
+    branches: [main, feat/fygaro]
 
 jobs:
   spelling:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 name: "Test"
 on:
+  push:
+    branches: [feat/fygaro]
   pull_request:
-    branches: [main]
+    branches: [main, feat/fygaro]
 jobs:
   check-code:
     name: Tests


### PR DESCRIPTION
## Why
CI was never running on the Fygaro PR stack. Two causes were found:

1. **Actions was disabled repo-wide** (`actions/permissions → enabled:false`) — now re-enabled to "Allow all actions and reusable workflows".
2. **Every test/check workflow is filtered to `pull_request: branches: [main]`.** That filter matches the PR's *base* branch, so PRs targeting `feat/fygaro` (#634, #635, #636) never trigger CI. This PR fixes #2.

## What
- Add `feat/fygaro` to the `pull_request` branch filter on the gating workflows: `check-code`, `test`, `conventional`, `spelling`. PRs into `feat/fygaro` now get the same checks as PRs into `main`.
- Add a `push` trigger on `feat/fygaro` to the core workflows (`check-code`, `test`) so the branch tip stays green as PRs stack onto it.

Left intentionally untouched: `codeql` (security scan, `main` + schedule), `i18n-drift` (already triggers on any PR touching `app/i18n/**`), `update_pods` (dependabot-scoped).

## Notes
- **This must land on `feat/fygaro`** (not `main`): `pull_request` reads the branch filter from the base branch, so the stacked PRs only pick it up once it's here.
- **Already-open PRs need a nudge** — push a commit or close/reopen #634/#635/#636 (and #621, base `main`) to trigger their first run.
- **Cleanup follow-up:** when `feat/fygaro` merges to `main` and is deleted, remove these temporary branch references.
- Heads-up: `conventional` (Conventional Commits) will now gate these PRs — if the stack's commit/title style isn't conventional, expect it to flag. Drop it from this PR if you'd rather not enforce that on the feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)