### PR TITLE
feat(watchos): Apple Watch app + BTC price complication

### DIFF
--- a/app/components/watch-currency-sync/index.tsx
+++ b/app/components/watch-currency-sync/index.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react"
+
+import { useDisplayCurrency } from "@app/hooks/use-display-currency"
+import { setWatchCurrency } from "@app/utils/watch"
+
+/**
+ * Keeps the paired Apple Watch in sync with the user's display currency. Renders
+ * nothing; mount it once inside the authed Apollo tree (alongside the price
+ * updates). The watch fetches the BTC price itself, so only the currency
+ * preference is pushed. No-op on Android / when no watch is paired.
+ */
+export const WatchCurrencySync: React.FC = () => {
+  const { fractionDigits, fiatSymbol, displayCurrency } = useDisplayCurrency()
+
+  useEffect(() => {
+    if (!displayCurrency) {
+      return
+    }
+    setWatchCurrency({
+      currencyCode: displayCurrency,
+      currencySymbol: fiatSymbol,
+      fractionDigits,
+    })
+  }, [displayCurrency, fiatSymbol, fractionDigits])
+
+  return null
+}

--- a/app/graphql/client.tsx
+++ b/app/graphql/client.tsx
@@ -34,6 +34,7 @@ import { NetworkErrorContextProvider } from "./network-error-context"
 import { onError } from "@apollo/client/link/error"
 
 import { getLanguageFromString, getLocaleFromLanguage } from "@app/utils/locale-detector"
+import { WatchCurrencySync } from "@app/components/watch-currency-sync"
 import { MessagingContainer } from "./messaging"
 import { SCHEMA_VERSION_KEY } from "@app/config"
 import { NetworkError } from "@apollo/client/errors"
@@ -335,6 +336,7 @@ const GaloyClient: React.FC<PropsWithChildren> = ({ children }) => {
             <LanguageSync />
             <AnalyticsContainer />
             <MyPriceUpdates />
+            <WatchCurrencySync />
             {children}
           </NetworkErrorContextProvider>
         </LevelContainer>

--- a/app/utils/watch.ts
+++ b/app/utils/watch.ts
@@ -1,0 +1,32 @@
+import { NativeModules } from "react-native"
+
+export type WatchCurrencyData = {
+  currencyCode: string
+  currencySymbol: string
+  fractionDigits: number
+}
+
+const { WatchConnectivityBridge } = NativeModules as {
+  WatchConnectivityBridge?: {
+    syncCurrency: (data: WatchCurrencyData) => Promise<void>
+  }
+}
+
+/**
+ * Pushes the user's display currency to the paired Apple Watch so the Flash
+ * watch app and complication render BTC in the same currency as the phone. The
+ * watch fetches the price itself, so this only carries the currency preference.
+ *
+ * Best-effort: iOS-only, and a no-op when the module isn't in the binary or no
+ * watch is paired. Failures are swallowed — the watch falls back to USD.
+ */
+export const setWatchCurrency = async (data: WatchCurrencyData): Promise<void> => {
+  try {
+    if (!WatchConnectivityBridge?.syncCurrency) {
+      return
+    }
+    await WatchConnectivityBridge.syncCurrency(data)
+  } catch {
+    // ignore — the watch falls back to its own currency (USD by default)
+  }
+}

--- a/ios/FlashWatch Watch App/ContentView.swift
+++ b/ios/FlashWatch Watch App/ContentView.swift
@@ -1,0 +1,139 @@
+//
+//  ContentView.swift
+//  FlashWatch
+//
+//  The watch app's single screen: a big, glanceable BTC price in the user's
+//  display currency, the last-updated time, a manual refresh, and Scan/Receive
+//  quick actions that hand off to the iPhone.
+//
+
+import SwiftUI
+
+enum FlashStyle {
+  static let accent = Color(red: 0.0, green: 0.78, blue: 0.55) // Flash green
+  static let secondary = Color.primary.opacity(0.6)
+}
+
+struct ContentView: View {
+  @ObservedObject private var connectivity = PhoneConnectivity.shared
+  @State private var snapshot = WatchStore.read()
+  @State private var isRefreshing = false
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: 12) {
+        priceCard
+        actions
+        footer
+      }
+      .padding(.horizontal, 4)
+    }
+    .navigationTitle("Flash")
+    .task { await refresh() }
+    // Re-fetch in the new currency when the phone pushes a preference change.
+    .onChange(of: connectivity.currencyRevision) { _ in
+      snapshot = WatchStore.read()
+      Task { await refresh() }
+    }
+  }
+
+  // MARK: - Sections
+
+  private var priceCard: some View {
+    VStack(spacing: 4) {
+      HStack(spacing: 4) {
+        Image(systemName: "bitcoinsign.circle.fill")
+          .foregroundColor(FlashStyle.accent)
+        Text("BTC")
+          .font(.caption).fontWeight(.semibold)
+          .foregroundColor(FlashStyle.secondary)
+      }
+      Text(snapshot.hasPrice ? snapshot.formattedPrice : "—")
+        .font(.system(size: 30, weight: .bold, design: .rounded))
+        .minimumScaleFactor(0.5)
+        .lineLimit(1)
+      Text(snapshot.currencyCode)
+        .font(.caption2)
+        .foregroundColor(FlashStyle.secondary)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 10)
+    .background(FlashStyle.accent.opacity(0.12))
+    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+  }
+
+  private var actions: some View {
+    HStack(spacing: 8) {
+      QuickAction(title: "Scan", systemImage: "qrcode.viewfinder") {
+        connectivity.requestQuickAction("scan")
+      }
+      QuickAction(title: "Receive", systemImage: "qrcode") {
+        connectivity.requestQuickAction("receive")
+      }
+    }
+  }
+
+  private var footer: some View {
+    HStack(spacing: 6) {
+      if isRefreshing {
+        ProgressView().scaleEffect(0.7)
+      } else {
+        Button {
+          Task { await refresh() }
+        } label: {
+          Image(systemName: "arrow.clockwise")
+        }
+        .buttonStyle(.plain)
+        .foregroundColor(FlashStyle.accent)
+      }
+      Text(lastUpdatedText)
+        .font(.caption2)
+        .foregroundColor(FlashStyle.secondary)
+    }
+    .padding(.top, 2)
+  }
+
+  // MARK: - Helpers
+
+  private var lastUpdatedText: String {
+    guard let date = snapshot.updatedAt else { return "Tap to refresh" }
+    let formatter = RelativeDateTimeFormatter()
+    formatter.unitsStyle = .short
+    return "Updated \(formatter.localizedString(for: date, relativeTo: Date()))"
+  }
+
+  @MainActor
+  private func refresh() async {
+    guard !isRefreshing else { return }
+    isRefreshing = true
+    snapshot = await PriceService.fetch(previous: snapshot)
+    isRefreshing = false
+  }
+}
+
+private struct QuickAction: View {
+  let title: String
+  let systemImage: String
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      VStack(spacing: 4) {
+        Image(systemName: systemImage)
+          .font(.system(size: 18, weight: .semibold))
+        Text(title)
+          .font(.caption2).fontWeight(.semibold)
+      }
+      .frame(maxWidth: .infinity)
+      .padding(.vertical, 8)
+    }
+    .buttonStyle(.plain)
+    .background(FlashStyle.accent.opacity(0.15))
+    .foregroundColor(FlashStyle.accent)
+    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+  }
+}
+
+#Preview {
+  ContentView()
+}

