### PR TITLE
fix(send): route QR-scanned usernames to BTC-default recipients via LNURL (ENG-399)

### DIFF
--- a/__tests__/payment-destination/resolve-username-to-lnurl.spec.ts
+++ b/__tests__/payment-destination/resolve-username-to-lnurl.spec.ts
@@ -1,0 +1,141 @@
+import { PaymentType } from "@galoymoney/client"
+import { WalletCurrency } from "@app/graphql/generated"
+import { InvalidDestinationReason } from "@app/screens/send-bitcoin-screen/payment-destination/index.types"
+
+const mockParsePaymentDestination = jest.fn()
+jest.mock("@flash/client", () => ({
+  parsePaymentDestination: (...args: unknown[]) => mockParsePaymentDestination(...args),
+  Network: {},
+}))
+
+const mockRequestPayServiceParams = jest.fn()
+jest.mock("lnurl-pay", () => ({
+  requestPayServiceParams: (...args: unknown[]) => mockRequestPayServiceParams(...args),
+}))
+
+const mockCreateLnurlPaymentDestination = jest.fn()
+jest.mock("@app/screens/send-bitcoin-screen/payment-destination/lnurl", () => ({
+  createLnurlPaymentDestination: (...args: unknown[]) =>
+    mockCreateLnurlPaymentDestination(...args),
+}))
+
+import { maybeResolveManualUsernameToLnurl } from "@app/screens/send-bitcoin-screen/payment-destination/resolve-username-to-lnurl"
+
+const LN_ADDRESS_HOSTNAME = "flashapp.me"
+
+const baseParams = {
+  rawInput: "satoshi",
+  myWalletIds: ["my-usd-wallet"],
+  lnAddressHostname: LN_ADDRESS_HOSTNAME,
+}
+
+const intraledgerParse = {
+  paymentType: PaymentType.Intraledger,
+  valid: true,
+  handle: "satoshi",
+}
+
+describe("maybeResolveManualUsernameToLnurl", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("returns null for a non-intraledger destination (falls back to parseDestination)", async () => {
+    mockParsePaymentDestination.mockReturnValue({
+      paymentType: PaymentType.Lightning,
+      valid: true,
+    })
+    const accountDefaultWalletQuery = jest.fn()
+
+    const result = await maybeResolveManualUsernameToLnurl({
+      ...baseParams,
+      accountDefaultWalletQuery,
+    })
+
+    expect(result).toBeNull()
+    expect(accountDefaultWalletQuery).not.toHaveBeenCalled()
+  })
+
+  it("returns null when the recipient's default wallet is not BTC", async () => {
+    mockParsePaymentDestination.mockReturnValue(intraledgerParse)
+    const accountDefaultWalletQuery = jest.fn().mockResolvedValue({
+      data: { accountDefaultWallet: { id: "their-usd-wallet", walletCurrency: WalletCurrency.Usd } },
+    })
+
+    const result = await maybeResolveManualUsernameToLnurl({
+      ...baseParams,
+      accountDefaultWalletQuery,
+    })
+
+    expect(result).toBeNull()
+    expect(mockRequestPayServiceParams).not.toHaveBeenCalled()
+  })
+
+  it("returns a self-payment error when the BTC wallet belongs to the sender", async () => {
+    mockParsePaymentDestination.mockReturnValue(intraledgerParse)
+    const accountDefaultWalletQuery = jest.fn().mockResolvedValue({
+      data: { accountDefaultWallet: { id: "my-usd-wallet", walletCurrency: WalletCurrency.Btc } },
+    })
+
+    const result = await maybeResolveManualUsernameToLnurl({
+      ...baseParams,
+      accountDefaultWalletQuery,
+    })
+
+    expect(result).toEqual({
+      valid: false,
+      invalidReason: InvalidDestinationReason.SelfPayment,
+      invalidPaymentDestination: intraledgerParse,
+    })
+  })
+
+  it("re-routes a BTC-default recipient through LNURL using handle@hostname", async () => {
+    mockParsePaymentDestination.mockReturnValue(intraledgerParse)
+    const accountDefaultWalletQuery = jest.fn().mockResolvedValue({
+      data: { accountDefaultWallet: { id: "their-btc-wallet", walletCurrency: WalletCurrency.Btc } },
+    })
+    const lnurlParams = { min: 1, max: 1000 }
+    mockRequestPayServiceParams.mockResolvedValue(lnurlParams)
+    const lnurlDestination = { valid: true, destinationDirection: "Send" }
+    mockCreateLnurlPaymentDestination.mockReturnValue(lnurlDestination)
+
+    const result = await maybeResolveManualUsernameToLnurl({
+      ...baseParams,
+      accountDefaultWalletQuery,
+    })
+
+    expect(mockRequestPayServiceParams).toHaveBeenCalledWith({
+      lnUrlOrAddress: `satoshi@${LN_ADDRESS_HOSTNAME}`,
+    })
+    expect(mockCreateLnurlPaymentDestination).toHaveBeenCalledWith({
+      paymentType: PaymentType.Lnurl,
+      valid: true,
+      lnurl: `satoshi@${LN_ADDRESS_HOSTNAME}`,
+      lnurlParams,
+    })
+    expect(result).toBe(lnurlDestination)
+  })
+
+  it("returns an LnurlError when the lightning address cannot be resolved", async () => {
+    mockParsePaymentDestination.mockReturnValue(intraledgerParse)
+    const accountDefaultWalletQuery = jest.fn().mockResolvedValue({
+      data: { accountDefaultWallet: { id: "their-btc-wallet", walletCurrency: WalletCurrency.Btc } },
+    })
+    mockRequestPayServiceParams.mockRejectedValue(new Error("not found"))
+
+    const result = await maybeResolveManualUsernameToLnurl({
+      ...baseParams,
+      accountDefaultWalletQuery,
+    })
+
+    expect(result).toEqual({
+      valid: false,
+      invalidReason: InvalidDestinationReason.LnurlError,
+      invalidPaymentDestination: {
+        paymentType: PaymentType.Lnurl,
+        valid: false,
+        invalidReason: "unknown",
+      },
+    })
+  })
+})

