### PR TITLE
feat(flags): gate cashWalletCutover query behind usdtWalletEnabled (ENG-465)

### DIFF
--- a/app/components/topup-cashout-flow/CashWalletCutoverModal.tsx
+++ b/app/components/topup-cashout-flow/CashWalletCutoverModal.tsx
@@ -6,6 +6,7 @@ import { useI18nContext } from "@app/i18n/i18n-react"
 import { PrimaryBtn } from "@app/components/buttons"
 import DollarIllustration from "@app/assets/illustrations/dollar.svg"
 import { usePersistentStateContext } from "@app/store/persistent-state"
+import { useFeatureFlags } from "@app/config/feature-flags-context"
 import {
   CashWalletCutoverState,
   useCashWalletCutoverQuery,
@@ -18,7 +19,8 @@ const CashWalletCutoverModal = () => {
   const { width } = useWindowDimensions()
   const { colors } = useTheme().theme
   const { persistentState, updateState } = usePersistentStateContext()
-  const { data: cutoverData } = useCashWalletCutoverQuery()
+  const { usdtWalletEnabled } = useFeatureFlags()
+  const { data: cutoverData } = useCashWalletCutoverQuery({ skip: !usdtWalletEnabled })
   const { data: meData } = useHomeAuthedQuery()
 
   const cutoverState = cutoverData?.cashWalletCutover?.state

--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -4,21 +4,29 @@ import { useAppConfig } from "@app/hooks"
 import { useLevel } from "@app/graphql/level-context"
 
 const DeviceAccountEnabledKey = "deviceAccountEnabledRestAuth"
+const UsdtWalletEnabledKey = "usdtWalletEnabled"
 
 type FeatureFlags = {
   deviceAccountEnabled: boolean
+  usdtWalletEnabled: boolean
 }
 
 type RemoteConfig = {
   [DeviceAccountEnabledKey]: boolean
+  [UsdtWalletEnabledKey]: boolean
 }
 
 const defaultRemoteConfig: RemoteConfig = {
   deviceAccountEnabledRestAuth: true,
+  // Default OFF: the USDT cutover GraphQL field may not exist on the connected
+  // backend yet. Keep this off until backend support is confirmed, then flip in
+  // Firebase Remote Config. Gates the cashWalletCutover query.
+  usdtWalletEnabled: false,
 }
 
 const defaultFeatureFlags = {
   deviceAccountEnabled: false,
+  usdtWalletEnabled: false,
 }
 
 getRemoteConfig().setDefaults(defaultRemoteConfig)
@@ -48,7 +56,10 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
         const deviceAccountEnabledRestAuth = getRemoteConfig()
           .getValue(DeviceAccountEnabledKey)
           .asBoolean()
-        setRemoteConfig({ deviceAccountEnabledRestAuth })
+        const usdtWalletEnabled = getRemoteConfig()
+          .getValue(UsdtWalletEnabledKey)
+          .asBoolean()
+        setRemoteConfig({ deviceAccountEnabledRestAuth, usdtWalletEnabled })
       } catch (err) {
         console.error("Error fetching remote config: ", err)
       } finally {
@@ -60,6 +71,8 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
   const featureFlags = {
     deviceAccountEnabled:
       remoteConfig.deviceAccountEnabledRestAuth || galoyInstance.id === "Local",
+    usdtWalletEnabled:
+      remoteConfig.usdtWalletEnabled || galoyInstance.id === "Local",
   }
 
   if (!remoteConfigReady && currentLevel === "NonAuth") {


### PR DESCRIPTION
## What
Adds a `usdtWalletEnabled` Firebase Remote Config flag (default **OFF**) and gates the USDT cutover query behind it.

- `feature-flags-context.tsx`: new `usdtWalletEnabled` flag (default off; on for `Local`)
- `CashWalletCutoverModal.tsx`: `useCashWalletCutoverQuery({ skip: !usdtWalletEnabled })`

## Why (ENG-465, audit P0)
`cashWalletCutover` is queried from the home screen for every account. If the app reaches users before the backend exposes the field, they hit GraphQL validation errors. The modal already hides when the data is null, so with the flag OFF this is a clean no-op.

## Toggle behavior
- **OFF (default):** query never fires; modal never shows.
- **ON:** unchanged from today.

## Verification
Local full typecheck not run (isolated worktree has no node_modules) — relying on CI. Minimal change following the existing `skip: !deviceAccountEnabled` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)