--- a/ios/FlashWatch Watch App/FlashWatch.entitlements
+++ b/ios/FlashWatch Watch App/FlashWatch.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.lnflash.watch</string>
+	</array>
+</dict>
+</plist>

--- a/ios/FlashWatch Watch App/FlashWatchApp.swift
+++ b/ios/FlashWatch Watch App/FlashWatchApp.swift
@@ -1,0 +1,27 @@
+//
+//  FlashWatchApp.swift
+//  FlashWatch
+//
+//  Entry point for the Flash watchOS app. Activates WatchConnectivity on launch
+//  so the watch picks up the iPhone's display-currency preference, then shows
+//  the live BTC price.
+//
+
+import SwiftUI
+
+@main
+struct FlashWatchApp: App {
+  @WKApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+    }
+  }
+}
+
+final class AppDelegate: NSObject, WKApplicationDelegate {
+  func applicationDidFinishLaunching() {
+    PhoneConnectivity.shared.activate()
+  }
+}

--- a/ios/FlashWatch Watch App/Info.plist
+++ b/ios/FlashWatch Watch App/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>Flash</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>WKApplication</key>
+	<true/>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>com.lnflash</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>

--- a/ios/FlashWatch Watch App/PhoneConnectivity.swift
+++ b/ios/FlashWatch Watch App/PhoneConnectivity.swift
@@ -1,0 +1,85 @@
+//
+//  PhoneConnectivity.swift
+//  FlashWatch
+//
+//  Watch-side WatchConnectivity session. Two jobs:
+//
+//   1. Receive the user's display-currency preference from the paired iPhone
+//      (pushed via `updateApplicationContext` by WatchConnectivityBridge on the
+//      app side). This is best-effort personalization: the watch works fine on
+//      its own (USD) until the phone delivers the preference.
+//
+//   2. Send quick-action requests ("scan" / "receive") to the iPhone so it can
+//      open the matching screen via its existing `flash://` deep links.
+//
+//  The watch never needs the phone to be reachable to show a price — it fetches
+//  that itself. Connectivity is purely for currency sync + handing actions off.
+//
+
+import Foundation
+import WatchConnectivity
+
+final class PhoneConnectivity: NSObject, ObservableObject {
+  static let shared = PhoneConnectivity()
+
+  /// Bumped whenever the currency changes so SwiftUI can re-fetch the price.
+  @Published private(set) var currencyRevision: Int = 0
+
+  private var session: WCSession? {
+    WCSession.isSupported() ? WCSession.default : nil
+  }
+
+  func activate() {
+    guard let session else { return }
+    session.delegate = self
+    session.activate()
+  }
+
+  /// Ask the iPhone to open one of its deep-linked screens. No-op if the phone
+  /// isn't reachable; the user can always open the app on the phone manually.
+  func requestQuickAction(_ action: String) {
+    guard let session, session.isReachable else { return }
+    session.sendMessage(["action": action], replyHandler: nil, errorHandler: nil)
+  }
+
+  private func applyContext(_ context: [String: Any]) {
+    guard
+      let code = context["currencyCode"] as? String,
+      let symbol = context["currencySymbol"] as? String
+    else { return }
+    let fractionDigits = (context["fractionDigits"] as? NSNumber)?.intValue ?? 2
+
+    let previous = WatchStore.read()
+    guard
+      previous.currencyCode != code
+        || previous.currencySymbol != symbol
+        || previous.fractionDigits != fractionDigits
+    else { return }
+
+    WatchStore.writeCurrency(code: code, symbol: symbol, fractionDigits: fractionDigits)
+    DispatchQueue.main.async { self.currencyRevision += 1 }
+  }
+}
+
+extension PhoneConnectivity: WCSessionDelegate {
+  func session(
+    _ session: WCSession,
+    activationDidCompleteWith state: WCSessionActivationState,
+    error: Error?
+  ) {
+    // The phone may have delivered the latest currency while we were inactive.
+    if !session.receivedApplicationContext.isEmpty {
+      applyContext(session.receivedApplicationContext)
+    }
+  }
+
+  func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
+    applyContext(applicationContext)
+  }
+
+  func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
+    if message["currencyCode"] != nil {
+      applyContext(message)
+    }
+  }
+}

