### PR TITLE
fix(import-wallet): keep seed input visible above the keyboard (ENG-85)

### DIFF
--- a/app/screens/import-wallet-screen/ImportWallet.tsx
+++ b/app/screens/import-wallet-screen/ImportWallet.tsx
@@ -5,6 +5,7 @@ import { StackScreenProps } from "@react-navigation/stack"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
 import * as Keychain from "react-native-keychain"
 import * as bip39 from "bip39"
+import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view"
 
 // components
 import { PrimaryBtn } from "@app/components/buttons"
@@ -123,29 +124,38 @@ const ImportWallet: React.FC<Props> = ({ navigation, route }) => {
 
   return (
     <Wrapper style={{ backgroundColor: colors.white }}>
-      <Container>
-        <Text type="h01" bold style={{ textAlign: "center" }}>
-          {insideApp ? LL.ImportWallet.importTitle() : LL.ImportWallet.title()}
-        </Text>
-        <Text type="p1" color={colors.grey2} style={{ textAlign: "center" }}>
-          {LL.ImportWallet.description()}
-        </Text>
-        <FlatList
-          data={inputSeedPhrase}
-          numColumns={2}
-          renderItem={renderItemHandler}
-          columnWrapperStyle={{ justifyContent: "space-between", columnGap: 15 }}
-          scrollEnabled={false}
-          style={{ marginVertical: 20 }}
+      <KeyboardAwareScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ flexGrow: 1, justifyContent: "space-between" }}
+        enableOnAndroid
+        extraScrollHeight={20}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <Container>
+          <Text type="h01" bold style={{ textAlign: "center" }}>
+            {insideApp ? LL.ImportWallet.importTitle() : LL.ImportWallet.title()}
+          </Text>
+          <Text type="p1" color={colors.grey2} style={{ textAlign: "center" }}>
+            {LL.ImportWallet.description()}
+          </Text>
+          <FlatList
+            data={inputSeedPhrase}
+            numColumns={2}
+            renderItem={renderItemHandler}
+            columnWrapperStyle={{ justifyContent: "space-between", columnGap: 15 }}
+            scrollEnabled={false}
+            style={{ marginVertical: 20 }}
+          />
+        </Container>
+        <PrimaryBtn
+          label={LL.ImportWallet.complete()}
+          disabled={disabled}
+          loading={loading}
+          onPress={onComplete}
+          btnStyle={{ marginBottom: bottom || 10 }}
         />
-      </Container>
-      <PrimaryBtn
-        label={LL.ImportWallet.complete()}
-        disabled={disabled}
-        loading={loading}
-        onPress={onComplete}
-        btnStyle={{ marginBottom: bottom || 10 }}
-      />
+      </KeyboardAwareScrollView>
       {loading && <Loading />}
     </Wrapper>
   )


### PR DESCRIPTION
Fixes #517 · ENG-85

## Problem
On the wallet-import screen the 12 seed-word inputs render in a static `FlatList` (`scrollEnabled={false}`) inside a plain flex `View`, with the Complete button pinned at the bottom. Nothing scrolls or avoids the keyboard, so the on-screen keyboard **hides the lower inputs** — the user can't see what they're typing. (Confirmed still reproducing on `main`.)

## Fix
Wrap the screen content in `KeyboardAwareScrollView` (the dep is already in `package.json`) so the focused input scrolls above the keyboard:
- `enableOnAndroid` (the lib is iOS-only by default)
- `keyboardShouldPersistTaps="handled"` (tap other inputs/button without dismissing first)
- `extraScrollHeight={20}`, `contentContainerStyle={{ flexGrow: 1, justifyContent: "space-between" }}` to preserve the original "content top, button bottom" layout

The seed-grid `FlatList` and all styling are unchanged — only the wrapper is added.

## Verification
- [ ] **Needs device verification (iOS + Android)** per the acceptance criteria — I can't run the simulator here, so this is verified-by-construction, not on-device. Please confirm the focused word stays visible across keyboard heights on both platforms.

## Notes
- The inner `FlatList` is `scrollEnabled={false}` (a static 2-col grid), so nesting it in the scroll view is functionally fine but will emit the dev-only "VirtualizedLists should never be nested" warning. If you'd rather silence it, a follow-up can convert the static grid to a plain flex-wrap `map` — left out here to keep the layout byte-for-byte identical.
- CI on flash-mobile `main` is currently red on pre-existing repo-wide debt (ENG-422-class / tsc backlog), unrelated to this one-file change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)