### PR TITLE
feat(flags): gate Bridge top-up/KYC queries behind bridgeTopupEnabled (ENG-465)

### DIFF
--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -4,21 +4,29 @@ import { useAppConfig } from "@app/hooks"
 import { useLevel } from "@app/graphql/level-context"
 
 const DeviceAccountEnabledKey = "deviceAccountEnabledRestAuth"
+const BridgeTopupEnabledKey = "bridgeTopupEnabled"
 
 type FeatureFlags = {
   deviceAccountEnabled: boolean
+  bridgeTopupEnabled: boolean
 }
 
 type RemoteConfig = {
   [DeviceAccountEnabledKey]: boolean
+  [BridgeTopupEnabledKey]: boolean
 }
 
 const defaultRemoteConfig: RemoteConfig = {
   deviceAccountEnabledRestAuth: true,
+  // Client kill switch for the Bridge top-up / KYC flow. Default OFF: keep the
+  // bridge queries dark until the backend bridge is confirmed enabled for the
+  // cohort, then flip in Firebase Remote Config. Gates TopupCashout / AccountType.
+  bridgeTopupEnabled: false,
 }
 
 const defaultFeatureFlags = {
   deviceAccountEnabled: false,
+  bridgeTopupEnabled: false,
 }
 
 getRemoteConfig().setDefaults(defaultRemoteConfig)
@@ -48,7 +56,10 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
         const deviceAccountEnabledRestAuth = getRemoteConfig()
           .getValue(DeviceAccountEnabledKey)
           .asBoolean()
-        setRemoteConfig({ deviceAccountEnabledRestAuth })
+        const bridgeTopupEnabled = getRemoteConfig()
+          .getValue(BridgeTopupEnabledKey)
+          .asBoolean()
+        setRemoteConfig({ deviceAccountEnabledRestAuth, bridgeTopupEnabled })
       } catch (err) {
         console.error("Error fetching remote config: ", err)
       } finally {
@@ -60,6 +71,8 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
   const featureFlags = {
     deviceAccountEnabled:
       remoteConfig.deviceAccountEnabledRestAuth || galoyInstance.id === "Local",
+    bridgeTopupEnabled:
+      remoteConfig.bridgeTopupEnabled || galoyInstance.id === "Local",
   }
 
   if (!remoteConfigReady && currentLevel === "NonAuth") {

--- a/app/screens/account-upgrade-flow/AccountType.tsx
+++ b/app/screens/account-upgrade-flow/AccountType.tsx
@@ -19,6 +19,7 @@ import { ProgressSteps } from "@app/components/account-upgrade-flow"
 import { useLevel } from "@app/graphql/level-context"
 import { useActivityIndicator } from "@app/hooks"
 import { useI18nContext } from "@app/i18n/i18n-react"
+import { useFeatureFlags } from "@app/config/feature-flags-context"
 
 // store
 import { useAppDispatch } from "@app/store/redux"
@@ -33,18 +34,21 @@ const AccountType: React.FC<Props> = ({ navigation }) => {
   const { LL } = useI18nContext()
   const { currentLevel } = useLevel()
   const { toggleActivityIndicator } = useActivityIndicator()
+  const { bridgeTopupEnabled } = useFeatureFlags()
 
   const [bridgeKycModalVisible, setBridgeKycModalVisible] = useState(false)
 
   const [initiateBridgeKyc] = useBridgeInitiateKycMutation()
   const { data: kycStatusData, refetch: refetchKycStatus } = useBridgeKycStatusQuery({
     fetchPolicy: "cache-and-network",
+    skip: !bridgeTopupEnabled,
   })
 
   useFocusEffect(
     useCallback(() => {
+      if (!bridgeTopupEnabled) return
       refetchKycStatus()
-    }, [refetchKycStatus]),
+    }, [bridgeTopupEnabled, refetchKycStatus]),
   )
 
   const bridgeKycStatus = kycStatusData?.bridgeKycStatus

--- a/app/screens/topup-cashout-flow/TopupCashout.tsx
+++ b/app/screens/topup-cashout-flow/TopupCashout.tsx
@@ -28,6 +28,7 @@ import {
 } from "@app/graphql/generated"
 import { useActivityIndicator } from "@app/hooks"
 import { useLevel } from "@app/graphql/level-context"
+import { useFeatureFlags } from "@app/config/feature-flags-context"
 
 type Props = StackScreenProps<RootStackParamList, "TopupCashout">
 
@@ -37,6 +38,7 @@ const TopupCashout: React.FC<Props> = ({ navigation }) => {
   const { currentLevel } = useLevel()
   const { colors } = useTheme().theme
   const { toggleActivityIndicator } = useActivityIndicator()
+  const { bridgeTopupEnabled } = useFeatureFlags()
 
   const [topupModalVisible, setTopupModalVisible] = useState(false)
   const [settleModalVisible, setSettleModalVisible] = useState(false)
@@ -48,17 +50,20 @@ const TopupCashout: React.FC<Props> = ({ navigation }) => {
 
   const { data: kycStatusData, refetch: refetchKycStatus } = useBridgeKycStatusQuery({
     fetchPolicy: "cache-and-network",
+    skip: !bridgeTopupEnabled,
   })
   const { data: externalAccountsData, refetch: refetchExternalAccounts } =
     useBridgeExternalAccountsQuery({
       fetchPolicy: "cache-and-network",
+      skip: !bridgeTopupEnabled,
     })
 
   useFocusEffect(
     useCallback(() => {
+      if (!bridgeTopupEnabled) return
       refetchKycStatus()
       refetchExternalAccounts()
-    }, [refetchKycStatus, refetchExternalAccounts]),
+    }, [bridgeTopupEnabled, refetchKycStatus, refetchExternalAccounts]),
   )
 
   const onRefresh = useCallback(async () => {


### PR DESCRIPTION
Folds the ENG-465 client kill switch **into the #621 epic** (`feat/fygaro`).

## What
- `feature-flags-context.tsx`: new `bridgeTopupEnabled` Remote Config flag (default **OFF**; on for `Local`)
- `TopupCashout.tsx` + `AccountType.tsx`: `skip: !bridgeTopupEnabled` on `useBridgeKycStatusQuery` / `useBridgeExternalAccountsQuery` + guard the on-focus refetch

## Why
These bridge queries fire on mount/focus for every level≥1 user. With only the backend `bridge.enabled` toggle, disabling bridge makes resolvers throw → client errors. This adds a client-side kill switch so bridge stays dark (graceful) until flipped on for the beta cohort.

## Scope note
USDT gating is intentionally omitted — the USDT cutover is the deliberate default (flash#413), so `cashWalletCutover` exists on main and needs no client skip. Supersedes the earlier ENG-465 PRs #656/#657, which targeted sibling branches not in this epic.

Local typecheck not run (isolated worktree); relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)