--- a/ios/FlashWatch Watch App/PriceService.swift
+++ b/ios/FlashWatch Watch App/PriceService.swift
@@ -1,0 +1,107 @@
+//
+//  PriceService.swift
+//  FlashWatch
+//
+//  Lets the watch app and its complication fetch a fresh BTC price on their own
+//  — even when the iPhone is away — using the public, unauthenticated
+//  `realtimePrice` GraphQL query. The currency + fractionDigits come from the
+//  last snapshot (seeded by the phone over WatchConnectivity, or defaulting to
+//  USD), so the watch always renders in the user's chosen display currency.
+//
+//  This intentionally mirrors ios/FlashWidget/PriceService.swift; the watch is a
+//  separate target/device, so the code is duplicated rather than shared.
+//
+
+import Foundation
+#if canImport(WidgetKit)
+import WidgetKit
+#endif
+
+enum PriceService {
+  /// Production Flash GraphQL endpoint (see app/config/galoy-instances.ts → "Main").
+  static let endpoint = URL(string: "https://api.flashapp.me/graphql")!
+
+  static let query = """
+  query realtimePriceUnauthed($currency: DisplayCurrency!) {
+    realtimePrice(currency: $currency) {
+      timestamp
+      btcSatPrice { base offset }
+      denominatorCurrency
+    }
+  }
+  """
+
+  /// Fetches the latest price for the currency stored in `previous`, converts it
+  /// to a major-unit BTC price, persists it to `WatchStore`, reloads any
+  /// complications, and returns the new snapshot. Falls back to `previous` on
+  /// any failure so the UI never blanks out once it has data.
+  static func fetch(
+    previous: PriceSnapshot,
+    completion: @escaping (PriceSnapshot) -> Void
+  ) {
+    var request = URLRequest(url: endpoint)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.timeoutInterval = 12
+
+    let body: [String: Any] = [
+      "query": query,
+      "variables": ["currency": previous.currencyCode],
+    ]
+    guard let data = try? JSONSerialization.data(withJSONObject: body) else {
+      completion(previous)
+      return
+    }
+    request.httpBody = data
+
+    URLSession.shared.dataTask(with: request) { data, _, _ in
+      guard
+        let data = data,
+        let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let dataObj = json["data"] as? [String: Any],
+        let realtime = dataObj["realtimePrice"] as? [String: Any],
+        let btcSat = realtime["btcSatPrice"] as? [String: Any],
+        let base = (btcSat["base"] as? NSNumber)?.doubleValue,
+        let offset = (btcSat["offset"] as? NSNumber)?.doubleValue
+      else {
+        completion(previous)
+        return
+      }
+
+      // displayCurrencyPerSat is in the display currency's MINOR units per sat.
+      // 1 BTC = 100,000,000 sats → major-unit price = perSat * 1e8 / 10^fractionDigits.
+      let displayCurrencyPerSat = base / pow(10, offset)
+      let btcPrice =
+        displayCurrencyPerSat * 100_000_000 / pow(10, Double(previous.fractionDigits))
+      let ts = (realtime["timestamp"] as? NSNumber)?.doubleValue ?? Date().timeIntervalSince1970
+
+      let snapshot = PriceSnapshot(
+        btcPrice: btcPrice,
+        currencyCode: previous.currencyCode,
+        currencySymbol: previous.currencySymbol,
+        fractionDigits: previous.fractionDigits,
+        timestamp: ts
+      )
+      WatchStore.write(snapshot)
+      reloadComplications()
+      completion(snapshot)
+    }.resume()
+  }
+
+  /// async/await convenience for the SwiftUI view layer.
+  static func fetch(previous: PriceSnapshot) async -> PriceSnapshot {
+    await withCheckedContinuation { continuation in
+      fetch(previous: previous) { snapshot in
+        continuation.resume(returning: snapshot)
+      }
+    }
+  }
+
+  static func reloadComplications() {
+    #if canImport(WidgetKit)
+    if #available(watchOS 9.0, *) {
+      WidgetCenter.shared.reloadAllTimelines()
+    }
+    #endif
+  }
+}

