### PR TITLE
feat(ui): display stablecoins as fiat currency in all screens

### DIFF
--- a/__tests__/components/currency-tag.spec.tsx
+++ b/__tests__/components/currency-tag.spec.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from "@rneui/themed"
 
 import { CurrencyTag } from "@app/components/currency-tag"
 import { WalletCurrency } from "@app/graphql/generated"
+import { displayCurrencyCode } from "@app/utils/currency-display"
 import theme from "@app/rne-theme/theme"
 
 const renderCurrencyTag = (walletCurrency: WalletCurrency) =>
@@ -16,10 +17,11 @@ const renderCurrencyTag = (walletCurrency: WalletCurrency) =>
 describe("CurrencyTag", () => {
   it.each([WalletCurrency.Btc, WalletCurrency.Usd, WalletCurrency.Usdt])(
     "renders a %s tag",
-    (walletCurrency) => {
+    (walletCurrency: WalletCurrency) => {
       const { getByText } = renderCurrencyTag(walletCurrency)
 
-      expect(getByText(walletCurrency)).toBeTruthy()
+      // USDT displays as USD (stablecoin → fiat mapping)
+      expect(getByText(displayCurrencyCode(walletCurrency))).toBeTruthy()
     },
   )
 })

--- a/app/components/cards/Balance.tsx
+++ b/app/components/cards/Balance.tsx
@@ -8,6 +8,9 @@ import HideableArea from "../hideable-area/hideable-area"
 // hooks
 import { useHideBalanceQuery } from "@app/graphql/generated"
 
+// utils
+import { displayCurrencyCode } from "@app/utils/currency-display"
+
 // assets
 import Cash from "@app/assets/icons/cash.svg"
 import Bitcoin from "@app/assets/icons/bitcoin.svg"
@@ -67,7 +70,7 @@ const Balance: React.FC<Props> = ({
               <Text type="h02" bold>
                 {amount}{" "}
                 <Text type="h02" color={colors.text02}>
-                  {currency}
+                  {displayCurrencyCode(currency)}
                 </Text>
               </Text>
             </HideableArea>

--- a/app/components/currency-tag/currency-tag.tsx
+++ b/app/components/currency-tag/currency-tag.tsx
@@ -1,4 +1,5 @@
 import { WalletCurrency } from "@app/graphql/generated"
+import { displayCurrencyCode } from "@app/utils/currency-display"
 import { makeStyles, useTheme } from "@rneui/themed"
 import React, { FC } from "react"
 import { Text, View } from "react-native"
@@ -36,7 +37,7 @@ export const CurrencyTag: FC<CurrencyTagProps> = ({ walletCurrency }) => {
 
   return (
     <View style={styles.currencyTag}>
-      <Text style={styles.currencyText}>{walletCurrency}</Text>
+      <Text style={styles.currencyText}>{displayCurrencyCode(walletCurrency)}</Text>
     </View>
   )
 }

--- a/app/components/topup-cashout-flow/CashoutWithdrawTo.tsx
+++ b/app/components/topup-cashout-flow/CashoutWithdrawTo.tsx
@@ -4,6 +4,7 @@ import { Icon, makeStyles, Text, useTheme } from "@rneui/themed"
 
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { useBankAccountsQuery } from "@app/graphql/generated"
+import { displayCurrencyCode } from "@app/utils/currency-display"
 
 type Props = {
   preferredCurrency?: string
@@ -59,7 +60,7 @@ const CashoutWithdrawTo: React.FC<Props> = ({ preferredCurrency }) => {
               value={String(bankAccount.accountNumber)}
             />
             <DetailRow label={LL.Cashout.accountType()} value={bankAccount.accountType} />
-            <DetailRow label={LL.Cashout.currency()} value={bankAccount.currency} />
+            <DetailRow label={LL.Cashout.currency()} value={displayCurrencyCode(bankAccount.currency)} />
           </View>
         )}
       </TouchableOpacity>

--- a/app/hooks/use-display-currency.ts
+++ b/app/hooks/use-display-currency.ts
@@ -9,6 +9,7 @@ import {
   WalletAmount,
   WalletOrDisplayCurrency,
 } from "@app/types/amounts"
+import { displayCurrencyCode } from "@app/utils/currency-display"
 import { useCallback, useMemo } from "react"
 import { usePriceConversion } from "./use-price-conversion"
 import { useI18nContext } from "@app/i18n/i18n-react"
@@ -125,7 +126,7 @@ export const useDisplayCurrency = () => {
         symbol: usdDisplayCurrency.symbol,
         minorUnitToMajorUnitOffset: 6,
         showFractionDigits: true,
-        currencyCode: "USDT",
+        currencyCode: usdDisplayCurrency.id,
       },
       [WalletCurrency.Btc]: {
         symbol: "₿",
@@ -203,9 +204,7 @@ export const useDisplayCurrency = () => {
         symbol: noSymbol ? "" : symbol,
         fractionDigits: showFractionDigits ? minorUnitToMajorUnitOffset : 0,
         currencyCode:
-          (moneyAmount.currency === WalletCurrency.Btc ||
-            moneyAmount.currency === WalletCurrency.Usdt) &&
-          !noSuffix
+          moneyAmount.currency === WalletCurrency.Btc && !noSuffix
             ? currencyCode
             : undefined,
       })

--- a/app/types/amounts.ts
+++ b/app/types/amounts.ts
@@ -39,7 +39,7 @@ export const ZeroUsdMoneyAmount: UsdMoneyAmount = {
 export const ZeroUsdtMoneyAmount: UsdtMoneyAmount = {
   amount: 0,
   currency: WalletCurrency.Usdt,
-  currencyCode: "USDT",
+  currencyCode: "USD",
 }
 
 export const ZeroBtcMoneyAmount: BtcMoneyAmount = {
@@ -83,13 +83,13 @@ export const toUsdtMoneyAmount = (amount: number | undefined | null): UsdtMoneyA
     return {
       amount: NaN,
       currency: WalletCurrency.Usdt,
-      currencyCode: "USDT",
+      currencyCode: "USD",
     }
   }
   return {
     amount,
     currency: WalletCurrency.Usdt,
-    currencyCode: "USDT",
+    currencyCode: "USD",
   }
 }
 

--- a/app/utils/currency-display.ts
+++ b/app/utils/currency-display.ts
@@ -1,0 +1,46 @@
+// app/utils/currency-display.ts
+
+import { WalletCurrency } from "@app/graphql/generated"
+
+/**
+ * Stablecoin → fiat display mapping.
+ *
+ * The backend may add new stablecoin wallets (USDC, USDB, PYUSD, EURC, etc).
+ * In the UI, these should always display as their underlying fiat currency,
+ * not the stablecoin ticker. This keeps the user experience consistent —
+ * they see "USD" whether their cash wallet is USDT, USDC, or any future USD
+ * stablecoin.
+ *
+ * To add a new stablecoin: add its WalletCurrency string value to this map
+ * with the fiat code it should display as.
+ *
+ * NOTE: As of now only USDT exists in the enum. When new currencies are added
+ * to WalletCurrency, extend this map. Any currency not in the map displays as-is.
+ */
+
+const STABLECOIN_DISPLAY_MAP: Record<string, string> = {
+  // USD-pegged stablecoins → display as "USD"
+  USDT: "USD",
+  // USDC: "USD",    // future
+  // USDB: "USD",    // future
+  // PYUSD: "USD",   // future
+
+  // EUR-pegged stablecoins → display as "EUR"
+  // EURC: "EUR",    // future
+}
+
+/**
+ * Returns the user-facing currency code for a wallet currency.
+ * Stablecoins map to their fiat equivalent; everything else passes through.
+ *
+ * @example
+ * displayCurrencyCode("USDT")  → "USD"
+ * displayCurrencyCode("USD")   → "USD"
+ * displayCurrencyCode("BTC")   → "BTC"
+ * displayCurrencyCode("USDC")  → "USD"  (once added to map)
+ */
+export const displayCurrencyCode = (
+  currency: WalletCurrency | string,
+): string => {
+  return STABLECOIN_DISPLAY_MAP[currency] ?? currency
+}


### PR DESCRIPTION
## Summary

Stablecoin wallets (USDT today; USDC, USDB, PYUSD, EURC, etc. in the future) should display as their underlying fiat currency — not the stablecoin ticker. Users see **"USD"** whether their cash wallet is USDT, USDC, or any future USD-pegged stablecoin.

**UI-only change.** Underlying wallet routing, currency enums, amount conversions, and settlement logic remain unchanged.

## Changes

| File | Change |
|------|--------|
| `app/utils/currency-display.ts` | **New** — `STABLECOIN_DISPLAY_MAP` + `displayCurrencyCode()` helper |
| `app/components/currency-tag/currency-tag.tsx` | Render `displayCurrencyCode()` instead of raw `{walletCurrency}` |
| `app/hooks/use-display-currency.ts` | `currencyCode: "USD"` for USDT + suppress suffix (renders like USD) |
| `app/types/amounts.ts` | `currencyCode: "USD"` in USDT amount objects |
| `app/components/cards/Balance.tsx` | Map currency through `displayCurrencyCode()` |
| `app/components/topup-cashout-flow/CashoutWithdrawTo.tsx` | Map bank account currency through `displayCurrencyCode()` |
| `__tests__/components/currency-tag.spec.tsx` | Assert display mapping in test |

## Future Extensibility

When the backend adds new stablecoin wallets, adding the display mapping is **one line**:

```ts
const STABLECOIN_DISPLAY_MAP = {
  USDT: "USD",     // today
  USDC: "USD",     // future
  USDB: "USD",     // future
  PYUSD: "USD",    // future
  EURC: "EUR",     // future
}
```

No other display code needs to change.

## Test Plan

- [x] `currency-tag.spec.tsx` — 3/3 pass (BTC, USD, USDT all verified)
- [x] `payment-request.spec.ts` — 12/12 pass
- [x] TypeScript: no new errors (pre-existing errors unaffected)
- [ ] Manual: Home screen balance shows "USD" not "USDT"
- [ ] Manual: Transaction history shows "USD" tags
- [ ] Manual: Send flow confirmation shows "USD"
- [ ] Manual: Receive screen shows "USD"
- [ ] Manual: Cashout details show "USD" for bank currency
