### PR TITLE
chore(bridge): drop KYC-response console.logs

### DIFF
--- a/app/screens/account-upgrade-flow/AccountType.tsx
+++ b/app/screens/account-upgrade-flow/AccountType.tsx
@@ -82,7 +82,6 @@ const AccountType: React.FC<Props> = ({ navigation }) => {
         },
       })
       toggleActivityIndicator(false)
-      console.log("BRIDGE INITIATE KYC RESPONSE: ", res)
       const errors = res.data?.bridgeInitiateKyc?.errors
       if (errors && errors.length > 0) {
         Alert.alert("Error", errors[0].message)

--- a/app/screens/topup-cashout-flow/TopupCashout.tsx
+++ b/app/screens/topup-cashout-flow/TopupCashout.tsx
@@ -218,7 +218,6 @@ const TopupCashout: React.FC<Props> = ({ navigation }) => {
         },
       })
       toggleActivityIndicator(false)
-      console.log("BRIDGE INITIATE KYC RESPONSE: ", res)
       const errors = res.data?.bridgeInitiateKyc?.errors
       if (errors && errors.length > 0) {
         Alert.alert("Error", errors[0].message)


### PR DESCRIPTION
## Summary

Removes two `console.log("BRIDGE INITIATE KYC RESPONSE: ", res)` statements in the Bridge KYC-initiation flow:
- `app/screens/account-upgrade-flow/AccountType.tsx`
- `app/screens/topup-cashout-flow/TopupCashout.tsx`

Logging the raw KYC response writes **sensitive identity data** to the console and serves no production purpose. `res` is still used for error handling immediately after, so behavior is unchanged.

## Scope
- Surfaced during review of #621.
- The transaction-details TODO stub on the cashout success screen (`payment-success-screen.tsx`) is **intentionally left as-is** per the review decision.

## Note on sequencing
This targets `feat/fygaro`, so it needs to land here **before** #621 (feat/fygaro → main) is merged for the cleanup to be included. Two-line deletion; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)