--- a/app/screens/send-bitcoin-screen/payment-destination/resolve-username-to-lnurl.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/resolve-username-to-lnurl.ts
@@ -1,0 +1,94 @@
+import { PaymentType } from "@galoymoney/client"
+import { Network as NetworkGaloyClient, parsePaymentDestination } from "@flash/client"
+import { requestPayServiceParams } from "lnurl-pay"
+
+import { LNURL_DOMAINS } from "@app/config"
+import {
+  AccountDefaultWalletLazyQueryHookResult,
+  WalletCurrency,
+} from "@app/graphql/generated"
+
+import { createLnurlPaymentDestination } from "./lnurl"
+import { InvalidDestinationReason, ParseDestinationResult } from "./index.types"
+
+/**
+ * When a bare Flash username / intraledger handle resolves to a recipient whose
+ * default wallet is BTC/Breez, an intraledger send from a USD wallet fails. In
+ * that case we instead route the payment through the recipient's lightning
+ * address (`handle@lnAddressHostname`) so the USD wallet pays the generated
+ * LNURL invoice.
+ *
+ * Returns:
+ *  - an LNURL `ParseDestinationResult` when the username should be re-routed,
+ *  - an invalid result for self-payment or an unreachable lightning address,
+ *  - `null` when this helper does not apply (not a username, or the recipient's
+ *    default wallet is not BTC), so the caller falls back to `parseDestination`.
+ *
+ * Shared by every send entry point that can receive a bare username (manual
+ * entry and QR scan) so the routing decision is not duplicated. See ENG-399.
+ */
+export const maybeResolveManualUsernameToLnurl = async ({
+  rawInput,
+  myWalletIds,
+  lnAddressHostname,
+  accountDefaultWalletQuery,
+}: {
+  rawInput: string
+  myWalletIds: string[]
+  lnAddressHostname: string
+  accountDefaultWalletQuery: AccountDefaultWalletLazyQueryHookResult[0]
+}): Promise<ParseDestinationResult | null> => {
+  const parsedDestination = parsePaymentDestination({
+    destination: rawInput,
+    network: "mainnet" as NetworkGaloyClient,
+    lnAddressDomains: LNURL_DOMAINS,
+  })
+
+  if (
+    parsedDestination.paymentType !== PaymentType.Intraledger ||
+    !parsedDestination.valid
+  ) {
+    return null
+  }
+
+  const { handle } = parsedDestination
+  const { data } = await accountDefaultWalletQuery({ variables: { username: handle } })
+  const wallet = data?.accountDefaultWallet
+
+  if (!wallet || wallet.walletCurrency !== WalletCurrency.Btc) {
+    return null
+  }
+
+  if (myWalletIds.includes(wallet.id)) {
+    return {
+      valid: false,
+      invalidReason: InvalidDestinationReason.SelfPayment,
+      invalidPaymentDestination: parsedDestination,
+    } as const
+  }
+
+  const lnurl = `${handle}@${lnAddressHostname}`
+
+  try {
+    const lnurlParams = await requestPayServiceParams({
+      lnUrlOrAddress: lnurl,
+    })
+
+    return createLnurlPaymentDestination({
+      paymentType: PaymentType.Lnurl,
+      valid: true,
+      lnurl,
+      lnurlParams,
+    })
+  } catch {
+    return {
+      valid: false,
+      invalidReason: InvalidDestinationReason.LnurlError,
+      invalidPaymentDestination: {
+        paymentType: PaymentType.Lnurl,
+        valid: false,
+        invalidReason: "unknown",
+      },
+    } as const
+  }
+}

