### PR TITLE
ci: stop conventional-pr from auto-closing invalid PRs

### DIFF
--- a/.github/workflows/conventional.yaml
+++ b/.github/workflows/conventional.yaml
@@ -14,3 +14,6 @@ jobs:
         message: this PR needs to be updated to follow conventional commits message
         body: false
         issue: false
+        # Report on invalid PRs instead of closing them (avoids nuking
+        # long-lived PRs like the feat/fygaro umbrella #621).
+        close: false


### PR DESCRIPTION
`Namchee/conventional-pr` defaults to **closing** any non-draft PR whose title isn't conventional. With Actions re-enabled, this auto-closed the `feat/fygaro` umbrella PR #621 repeatedly (every reopen re-triggered it).

Sets `close: false` so the action **comments/reports** instead of closing. Pairs with renaming #634/#635/#636 to conventional titles.

Conventional-commit title here, so the action passes on this PR itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)