### PR TITLE
ci: run Check Code + Test on push to main

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -1,7 +1,7 @@
 name: "Check code"
 on:
   push:
-    branches: [feat/fygaro]
+    branches: [feat/fygaro, main]
   pull_request:
     branches: [main, feat/fygaro]
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: "Test"
 on:
   push:
-    branches: [feat/fygaro]
+    branches: [feat/fygaro, main]
   pull_request:
     branches: [main, feat/fygaro]
 jobs:


### PR DESCRIPTION
Adds `main` to the **push** trigger of the core `check-code` and `test` workflows, so `main`'s own tip is continuously validated after every merge — not only PRs *into* `main` (today CI is `pull_request`-only for `main`, plus CodeQL).

Targets `feat/fygaro` so it lands on `main` in one shot via **#621**, consistent with routing all CI work through the integration branch.

- Scoped to the two core correctness workflows (mirrors the `feat/fygaro` push trigger added in #637); `conventional` stays PR-only (it validates PRs), and `codeql` already runs on push to `main`.
- Cleanup note: once `feat/fygaro` merges and is deleted, `feat/fygaro` can be dropped from these push lists.

Part of the feat/fygaro CI cleanup sprint (ENG-420/421/425/426).

🤖 Generated with [Claude Code](https://claude.com/claude-code)