### PR TITLE
fix(ci): resolve feat/fygaro tsconfig TS5095 + spelling allowlist

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@react-native/typescript-config/tsconfig.json",
   "compilerOptions": {
     "target": "ES2017",
-    "module": "Node16",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "allowJs": false,
     "sourceMap": true,

--- a/typos.toml
+++ b/typos.toml
@@ -24,6 +24,11 @@ InforError = "InforError"
 # Nostr terminology: "parameterized replaceable events" are referred to as
 # "replaceables" in NIP discussions.
 replaceables = "replaceables"
+# Earns quiz-ID misspellings that also surface as bare words (i18n strings /
+# generated types). The identifiers are a backend contract and can't be renamed
+# (see extend-identifiers above), so accept the word form everywhere too.
+Aggrement = "Aggrement"
+Governement = "Governement"
 
 [files]
 extend-exclude = ["*.svg", "app/i18n/raw-i18n", "earns-utils.test.ts", "*.plist", "*.pbxproj", "Appfile", "google-services.json", "patches", "ci/tasks/*", "logcat.txt", "*.storyboard"]


### PR DESCRIPTION
Part of getting `feat/fygaro` CI green. Fixes two of the four failing checks; the other two are out of scope (noted below).

## Fixes
- **Check Code (tsc `TS5095`)** — `tsconfig.json` set `module: "Node16"`, but the extended `@react-native/typescript-config` uses `moduleResolution: "bundler"`, which requires an esnext-class module. Set `module: "esnext"` + explicit `moduleResolution: "bundler"` (the standard RN/Metro combo). Addresses **ENG-420**.
- **Spelling** — `Aggrement`/`Governement` were flagged as bare words (the earns quiz-ID misspellings also appear in i18n strings / generated types). They're a **backend contract** (matched against server quiz data + sent to `quizCompleted`), so they can't be renamed — added to the `typos.toml` word allowlist.

## Out of scope (separate work)
- **Test (`ttypescript`)** — needs the ts-jest → ts-patch migration, which **#640** is already doing. #640 is itself blocked on this same tsconfig, so this PR should help unblock it; recommend landing #640 rather than duplicating it.
- **i18n-drift** — new `BankTransfer.*` / `AccountUpgrade.international*` keys are in `en.json` but missing from the other locales. Fix is `yarn update-translations` (typesafe-i18n regen) run locally — can't run Node tooling in CI authoring.

Note: `Check Code` is a chain (`tsc → eslint → check:translations → codegen → graphql-check`); this clears the `tsc` gate, but it may surface a later step (esp. `check:translations`, which is the same i18n drift) until the i18n keys are backfilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)