--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -9,6 +9,7 @@ import { useNavigation } from "@react-navigation/native"
 // utils
 import { LNURL_DOMAINS } from "@app/config"
 import { parseDestination } from "./payment-destination"
+import { maybeResolveManualUsernameToLnurl } from "./payment-destination/resolve-username-to-lnurl"
 import { logParseDestinationResult } from "@app/utils/analytics"
 
 // types
@@ -23,6 +24,7 @@ import {
 } from "@app/graphql/generated"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { useI18nContext } from "@app/i18n/i18n-react"
+import { useAppConfig } from "@app/hooks"
 
 // components
 import { Screen } from "../../components/screen"
@@ -38,6 +40,11 @@ export const ScanningQRCodeScreen = () => {
 
   const { LL } = useI18nContext()
   const { hasPermission, requestPermission } = useCameraPermission()
+  const {
+    appConfig: {
+      galoyInstance: { lnAddressHostname },
+    },
+  } = useAppConfig()
 
   const [pending, setPending] = useState(false)
 
@@ -76,13 +83,23 @@ export const ScanningQRCodeScreen = () => {
       try {
         setPending(true)
 
-        const destination = await parseDestination({
-          rawInput: data,
-          myWalletIds: wallets.map((wallet) => wallet.id),
-          bitcoinNetwork,
-          lnurlDomains: LNURL_DOMAINS,
-          accountDefaultWalletQuery,
-        })
+        // A bare Flash username scanned via QR whose recipient defaults to a
+        // BTC/Breez wallet must be re-routed through LNURL, otherwise a USD
+        // send fails as an intraledger payment. Mirror the manual-entry path.
+        const destination =
+          (await maybeResolveManualUsernameToLnurl({
+            rawInput: data,
+            myWalletIds: wallets.map((wallet) => wallet.id),
+            lnAddressHostname,
+            accountDefaultWalletQuery,
+          })) ??
+          (await parseDestination({
+            rawInput: data,
+            myWalletIds: wallets.map((wallet) => wallet.id),
+            bitcoinNetwork,
+            lnurlDomains: LNURL_DOMAINS,
+            accountDefaultWalletQuery,
+          }))
         logParseDestinationResult(destination)
 
         if (destination.valid) {
@@ -144,6 +161,7 @@ export const ScanningQRCodeScreen = () => {
     bitcoinNetwork,
     wallets,
     accountDefaultWalletQuery,
+    lnAddressHostname,
   ])
 
   if (!hasPermission) {

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -13,13 +13,11 @@ import { DestinationInformation } from "./destination-information"
 
 // hooks
 import {
-  AccountDefaultWalletLazyQueryHookResult,
   useAccountDefaultWalletLazyQuery,
   useLnUsdInvoiceAmountMutation,
   useNpubByUsernameLazyQuery,
   useRealtimePriceQuery,
   useSendBitcoinDestinationQuery,
-  WalletCurrency,
 } from "@app/graphql/generated"
 import { useActivityIndicator, useAppConfig } from "@app/hooks"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
@@ -27,20 +25,17 @@ import { useIsAuthed } from "@app/graphql/is-authed-context"
 // types
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
 import { PaymentType } from "@galoymoney/client"
-import { Network as NetworkGaloyClient, parsePaymentDestination } from "@flash/client"
 import {
   DestinationDirection,
   InvalidDestinationReason,
-  ParseDestinationResult,
 } from "./payment-destination/index.types"
 
 // utils
 import { LNURL_DOMAINS } from "@app/config"
 import { toUsdMoneyAmount } from "@app/types/amounts"
 import { parseDestination } from "./payment-destination"
-import { createLnurlPaymentDestination } from "./payment-destination/lnurl"
+import { maybeResolveManualUsernameToLnurl } from "./payment-destination/resolve-username-to-lnurl"
 import { logParseDestinationResult } from "@app/utils/analytics"
-import { requestPayServiceParams } from "lnurl-pay"
 
 // store
 import {
@@ -336,72 +331,6 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ navigation, route }) =>
 }
 
 export default SendBitcoinDestinationScreen
-
-const maybeResolveManualUsernameToLnurl = async ({
-  rawInput,
-  myWalletIds,
-  lnAddressHostname,
-  accountDefaultWalletQuery,
-}: {
-  rawInput: string
-  myWalletIds: string[]
-  lnAddressHostname: string
-  accountDefaultWalletQuery: AccountDefaultWalletLazyQueryHookResult[0]
-}): Promise<ParseDestinationResult | null> => {
-  const parsedDestination = parsePaymentDestination({
-    destination: rawInput,
-    network: "mainnet" as NetworkGaloyClient,
-    lnAddressDomains: LNURL_DOMAINS,
-  })
-
-  if (
-    parsedDestination.paymentType !== PaymentType.Intraledger ||
-    !parsedDestination.valid
-  ) {
-    return null
-  }
-
-  const { handle } = parsedDestination
-  const { data } = await accountDefaultWalletQuery({ variables: { username: handle } })
-  const wallet = data?.accountDefaultWallet
-
-  if (!wallet || wallet.walletCurrency !== WalletCurrency.Btc) {
-    return null
-  }
-
-  if (myWalletIds.includes(wallet.id)) {
-    return {
-      valid: false,
-      invalidReason: InvalidDestinationReason.SelfPayment,
-      invalidPaymentDestination: parsedDestination,
-    } as const
-  }
-
-  const lnurl = `${handle}@${lnAddressHostname}`
-
-  try {
-    const lnurlParams = await requestPayServiceParams({
-      lnUrlOrAddress: lnurl,
-    })
-
-    return createLnurlPaymentDestination({
-      paymentType: PaymentType.Lnurl,
-      valid: true,
-      lnurl,
-      lnurlParams,
-    })
-  } catch {
-    return {
-      valid: false,
-      invalidReason: InvalidDestinationReason.LnurlError,
-      invalidPaymentDestination: {
-        paymentType: PaymentType.Lnurl,
-        valid: false,
-        invalidReason: "unknown",
-      },
-    } as const
-  }
-}
 
 const usestyles = makeStyles(({ colors }) => ({
   screenStyle: {


### PR DESCRIPTION
## Summary

A bare Flash username **scanned via QR** that resolves to a recipient whose **default wallet is BTC/Breez** fails when the **sender's wallet is USD**: the shared parser treats it as `PaymentType.Intraledger`, and the USD send then calls `intraLedgerUsdPaymentSend` against the recipient's BTC wallet — failing with the generic support error.

Manual bare-username entry already handles this (PR #602) via a module-private `maybeResolveManualUsernameToLnurl`, which detects the BTC-default recipient and re-routes the payment through their lightning address (`username@lnAddressHostname`). This PR brings the **QR path** to parity.

## Changes

- **Extract** `maybeResolveManualUsernameToLnurl` into `payment-destination/resolve-username-to-lnurl.ts` so every entry point shares one routing decision (the ticket explicitly calls out the duplicated-logic risk). No behavior change for manual entry — it now imports the shared helper.
- **Apply** it in the QR-scan `processInvoice` using the same `maybeResolve… ?? parseDestination` fallthrough as manual entry. The helper returns `null` for anything that isn't a BTC-default-recipient username, so all other QR destinations are unaffected.
- **Tests** — `__tests__/payment-destination/resolve-username-to-lnurl.spec.ts` covers all five branches: non-intraledger pass-through, USD-recipient pass-through, self-payment, successful LNURL re-route (`handle@hostname`), and the unreachable-lightning-address (`LnurlError`) case.

## Scope (why only QR)

Of the four `parseDestination` entry points, **QR is the only one that carries a bare username into a send**:
- **NFC** (`modal-nfc.tsx`) is receive/withdraw-only — it reads `lnurl` payloads only and explicitly rejects Send-direction destinations (`nfcOnlyReceive`).
- **Card** (`card.tsx`) always carries a **Flashcard LNURL**, never a bare username.

Editing those would be incorrect/risky, so they're intentionally untouched. The durable, all-entry-point fix is the backend `resolveSendDestination` resolver — **ENG-399 Phase 2** — filed as a separate follow-up.

## Validation

⚠️ `main`'s CI is currently red for **toolchain reasons unrelated to this PR** — the `tsconfig` TS5095 error (fixed on `feat/fygaro` by #642) and the `ttypescript`/`ts-jest` breakage (ENG-421/425). `main` inherits these fixes when **#621** lands. Validated locally instead:
- **Unit tests:** 5/5 pass (run via `babel-jest`, since `main`'s `ts-jest` can't load).
- **Typecheck:** with the #642 tsconfig fix applied locally, `tsc` shows **zero new errors** vs the `main` baseline (82 → 82; the 82 are the pre-existing ENG-425 cluster).

## Acceptance criteria
- [x] QR-scanned username to a BTC-default recipient routes through LNURL (USD send succeeds)
- [x] Routing logic shared, not duplicated per entry point
- [x] Other QR destinations unaffected (helper returns `null` to fall through)
- [x] Unit tests cover the routing policy
- [ ] Phase 2 backend resolver (`resolveSendDestination`) — tracked separately

Refs ENG-399 (Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)