### PR TITLE
feat(flags): gate Bridge top-up/KYC queries behind bridgeTopupEnabled (ENG-465)

### DIFF
--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -4,21 +4,29 @@ import { useAppConfig } from "@app/hooks"
 import { useLevel } from "@app/graphql/level-context"
 
 const DeviceAccountEnabledKey = "deviceAccountEnabledRestAuth"
+const BridgeTopupEnabledKey = "bridgeTopupEnabled"
 
 type FeatureFlags = {
   deviceAccountEnabled: boolean
+  bridgeTopupEnabled: boolean
 }
 
 type RemoteConfig = {
   [DeviceAccountEnabledKey]: boolean
+  [BridgeTopupEnabledKey]: boolean
 }
 
 const defaultRemoteConfig: RemoteConfig = {
   deviceAccountEnabledRestAuth: true,
+  // Default OFF: the Bridge/bank-topup GraphQL fields may not exist on the connected
+  // backend yet. Keep this off until backend support is confirmed, then flip in
+  // Firebase Remote Config. Gates the bridge queries in TopupCashout / AccountType.
+  bridgeTopupEnabled: false,
 }
 
 const defaultFeatureFlags = {
   deviceAccountEnabled: false,
+  bridgeTopupEnabled: false,
 }
 
 getRemoteConfig().setDefaults(defaultRemoteConfig)
@@ -48,7 +56,10 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
         const deviceAccountEnabledRestAuth = getRemoteConfig()
           .getValue(DeviceAccountEnabledKey)
           .asBoolean()
-        setRemoteConfig({ deviceAccountEnabledRestAuth })
+        const bridgeTopupEnabled = getRemoteConfig()
+          .getValue(BridgeTopupEnabledKey)
+          .asBoolean()
+        setRemoteConfig({ deviceAccountEnabledRestAuth, bridgeTopupEnabled })
       } catch (err) {
         console.error("Error fetching remote config: ", err)
       } finally {
@@ -60,6 +71,8 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
   const featureFlags = {
     deviceAccountEnabled:
       remoteConfig.deviceAccountEnabledRestAuth || galoyInstance.id === "Local",
+    bridgeTopupEnabled:
+      remoteConfig.bridgeTopupEnabled || galoyInstance.id === "Local",
   }
 
   if (!remoteConfigReady && currentLevel === "NonAuth") {

--- a/app/screens/account-upgrade-flow/AccountType.tsx
+++ b/app/screens/account-upgrade-flow/AccountType.tsx
@@ -19,6 +19,7 @@ import { ProgressSteps } from "@app/components/account-upgrade-flow"
 import { useLevel } from "@app/graphql/level-context"
 import { useActivityIndicator } from "@app/hooks"
 import { useI18nContext } from "@app/i18n/i18n-react"
+import { useFeatureFlags } from "@app/config/feature-flags-context"
 
 // store
 import { useAppDispatch } from "@app/store/redux"
@@ -33,18 +34,21 @@ const AccountType: React.FC<Props> = ({ navigation }) => {
   const { LL } = useI18nContext()
   const { currentLevel } = useLevel()
   const { toggleActivityIndicator } = useActivityIndicator()
+  const { bridgeTopupEnabled } = useFeatureFlags()
 
   const [bridgeKycModalVisible, setBridgeKycModalVisible] = useState(false)
 
   const [initiateBridgeKyc] = useBridgeInitiateKycMutation()
   const { data: kycStatusData, refetch: refetchKycStatus } = useBridgeKycStatusQuery({
     fetchPolicy: "cache-and-network",
+    skip: !bridgeTopupEnabled,
   })
 
   useFocusEffect(
     useCallback(() => {
+      if (!bridgeTopupEnabled) return
       refetchKycStatus()
-    }, [refetchKycStatus]),
+    }, [bridgeTopupEnabled, refetchKycStatus]),
   )
 
   const bridgeKycStatus = kycStatusData?.bridgeKycStatus

--- a/app/screens/topup-cashout-flow/TopupCashout.tsx
+++ b/app/screens/topup-cashout-flow/TopupCashout.tsx
@@ -28,6 +28,7 @@ import {
 } from "@app/graphql/generated"
 import { useActivityIndicator } from "@app/hooks"
 import { useLevel } from "@app/graphql/level-context"
+import { useFeatureFlags } from "@app/config/feature-flags-context"
 
 type Props = StackScreenProps<RootStackParamList, "TopupCashout">
 
@@ -37,6 +38,7 @@ const TopupCashout: React.FC<Props> = ({ navigation }) => {
   const { currentLevel } = useLevel()
   const { colors } = useTheme().theme
   const { toggleActivityIndicator } = useActivityIndicator()
+  const { bridgeTopupEnabled } = useFeatureFlags()
 
   const [topupModalVisible, setTopupModalVisible] = useState(false)
   const [settleModalVisible, setSettleModalVisible] = useState(false)
@@ -48,17 +50,20 @@ const TopupCashout: React.FC<Props> = ({ navigation }) => {
 
   const { data: kycStatusData, refetch: refetchKycStatus } = useBridgeKycStatusQuery({
     fetchPolicy: "cache-and-network",
+    skip: !bridgeTopupEnabled,
   })
   const { data: externalAccountsData, refetch: refetchExternalAccounts } =
     useBridgeExternalAccountsQuery({
       fetchPolicy: "cache-and-network",
+      skip: !bridgeTopupEnabled,
     })
 
   useFocusEffect(
     useCallback(() => {
+      if (!bridgeTopupEnabled) return
       refetchKycStatus()
       refetchExternalAccounts()
-    }, [refetchKycStatus, refetchExternalAccounts]),
+    }, [bridgeTopupEnabled, refetchKycStatus, refetchExternalAccounts]),
   )
 
   const onRefresh = useCallback(async () => {


### PR DESCRIPTION
## What
Adds a `bridgeTopupEnabled` Firebase Remote Config flag (default **OFF**) and gates the Bridge GraphQL queries behind it with Apollo `skip:`.

- `feature-flags-context.tsx`: new `bridgeTopupEnabled` flag (default off; on for `Local` instance, mirroring `deviceAccountEnabled`)
- `TopupCashout.tsx`: `skip: !bridgeTopupEnabled` on `useBridgeKycStatusQuery` + `useBridgeExternalAccountsQuery`; guard the on-focus refetch
- `AccountType.tsx`: same for `useBridgeKycStatusQuery`

## Why (ENG-465, audit P0)
These queries fire **on mount/focus for every level≥1 user**. If the app reaches users before the backend exposes `bridgeKycStatus` / `bridgeExternalAccounts`, they hit app-wide GraphQL validation errors. The flag lets us keep the UI dark until the backend is ready, and keeps the FE flag in sync with the backend `bridge.enabled`.

## Toggle behavior
- **OFF (default):** queries never fire; no refetch on focus; existing UI renders without bridge data (already null-safe).
- **ON:** unchanged from today.

## Verification
Local full typecheck not run (isolated worktree has no node_modules) — relying on CI. Change is minimal and follows the existing `skip: !deviceAccountEnabled` pattern; `skip` is a standard Apollo query option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)