--- a/ios/FlashWatch Watch App/WatchStore.swift
+++ b/ios/FlashWatch Watch App/WatchStore.swift
@@ -1,0 +1,115 @@
+//
+//  WatchStore.swift
+//  FlashWatch
+//
+//  Reads/writes the BTC price snapshot shared between the watch app and its
+//  complication via an App Group UserDefaults suite. This is a *watch-local*
+//  App Group — the iOS app group (group.com.lnflash) lives on a different
+//  device and cannot be reached from the watch.
+//
+//  The snapshot is populated two ways:
+//   1. The watch app / complication fetch it themselves via `PriceService`
+//      (public, unauthenticated query — works even with the phone away).
+//   2. The paired iPhone pushes the user's chosen display currency through
+//      WatchConnectivity (see PhoneConnectivity.swift), so the watch renders
+//      in the same currency as the phone instead of defaulting to USD.
+//
+//  Mirrors ios/FlashWidget/SharedStore.swift so the two stay conceptually in
+//  sync.
+//
+
+import Foundation
+
+enum WatchStore {
+  /// Must match the App Group id enabled on BOTH the watch app target and the
+  /// complication extension target (see FlashWatch.entitlements). This is a
+  /// distinct group from the iOS app's `group.com.lnflash`.
+  static let appGroupId = "group.com.lnflash.watch"
+
+  enum Key {
+    static let btcPrice = "btcPrice"
+    static let currencyCode = "currencyCode"
+    static let currencySymbol = "currencySymbol"
+    static let fractionDigits = "fractionDigits"
+    static let timestamp = "timestamp"
+  }
+
+  static var defaults: UserDefaults? {
+    UserDefaults(suiteName: appGroupId)
+  }
+
+  static func read() -> PriceSnapshot {
+    let d = defaults
+    return PriceSnapshot(
+      btcPrice: d?.double(forKey: Key.btcPrice) ?? 0,
+      currencyCode: d?.string(forKey: Key.currencyCode) ?? "USD",
+      currencySymbol: d?.string(forKey: Key.currencySymbol) ?? "$",
+      // `object(forKey:) == nil` lets us default to 2 instead of 0 on first run.
+      fractionDigits: (d?.object(forKey: Key.fractionDigits) as? Int) ?? 2,
+      timestamp: d?.double(forKey: Key.timestamp) ?? 0
+    )
+  }
+
+  static func write(_ snapshot: PriceSnapshot) {
+    guard let d = defaults else { return }
+    d.set(snapshot.btcPrice, forKey: Key.btcPrice)
+    d.set(snapshot.currencyCode, forKey: Key.currencyCode)
+    d.set(snapshot.currencySymbol, forKey: Key.currencySymbol)
+    d.set(snapshot.fractionDigits, forKey: Key.fractionDigits)
+    d.set(snapshot.timestamp, forKey: Key.timestamp)
+  }
+
+  /// Updates only the currency fields (used when the phone pushes the user's
+  /// display currency but no fresh price). Keeps the last known price so the UI
+  /// never blanks out, then lets the next fetch reprice in the new currency.
+  static func writeCurrency(code: String, symbol: String, fractionDigits: Int) {
+    guard let d = defaults else { return }
+    d.set(code, forKey: Key.currencyCode)
+    d.set(symbol, forKey: Key.currencySymbol)
+    d.set(fractionDigits, forKey: Key.fractionDigits)
+  }
+}
+
+struct PriceSnapshot: Equatable {
+  var btcPrice: Double
+  var currencyCode: String
+  var currencySymbol: String
+  var fractionDigits: Int
+  var timestamp: Double
+
+  var hasPrice: Bool { btcPrice > 0 }
+
+  var updatedAt: Date? {
+    timestamp > 0 ? Date(timeIntervalSince1970: timestamp) : nil
+  }
+
+  /// e.g. "$67,231" or "$67,231.50" depending on the currency's fraction digits.
+  var formattedPrice: String {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    formatter.maximumFractionDigits = fractionDigits
+    formatter.minimumFractionDigits = fractionDigits
+    let number = formatter.string(from: NSNumber(value: btcPrice)) ?? "—"
+    return "\(currencySymbol)\(number)"
+  }
+
+  /// Compact form for tight complication slots, e.g. "$67.2k" or "$1.05M".
+  var compactPrice: String {
+    guard hasPrice else { return "—" }
+    let value = btcPrice
+    let (scaled, suffix): (Double, String)
+    switch value {
+    case 1_000_000...:
+      (scaled, suffix) = (value / 1_000_000, "M")
+    case 1_000...:
+      (scaled, suffix) = (value / 1_000, "k")
+    default:
+      (scaled, suffix) = (value, "")
+    }
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    formatter.maximumFractionDigits = suffix.isEmpty ? 0 : 1
+    let number = formatter.string(from: NSNumber(value: scaled)) ?? "—"
+    return "\(currencySymbol)\(number)\(suffix)"
+  }
+}

--- a/ios/FlashWatch/SETUP.md
+++ b/ios/FlashWatch/SETUP.md
@@ -1,0 +1,143 @@
+# Flash watchOS app + complication — Xcode setup
+
+All Swift sources, `Info.plist`s, and entitlements are scaffolded on disk. The
+remaining steps create the two watch targets and wire the files into Xcode
+(these edit `project.pbxproj`, so they're done in the GUI to avoid corrupting
+it — same approach as `ios/FlashWidget/SETUP.md`). Do everything in
+`ios/LNFlash.xcworkspace`, **not** the `.xcodeproj`.
+
+> **What ships here**
+> - `ios/FlashWatch Watch App/` — the SwiftUI watch app (live BTC price, refresh, Scan/Receive hand-off).
+> - `ios/FlashWatchComplication/` — a WidgetKit complication (circular, inline, rectangular, corner).
+> - `ios/LNFlash/WatchConnectivityBridge.{swift,m}` — phone-side RN module that pushes the user's display currency to the watch and opens `flash://` deep links from watch quick-actions.
+> - `app/utils/watch.ts` + `app/components/watch-currency-sync/` — JS that calls the bridge (already mounted in `app/graphql/client.tsx`).
+
+## Architecture (why it's built this way)
+
+- The watch is a **separate device**, so it can't read the iOS App Group
+  `group.com.lnflash`. Instead the watch app and its complication share a
+  **watch-local** App Group, `group.com.lnflash.watch`.
+- The watch **fetches the BTC price itself** from the public, unauthenticated
+  `realtimePrice` GraphQL query (`https://api.flashapp.me/graphql`) — the same
+  query the home-screen widget uses. So it shows a price even with the phone
+  away and before the user logs in (defaults to USD).
+- **WatchConnectivity** carries only the user's *display currency* from phone →
+  watch, so the watch reprices in the user's chosen currency. This is
+  best-effort personalization; the watch is fully functional without it.
+- The complication uses **WidgetKit accessory families** (watchOS 9+). ClockKit
+  is deprecated and is not used.
+
+## 1. Add the phone-side bridge to the app target
+
+The native module that pushes currency to the watch lives in the **main app**
+target.
+
+1. In Xcode, right-click the `LNFlash` group → **Add Files to "LNFlash"…**
+2. Select `ios/LNFlash/WatchConnectivityBridge.swift` and
+   `ios/LNFlash/WatchConnectivityBridge.m`.
+3. **Target membership = LNFlash** (the app), **not** any watch target.
+   - The project already has a bridging header (`LNFlash-Bridging-Header.h`), so
+     no new-header prompt should appear. If it does, **Don't create**.
+
+## 2. Create the watch app target
+
+1. **File → New → Target… → watchOS → App** → **Next**.
+2. Product Name: **FlashWatch**. Interface: **SwiftUI**. Language: **Swift**.
+   Uncheck "Include Notification Scene". For "Include Complication", see step 3
+   (we add our own WidgetKit extension, so you can leave it unchecked).
+3. Set the watch app's bundle id to **`com.lnflash.watchkitapp`** and confirm
+   its **WKCompanionAppBundleIdentifier** points at the app (`com.lnflash`) —
+   the provided `Info.plist` already sets this. Team: your usual signing team.
+   **Finish**.
+4. When asked to **Activate "FlashWatch" scheme?** → **Activate**.
+5. Xcode generates a `FlashWatch Watch App/` group with a starter
+   `FlashWatchApp.swift`, `ContentView.swift`, `Assets.xcassets`, and
+   `Info.plist`. **Delete** the generated `FlashWatchApp.swift` and
+   `ContentView.swift` (Move to Trash) — we provide our own. Keep the generated
+   `Assets.xcassets` (add an `AccentColor` / app icon as desired).
+
+## 3. Add the scaffolded watch-app sources
+
+Add these (already on disk in `ios/FlashWatch Watch App/`) with **Target
+membership = FlashWatch Watch App** only:
+
+- `FlashWatchApp.swift`
+- `ContentView.swift`
+- `PriceService.swift`
+- `WatchStore.swift`
+- `PhoneConnectivity.swift`
+
+Use the provided `Info.plist` (replace the generated one, or point the target's
+**Info.plist File** build setting at `FlashWatch Watch App/Info.plist`).
+
+## 4. Create the complication (WidgetKit) extension
+
+1. **File → New → Target… → watchOS → Widget Extension** → **Next**.
+2. Product Name: **FlashWatchComplication**. Uncheck "Include Configuration
+   App Intent" and "Include Live Activity". Embed in: **FlashWatch Watch App**.
+   **Finish** → **Activate** the scheme if prompted.
+3. **Delete** the generated starter widget `.swift` (Move to Trash).
+4. Add these (already on disk in `ios/FlashWatchComplication/`) with **Target
+   membership = FlashWatchComplication** only:
+   - `FlashWatchComplicationBundle.swift`
+   - `ComplicationProvider.swift`
+   - `ComplicationViews.swift`
+5. **Share the model + fetch code** with the complication: select
+   `WatchStore.swift` and `PriceService.swift` (from `FlashWatch Watch App/`)
+   and, in the File Inspector, **also tick `FlashWatchComplication`** under
+   Target Membership. Both targets now compile the same snapshot/fetch logic.
+6. Use the provided `Info.plist` for the extension (it declares the
+   `widgetkit-extension` point).
+
+## 5. App Group capability (both watch targets)
+
+The App Group `group.com.lnflash.watch` is how the watch app and complication
+share the price snapshot. **Do not** reuse the iOS `group.com.lnflash`.
+
+1. Select **FlashWatch Watch App** target → **Signing & Capabilities → +
+   Capability → App Groups** → add/tick `group.com.lnflash.watch`. Point its
+   **Code Signing Entitlements** build setting at
+   `FlashWatch Watch App/FlashWatch.entitlements` (provided).
+2. Select **FlashWatchComplication** target → same: **+ Capability → App
+   Groups** → tick `group.com.lnflash.watch`, and set **Code Signing
+   Entitlements** to `FlashWatchComplication/FlashWatchComplication.entitlements`.
+3. In the Apple Developer portal, create the App Group `group.com.lnflash.watch`
+   and enable it on both watch App IDs (`com.lnflash.watchkitapp` and
+   `com.lnflash.watchkitapp.FlashWatchComplication`). Automatic signing handles
+   the profiles; regenerate manually-managed profiles if you use them.
+
+> The phone-side `WatchConnectivityBridge` needs **no** App Group — it talks to
+> the watch over WatchConnectivity, not shared storage.
+
+## 6. Deployment target
+
+Set both watch targets' **watchOS Deployment Target** to **9.0** or later
+(WidgetKit accessory complications require watchOS 9). watchOS 10+ is fine.
+
+## 7. Build & run
+
+1. `cd ios && pod install` (keeps the workspace consistent; the watch targets
+   need no pods).
+2. Select the **FlashWatch Watch App** scheme + a paired watch
+   simulator/device, build & run. You should see the live BTC price.
+3. Add a complication: on the watch, long-press the face → **Edit** → pick a
+   complication slot → choose **Flash**. Try the circular, rectangular, inline,
+   and corner faces.
+4. Currency sync: run the **LNFlash** app on the paired phone while logged in
+   and change your display currency in Settings — `WatchCurrencySync` pushes it
+   over, and the watch reprices on its next refresh.
+5. Quick actions: tap **Scan** / **Receive** in the watch app. When the phone is
+   reachable the bridge opens `flash://scan` / `flash://receive` on the phone.
+
+## Notes
+
+- **Self-refresh** uses the public unauthenticated `realtimePrice` query, so the
+  watch and complication show a price even before login (USD until the phone
+  pushes the user's currency). WidgetKit budgets watch refreshes; the
+  complication asks for one roughly every 20 minutes.
+- The `flash://scan` / `flash://receive` deep links resolve via the app's
+  existing React Navigation `linking` config (`PREFIX_LINKING` already includes
+  `flash://`). If a given screen route isn't registered, the action simply opens
+  the app — no crash.
+- Only the primary `com.lnflash` target gets the watch app. To attach it to
+  `LNFlash-Alt`, repeat the embed + App Group wiring for that target.

--- a/ios/FlashWatchComplication/ComplicationProvider.swift
+++ b/ios/FlashWatchComplication/ComplicationProvider.swift
@@ -1,0 +1,49 @@
+//
+//  ComplicationProvider.swift
+//  FlashWatchComplication
+//
+//  Supplies timeline entries to WidgetKit on the watch. Each refresh reads the
+//  last snapshot from the shared WatchStore, then attempts a live refresh via
+//  PriceService so the complication stays current even when the watch app isn't
+//  open. WidgetKit budgets watch refreshes, so we ask for one roughly every
+//  20 minutes.
+//
+
+import WidgetKit
+import SwiftUI
+
+struct ComplicationEntry: TimelineEntry {
+  let date: Date
+  let snapshot: PriceSnapshot
+}
+
+struct ComplicationProvider: TimelineProvider {
+  func placeholder(in context: Context) -> ComplicationEntry {
+    ComplicationEntry(
+      date: Date(),
+      snapshot: PriceSnapshot(
+        btcPrice: 67231,
+        currencyCode: "USD",
+        currencySymbol: "$",
+        fractionDigits: 2,
+        timestamp: Date().timeIntervalSince1970
+      )
+    )
+  }
+
+  func getSnapshot(in context: Context, completion: @escaping (ComplicationEntry) -> Void) {
+    completion(ComplicationEntry(date: Date(), snapshot: WatchStore.read()))
+  }
+
+  func getTimeline(in context: Context, completion: @escaping (Timeline<ComplicationEntry>) -> Void) {
+    let previous = WatchStore.read()
+    let nextRefresh =
+      Calendar.current.date(byAdding: .minute, value: 20, to: Date())
+      ?? Date().addingTimeInterval(1200)
+
+    PriceService.fetch(previous: previous) { snapshot in
+      let entry = ComplicationEntry(date: Date(), snapshot: snapshot)
+      completion(Timeline(entries: [entry], policy: .after(nextRefresh)))
+    }
+  }
+}

--- a/ios/FlashWatchComplication/ComplicationViews.swift
+++ b/ios/FlashWatchComplication/ComplicationViews.swift
@@ -1,0 +1,102 @@
+//
+//  ComplicationViews.swift
+//  FlashWatchComplication
+//
+//  SwiftUI views for each supported accessory family. Tapping any complication
+//  launches the Flash watch app (default behaviour for accessory widgets).
+//
+
+import WidgetKit
+import SwiftUI
+
+private enum ComplicationStyle {
+  static let accent = Color(red: 0.0, green: 0.78, blue: 0.55) // Flash green
+}
+
+struct ComplicationEntryView: View {
+  var entry: ComplicationEntry
+  @Environment(\.widgetFamily) var family
+
+  var body: some View {
+    switch family {
+    case .accessoryInline:
+      InlineView(snapshot: entry.snapshot)
+    case .accessoryCircular:
+      CircularView(snapshot: entry.snapshot)
+    case .accessoryCorner:
+      CornerView(snapshot: entry.snapshot)
+    default:
+      RectangularView(snapshot: entry.snapshot)
+    }
+  }
+}
+
+// MARK: - Inline (single line above/below the time)
+
+private struct InlineView: View {
+  let snapshot: PriceSnapshot
+  var body: some View {
+    // Inline complications render as plain text + an optional SF Symbol.
+    Label("BTC \(snapshot.compactPrice)", systemImage: "bitcoinsign")
+  }
+}
+
+// MARK: - Circular
+
+private struct CircularView: View {
+  let snapshot: PriceSnapshot
+  var body: some View {
+    VStack(spacing: 0) {
+      Image(systemName: "bitcoinsign")
+        .font(.system(size: 11, weight: .bold))
+        .foregroundColor(ComplicationStyle.accent)
+      Text(snapshot.compactPrice)
+        .font(.system(size: 13, weight: .semibold, design: .rounded))
+        .minimumScaleFactor(0.5)
+        .lineLimit(1)
+    }
+    .widgetAccentable()
+  }
+}
+
+// MARK: - Corner
+
+private struct CornerView: View {
+  let snapshot: PriceSnapshot
+  var body: some View {
+    Text(snapshot.compactPrice)
+      .font(.system(size: 14, weight: .semibold, design: .rounded))
+      .minimumScaleFactor(0.5)
+      .widgetCurvesContent()
+      .widgetLabel {
+        Text("BTC")
+      }
+  }
+}
+
+// MARK: - Rectangular
+
+private struct RectangularView: View {
+  let snapshot: PriceSnapshot
+  var body: some View {
+    HStack(spacing: 8) {
+      Image(systemName: "bitcoinsign.circle.fill")
+        .font(.system(size: 22))
+        .foregroundColor(ComplicationStyle.accent)
+        .widgetAccentable()
+      VStack(alignment: .leading, spacing: 1) {
+        Text("Bitcoin")
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundColor(.secondary)
+        Text(snapshot.hasPrice ? snapshot.formattedPrice : "—")
+          .font(.system(size: 17, weight: .bold, design: .rounded))
+          .minimumScaleFactor(0.5)
+          .lineLimit(1)
+        Text(snapshot.currencyCode)
+          .font(.system(size: 10))
+          .foregroundColor(.secondary)
+      }
+      Spacer(minLength: 0)
+    }
+  }
+}

--- a/ios/FlashWatchComplication/FlashWatchComplication.entitlements
+++ b/ios/FlashWatchComplication/FlashWatchComplication.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.lnflash.watch</string>
+	</array>
+</dict>
+</plist>

--- a/ios/FlashWatchComplication/FlashWatchComplicationBundle.swift
+++ b/ios/FlashWatchComplication/FlashWatchComplicationBundle.swift
@@ -1,0 +1,37 @@
+//
+//  FlashWatchComplicationBundle.swift
+//  FlashWatchComplication
+//
+//  Entry point for the watchOS complication, built with WidgetKit (watchOS 9+).
+//  ClockKit is deprecated, so the complication is a `Widget` restricted to the
+//  accessory families that render on watch faces.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct FlashWatchComplicationBundle: WidgetBundle {
+  var body: some Widget {
+    FlashPriceComplication()
+  }
+}
+
+struct FlashPriceComplication: Widget {
+  let kind: String = "FlashPriceComplication"
+
+  var body: some WidgetConfiguration {
+    StaticConfiguration(kind: kind, provider: ComplicationProvider()) { entry in
+      ComplicationEntryView(entry: entry)
+        .containerBackground(for: .widget) { Color.clear }
+    }
+    .configurationDisplayName("Flash BTC Price")
+    .description("Live Bitcoin price on your watch face.")
+    .supportedFamilies([
+      .accessoryCircular,
+      .accessoryInline,
+      .accessoryRectangular,
+      .accessoryCorner,
+    ])
+  }
+}

--- a/ios/FlashWatchComplication/Info.plist
+++ b/ios/FlashWatchComplication/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>Flash</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/ios/LNFlash/WatchConnectivityBridge.m
+++ b/ios/LNFlash/WatchConnectivityBridge.m
@@ -1,0 +1,16 @@
+//
+//  WatchConnectivityBridge.m
+//  LNFlash
+//
+//  Exposes the Swift `WatchConnectivityBridge` class to the React Native bridge.
+//
+
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(WatchConnectivityBridge, NSObject)
+
+RCT_EXTERN_METHOD(syncCurrency:(NSDictionary *)data
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+@end

--- a/ios/LNFlash/WatchConnectivityBridge.swift
+++ b/ios/LNFlash/WatchConnectivityBridge.swift
@@ -1,0 +1,104 @@
+//
+//  WatchConnectivityBridge.swift
+//  LNFlash
+//
+//  React Native native module that talks to the paired Apple Watch over
+//  WatchConnectivity. Two responsibilities:
+//
+//   1. Push the user's display-currency preference to the watch (so the watch
+//      app + complication render BTC in the same currency as the phone). The JS
+//      layer (app/utils/watch.ts) calls `syncCurrency` whenever the display
+//      currency changes.
+//
+//   2. Receive quick-action requests from the watch ("scan" / "receive") and
+//      open the matching `flash://` deep link, reusing the app's existing
+//      React Navigation linking config.
+//
+//  The watch fetches the BTC price itself, so this bridge is best-effort: if the
+//  watch is unpaired or unreachable, currency sync simply no-ops.
+//
+
+import Foundation
+import WatchConnectivity
+import UIKit
+
+@objc(WatchConnectivityBridge)
+class WatchConnectivityBridge: NSObject {
+
+  private var session: WCSession? {
+    WCSession.isSupported() ? WCSession.default : nil
+  }
+
+  override init() {
+    super.init()
+    if let session {
+      session.delegate = self
+      session.activate()
+    }
+  }
+
+  /// Pushes the user's display currency to the watch via `updateApplicationContext`,
+  /// which the system delivers even when the watch app is in the background.
+  @objc(syncCurrency:resolver:rejecter:)
+  func syncCurrency(
+    _ data: NSDictionary,
+    resolver resolve: RCTPromiseResolveBlock,
+    rejecter reject: RCTPromiseRejectBlock
+  ) {
+    guard let session, session.activationState == .activated else {
+      // Not an error: the device may have no paired watch.
+      resolve(nil)
+      return
+    }
+    guard session.isWatchAppInstalled || session.isPaired else {
+      resolve(nil)
+      return
+    }
+
+    let context: [String: Any] = [
+      "currencyCode": data["currencyCode"] as? String ?? "USD",
+      "currencySymbol": data["currencySymbol"] as? String ?? "$",
+      "fractionDigits": (data["fractionDigits"] as? NSNumber)?.intValue ?? 2,
+    ]
+
+    do {
+      try session.updateApplicationContext(context)
+      resolve(nil)
+    } catch {
+      reject("watch_context_failed", error.localizedDescription, error)
+    }
+  }
+
+  @objc
+  static func requiresMainQueueSetup() -> Bool {
+    return false
+  }
+
+  private func handleWatchAction(_ action: String) {
+    let allowed = ["scan", "receive", "home"]
+    guard allowed.contains(action), let url = URL(string: "flash://\(action)") else { return }
+    DispatchQueue.main.async {
+      UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    }
+  }
+}
+
+extension WatchConnectivityBridge: WCSessionDelegate {
+  func session(
+    _ session: WCSession,
+    activationDidCompleteWith state: WCSessionActivationState,
+    error: Error?
+  ) {}
+
+  // Required stubs on iOS so the session can re-activate after a watch switch.
+  func sessionDidBecomeInactive(_ session: WCSession) {}
+  func sessionDidDeactivate(_ session: WCSession) {
+    session.activate()
+  }
+
+  func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
+    if let action = message["action"] as? String {
+      handleWatchAction(action)
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds a native **watchOS app** and a **WidgetKit complication** to Flash that show a live BTC price on the watch and on any watch face. Built to mirror the conventions of the existing home-screen widget (`ios/FlashWidget`).

Linear: **ENG-459** — https://linear.app/island-bitcoin/issue/ENG-459

## Why

Glanceability. Users get the BTC price (in their display currency) on their wrist and watch face without opening the phone app — even when the phone is away.

## How it works

- **Self-contained price fetch** — the watch app and complication call the public, unauthenticated `realtimePrice` GraphQL query (`https://api.flashapp.me/graphql`), the same one the home-screen widget uses. Works before login; defaults to USD.
- **Watch-local App Group** `group.com.lnflash.watch` shares the price snapshot between the watch app and its complication. (The iOS `group.com.lnflash` lives on a different device and can't be reused.)
- **WatchConnectivity** carries the user's display currency phone → watch so the watch reprices in the chosen currency. Best-effort; the watch works standalone without it.
- **Complication** uses WidgetKit accessory families (watchOS 9+): circular, inline, rectangular, corner. ClockKit (deprecated) is not used.
- **Quick actions** — Scan/Receive in the watch app send a message to the phone, which opens `flash://scan` / `flash://receive` via the existing React Navigation linking (`PREFIX_LINKING` already includes `flash://`).

## Files

| Area | Files |
|------|-------|
| Watch app | `ios/FlashWatch Watch App/` — `FlashWatchApp`, `ContentView`, `PriceService`, `WatchStore`, `PhoneConnectivity` |
| Complication | `ios/FlashWatchComplication/` — bundle, provider, accessory views |
| Phone bridge | `ios/LNFlash/WatchConnectivityBridge.{swift,m}` |
| JS glue | `app/utils/watch.ts`, `app/components/watch-currency-sync/` (mounted in `app/graphql/client.tsx`) |
| Docs | `ios/FlashWatch/SETUP.md` |

## Reviewer / merge note

Creating the two watch Xcode targets edits `project.pbxproj`, which (per the widget's `ios/FlashWidget/SETUP.md`) is done in the **Xcode GUI** to avoid corrupting the project file. All Swift sources, `Info.plist`s, and entitlements are scaffolded here; **`ios/FlashWatch/SETUP.md`** has the exact step-by-step (target creation, target membership, App Group, deployment target, build/run + complication install). The JS side is wired and active immediately and no-ops on Android / when no watch is paired.

## Testing

- TypeScript: the JS mirrors the proven `widget-price-sync` pattern; `useDisplayCurrency()` returns the exact `fractionDigits` / `fiatSymbol` / `displayCurrency` fields consumed. (Repo-wide `tsc:check` currently errors with a pre-existing `TS5095` config issue on a clean `main` too — unrelated to this change.)
- Native build is verified manually via `SETUP.md` (CI here has Command Line Tools only, no `xcodebuild`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)