### PR TITLE
fix: convert cash send amounts at API boundary

### DIFF
--- a/__tests__/payment-details/amount-lightning-payment-details.spec.ts
+++ b/__tests__/payment-details/amount-lightning-payment-details.spec.ts
@@ -3,6 +3,7 @@ import * as PaymentDetails from "@app/screens/send-bitcoin-screen/payment-detail
 import {
   btcSendingWalletDescriptor,
   btcTestAmount,
+  convertMoneyAmountWithUsdtMock,
   convertMoneyAmountMock,
   createGetFeeMocks,
   createSendPaymentMocks,
@@ -10,7 +11,9 @@ import {
   getTestSetMemo,
   getTestSetSendingWalletDescriptor,
   usdSendingWalletDescriptor,
+  usdtSendingWalletDescriptor,
 } from "./helpers"
+import { USDT_MICROS_PER_USD_CENT } from "@app/types/amounts"
 
 const defaultParams: PaymentDetails.CreateAmountLightningPaymentDetailsParams<WalletCurrency> =
   {
@@ -150,6 +153,47 @@ describe("amount lightning payment details", () => {
             walletId: usdSendingWalletParams.sendingWalletDescriptor.id,
           },
         },
+      })
+    })
+  })
+
+  describe("sending from a usdt wallet", () => {
+    const usdtSendingWalletParams = {
+      ...defaultParams,
+      convertMoneyAmount: convertMoneyAmountWithUsdtMock,
+      sendingWalletDescriptor: usdtSendingWalletDescriptor,
+    }
+    const paymentDetails = createAmountLightningPaymentDetails(usdtSendingWalletParams)
+
+    it("converts fee probe cents back to USDT micros", async () => {
+      const feeParamsMocks = createGetFeeMocks()
+      ;(feeParamsMocks.lnUsdInvoiceFeeProbe as jest.Mock).mockResolvedValue({
+        data: {
+          lnUsdInvoiceFeeProbe: {
+            amount: 3,
+            errors: [],
+          },
+        },
+      })
+
+      if (!paymentDetails.canGetFee) {
+        throw new Error("Cannot get fee")
+      }
+
+      const fee = await paymentDetails.getFee(feeParamsMocks)
+
+      expect(feeParamsMocks.lnUsdInvoiceFeeProbe).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            paymentRequest: defaultParams.paymentRequest,
+            walletId: usdtSendingWalletParams.sendingWalletDescriptor.id,
+          },
+        },
+      })
+      expect(fee.amount).toEqual({
+        amount: 3 * USDT_MICROS_PER_USD_CENT,
+        currency: WalletCurrency.Usdt,
+        currencyCode: "USDT",
       })
     })
   })

--- a/__tests__/payment-details/helpers.ts
+++ b/__tests__/payment-details/helpers.ts
@@ -6,6 +6,7 @@ import {
   SendPaymentMutationParams,
 } from "@app/screens/send-bitcoin-screen/payment-details"
 import {
+  USDT_MICROS_PER_USD_CENT,
   ZeroBtcMoneyAmount,
   toBtcMoneyAmount,
   toUsdMoneyAmount,
@@ -14,6 +15,25 @@ import {
 export const convertMoneyAmountMock: ConvertMoneyAmount = (amount, currency) => {
   return {
     amount: amount.amount,
+    currency,
+    currencyCode: currency,
+  }
+}
+
+export const convertMoneyAmountWithUsdtMock: ConvertMoneyAmount = (amount, currency) => {
+  let convertedAmount = amount.amount
+
+  if (amount.currency === WalletCurrency.Usd && currency === WalletCurrency.Usdt) {
+    convertedAmount = amount.amount * USDT_MICROS_PER_USD_CENT
+  } else if (
+    amount.currency === WalletCurrency.Usdt &&
+    currency === WalletCurrency.Usd
+  ) {
+    convertedAmount = amount.amount / USDT_MICROS_PER_USD_CENT
+  }
+
+  return {
+    amount: convertedAmount,
     currency,
     currencyCode: currency,
   }
@@ -35,6 +55,11 @@ export const btcSendingWalletDescriptor = {
 export const usdSendingWalletDescriptor = {
   currency: WalletCurrency.Usd,
   id: "testwallet",
+}
+
+export const usdtSendingWalletDescriptor = {
+  currency: WalletCurrency.Usdt,
+  id: "testusdtwallet",
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/__tests__/payment-details/intraledger-payment-details.spec.ts
+++ b/__tests__/payment-details/intraledger-payment-details.spec.ts
@@ -2,6 +2,7 @@ import { WalletCurrency } from "@app/graphql/generated"
 import * as PaymentDetails from "@app/screens/send-bitcoin-screen/payment-details/intraledger"
 import {
   btcSendingWalletDescriptor,
+  convertMoneyAmountWithUsdtMock,
   convertMoneyAmountMock,
   createSendPaymentMocks,
   expectCannotGetFee,
@@ -12,8 +13,13 @@ import {
   getTestSetSendingWalletDescriptor,
   testAmount,
   usdSendingWalletDescriptor,
+  usdtSendingWalletDescriptor,
   zeroAmount,
 } from "./helpers"
+import {
+  toUsdMoneyAmount,
+  USDT_MICROS_PER_USD_CENT,
+} from "@app/types/amounts"
 
 const defaultParams: PaymentDetails.CreateIntraledgerPaymentDetailsParams<WalletCurrency> =
   {
@@ -120,6 +126,45 @@ describe("intraledger payment details", () => {
             recipientWalletId: defaultParams.recipientWalletId,
             amount: settlementAmount.amount,
             walletId: usdSendingWalletParams.sendingWalletDescriptor.id,
+          },
+        },
+      })
+    })
+  })
+
+  describe("sending from a usdt wallet", () => {
+    const unitOfAccountAmount = toUsdMoneyAmount(500)
+    const usdtSendingWalletParams = {
+      ...defaultParams,
+      convertMoneyAmount: convertMoneyAmountWithUsdtMock,
+      unitOfAccountAmount,
+      sendingWalletDescriptor: usdtSendingWalletDescriptor,
+    }
+    const paymentDetails = createIntraledgerPaymentDetails(usdtSendingWalletParams)
+    const settlementAmount = convertMoneyAmountWithUsdtMock(
+      unitOfAccountAmount,
+      WalletCurrency.Usdt,
+    )
+
+    it("uses USD cents for the send payment mutation", async () => {
+      const sendPaymentMocks = createSendPaymentMocks()
+      if (!paymentDetails.canSendPayment) {
+        throw new Error("Cannot send payment")
+      }
+
+      try {
+        await paymentDetails.sendPaymentMutation(sendPaymentMocks)
+      } catch {
+        // do nothing as function is expected to throw since we are not mocking the send payment response
+      }
+
+      expect(settlementAmount.amount).toBe(500 * USDT_MICROS_PER_USD_CENT)
+      expect(sendPaymentMocks.intraLedgerUsdPaymentSend).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            recipientWalletId: defaultParams.recipientWalletId,
+            amount: 500,
+            walletId: usdtSendingWalletParams.sendingWalletDescriptor.id,
           },
         },
       })

--- a/__tests__/payment-details/no-amount-lightning-payment-details.spec.ts
+++ b/__tests__/payment-details/no-amount-lightning-payment-details.spec.ts
@@ -3,6 +3,7 @@ import * as PaymentDetails from "@app/screens/send-bitcoin-screen/payment-detail
 import {
   testAmount,
   btcSendingWalletDescriptor,
+  convertMoneyAmountWithUsdtMock,
   convertMoneyAmountMock,
   createGetFeeMocks,
   createSendPaymentMocks,
@@ -13,8 +14,13 @@ import {
   getTestSetMemo,
   getTestSetSendingWalletDescriptor,
   usdSendingWalletDescriptor,
+  usdtSendingWalletDescriptor,
   zeroAmount,
 } from "./helpers"
+import {
+  toUsdMoneyAmount,
+  USDT_MICROS_PER_USD_CENT,
+} from "@app/types/amounts"
 
 const defaultParams: PaymentDetails.CreateNoAmountLightningPaymentDetailsParams<WalletCurrency> =
   {
@@ -166,6 +172,78 @@ describe("no amount lightning payment details", () => {
             paymentRequest: defaultParams.paymentRequest,
             amount: settlementAmount.amount,
             walletId: usdSendingWalletParams.sendingWalletDescriptor.id,
+          },
+        },
+      })
+    })
+  })
+
+  describe("sending from a usdt wallet", () => {
+    const unitOfAccountAmount = toUsdMoneyAmount(500)
+    const usdtSendingWalletParams = {
+      ...defaultParams,
+      convertMoneyAmount: convertMoneyAmountWithUsdtMock,
+      unitOfAccountAmount,
+      sendingWalletDescriptor: usdtSendingWalletDescriptor,
+    }
+    const paymentDetails = createNoAmountLightningPaymentDetails(usdtSendingWalletParams)
+    const settlementAmount = convertMoneyAmountWithUsdtMock(
+      unitOfAccountAmount,
+      WalletCurrency.Usdt,
+    )
+
+    it("sends USD cents to the backend and converts fee cents back to USDT micros", async () => {
+      const feeParamsMocks = createGetFeeMocks()
+      ;(feeParamsMocks.lnNoAmountUsdInvoiceFeeProbe as jest.Mock).mockResolvedValue({
+        data: {
+          lnNoAmountUsdInvoiceFeeProbe: {
+            amount: 2,
+            errors: [],
+          },
+        },
+      })
+
+      if (!paymentDetails.canGetFee) {
+        throw new Error("Cannot get fee")
+      }
+
+      const fee = await paymentDetails.getFee(feeParamsMocks)
+
+      expect(settlementAmount.amount).toBe(500 * USDT_MICROS_PER_USD_CENT)
+      expect(feeParamsMocks.lnNoAmountUsdInvoiceFeeProbe).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            paymentRequest: defaultParams.paymentRequest,
+            amount: 500,
+            walletId: usdtSendingWalletParams.sendingWalletDescriptor.id,
+          },
+        },
+      })
+      expect(fee.amount).toEqual({
+        amount: 2 * USDT_MICROS_PER_USD_CENT,
+        currency: WalletCurrency.Usdt,
+        currencyCode: "USDT",
+      })
+    })
+
+    it("uses USD cents for the send payment mutation", async () => {
+      const sendPaymentMocks = createSendPaymentMocks()
+      if (!paymentDetails.canSendPayment) {
+        throw new Error("Cannot send payment")
+      }
+
+      try {
+        await paymentDetails.sendPaymentMutation(sendPaymentMocks)
+      } catch {
+        // do nothing as function is expected to throw since we are not mocking the send payment response
+      }
+
+      expect(sendPaymentMocks.lnNoAmountUsdInvoicePaymentSend).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            paymentRequest: defaultParams.paymentRequest,
+            amount: 500,
+            walletId: usdtSendingWalletParams.sendingWalletDescriptor.id,
           },
         },
       })

--- a/__tests__/payment-details/no-amount-onchain.spec.ts
+++ b/__tests__/payment-details/no-amount-onchain.spec.ts
@@ -3,6 +3,7 @@ import * as PaymentDetails from "@app/screens/send-bitcoin-screen/payment-detail
 import {
   testAmount,
   btcSendingWalletDescriptor,
+  convertMoneyAmountWithUsdtMock,
   convertMoneyAmountMock,
   createGetFeeMocks,
   createSendPaymentMocks,
@@ -13,8 +14,13 @@ import {
   getTestSetMemo,
   getTestSetSendingWalletDescriptor,
   usdSendingWalletDescriptor,
+  usdtSendingWalletDescriptor,
   zeroAmount,
 } from "./helpers"
+import {
+  toUsdMoneyAmount,
+  USDT_MICROS_PER_USD_CENT,
+} from "@app/types/amounts"
 
 const defaultParams: PaymentDetails.CreateNoAmountOnchainPaymentDetailsParams<WalletCurrency> =
   {
@@ -163,6 +169,75 @@ describe("no amount lightning payment details", () => {
             address: defaultParams.address,
             amount: settlementAmount.amount,
             walletId: usdSendingWalletParams.sendingWalletDescriptor.id,
+          },
+        },
+      })
+    })
+  })
+
+  describe("sending from a usdt wallet", () => {
+    const unitOfAccountAmount = toUsdMoneyAmount(500)
+    const usdtSendingWalletParams = {
+      ...defaultParams,
+      convertMoneyAmount: convertMoneyAmountWithUsdtMock,
+      unitOfAccountAmount,
+      sendingWalletDescriptor: usdtSendingWalletDescriptor,
+    }
+    const paymentDetails = createNoAmountOnchainPaymentDetails(usdtSendingWalletParams)
+    const settlementAmount = convertMoneyAmountWithUsdtMock(
+      unitOfAccountAmount,
+      WalletCurrency.Usdt,
+    )
+
+    it("uses USD cents for fee requests and converts fee cents back to USDT micros", async () => {
+      const feeParamsMocks = createGetFeeMocks()
+      ;(feeParamsMocks.onChainUsdTxFee as jest.Mock).mockResolvedValue({
+        data: {
+          onChainUsdTxFee: {
+            amount: 4,
+          },
+        },
+      })
+
+      if (!paymentDetails.canGetFee) {
+        throw new Error("Cannot get fee")
+      }
+
+      const fee = await paymentDetails.getFee(feeParamsMocks)
+
+      expect(settlementAmount.amount).toBe(500 * USDT_MICROS_PER_USD_CENT)
+      expect(feeParamsMocks.onChainUsdTxFee).toHaveBeenCalledWith({
+        variables: {
+          address: defaultParams.address,
+          amount: 500,
+          walletId: usdtSendingWalletParams.sendingWalletDescriptor.id,
+        },
+      })
+      expect(fee.amount).toEqual({
+        amount: 4 * USDT_MICROS_PER_USD_CENT,
+        currency: WalletCurrency.Usdt,
+        currencyCode: "USDT",
+      })
+    })
+
+    it("uses USD cents for the send payment mutation", async () => {
+      const sendPaymentMocks = createSendPaymentMocks()
+      if (!paymentDetails.canSendPayment) {
+        throw new Error("Cannot send payment")
+      }
+
+      try {
+        await paymentDetails.sendPaymentMutation(sendPaymentMocks)
+      } catch {
+        // do nothing as function is expected to throw since we are not mocking the send payment response
+      }
+
+      expect(sendPaymentMocks.onChainUsdPaymentSend).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            address: defaultParams.address,
+            amount: 500,
+            walletId: usdtSendingWalletParams.sendingWalletDescriptor.id,
           },
         },
       })

--- a/__tests__/payment-details/utils.spec.ts
+++ b/__tests__/payment-details/utils.spec.ts
@@ -1,0 +1,90 @@
+import { WalletCurrency } from "@app/graphql/generated"
+import {
+  ConvertMoneyAmount,
+  PaymentDetail,
+  isValidAmount,
+} from "@app/screens/send-bitcoin-screen/payment-details"
+import {
+  MoneyAmount,
+  USDT_MICROS_PER_USD_CENT,
+  WalletOrDisplayCurrency,
+  toBtcMoneyAmount,
+  toUsdMoneyAmount,
+} from "@app/types/amounts"
+import { PaymentType } from "@galoymoney/client"
+
+const convertMoneyAmount: ConvertMoneyAmount = <T extends WalletOrDisplayCurrency>(
+  amount: MoneyAmount<WalletOrDisplayCurrency>,
+  currency: T,
+): MoneyAmount<T> => {
+  let convertedAmount = amount.amount
+
+  if (amount.currency === WalletCurrency.Usd && currency === WalletCurrency.Usdt) {
+    convertedAmount = amount.amount * USDT_MICROS_PER_USD_CENT
+  } else if (
+    amount.currency === WalletCurrency.Usdt &&
+    currency === WalletCurrency.Usd
+  ) {
+    convertedAmount = amount.amount / USDT_MICROS_PER_USD_CENT
+  }
+
+  return {
+    amount: convertedAmount,
+    currency,
+    currencyCode: currency,
+  }
+}
+
+const createPaymentDetail = ({
+  settlementAmount,
+}: {
+  settlementAmount: MoneyAmount<WalletCurrency>
+}) =>
+  ({
+    settlementAmount,
+    unitOfAccountAmount: toUsdMoneyAmount(5),
+    paymentType: PaymentType.Intraledger,
+    convertMoneyAmount,
+  }) as PaymentDetail<WalletCurrency>
+
+describe("isValidAmount", () => {
+  it("compares USDT settlement micros against API balance cents", () => {
+    const paymentDetail = createPaymentDetail({
+      settlementAmount: {
+        amount: 5 * USDT_MICROS_PER_USD_CENT,
+        currency: WalletCurrency.Usdt,
+        currencyCode: "USD",
+      },
+    })
+
+    expect(
+      isValidAmount({
+        paymentDetail,
+        usdWalletAmount: toUsdMoneyAmount(124),
+        btcWalletAmount: toBtcMoneyAmount(0),
+      }),
+    ).toEqual({ validAmount: true })
+  })
+
+  it("rejects USDT settlement micros only when they exceed API balance cents", () => {
+    const paymentDetail = createPaymentDetail({
+      settlementAmount: {
+        amount: 125 * USDT_MICROS_PER_USD_CENT,
+        currency: WalletCurrency.Usdt,
+        currencyCode: "USD",
+      },
+    })
+
+    expect(
+      isValidAmount({
+        paymentDetail,
+        usdWalletAmount: toUsdMoneyAmount(124),
+        btcWalletAmount: toBtcMoneyAmount(0),
+      }),
+    ).toEqual({
+      validAmount: false,
+      invalidReason: "InsufficientBalance",
+      balance: toUsdMoneyAmount(124),
+    })
+  })
+})

--- a/app/screens/send-bitcoin-screen/payment-details/intraledger.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/intraledger.ts
@@ -90,7 +90,7 @@ export const createIntraledgerPaymentDetails = <T extends WalletCurrency>(
           input: {
             walletId: sendingWalletDescriptor.id,
             recipientWalletId,
-            amount: settlementAmount.amount,
+            amount: convertMoneyAmount(settlementAmount, WalletCurrency.Usd).amount,
             memo,
           },
         },

--- a/app/screens/send-bitcoin-screen/payment-details/lightning.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/lightning.ts
@@ -3,6 +3,7 @@ import {
   BtcMoneyAmount,
   MoneyAmount,
   toBtcMoneyAmount,
+  toUsdMoneyAmount,
   toWalletAmount,
   WalletAmount,
   WalletOrDisplayCurrency,
@@ -121,7 +122,7 @@ export const createNoAmountLightningPaymentDetails = <T extends WalletCurrency>(
       const { data } = await getFeeFns.lnNoAmountUsdInvoiceFeeProbe({
         variables: {
           input: {
-            amount: settlementAmount.amount,
+            amount: convertMoneyAmount(settlementAmount, WalletCurrency.Usd).amount,
             paymentRequest,
             walletId: sendingWalletDescriptor.id,
           },
@@ -131,10 +132,10 @@ export const createNoAmountLightningPaymentDetails = <T extends WalletCurrency>(
       const rawAmount = data?.lnNoAmountUsdInvoiceFeeProbe.amount
       const amount =
         typeof rawAmount === "number"
-          ? toWalletAmount({
-              amount: rawAmount,
-              currency: sendingWalletDescriptor.currency,
-            })
+          ? convertMoneyAmount(
+              toUsdMoneyAmount(rawAmount),
+              sendingWalletDescriptor.currency,
+            )
           : rawAmount
 
       return {
@@ -149,7 +150,7 @@ export const createNoAmountLightningPaymentDetails = <T extends WalletCurrency>(
           input: {
             walletId: sendingWalletDescriptor.id,
             paymentRequest,
-            amount: settlementAmount.amount,
+            amount: convertMoneyAmount(settlementAmount, WalletCurrency.Usd).amount,
             memo,
           },
         },
@@ -297,10 +298,10 @@ export const createAmountLightningPaymentDetails = <T extends WalletCurrency>(
       const rawAmount = data?.lnUsdInvoiceFeeProbe.amount
       const amount =
         typeof rawAmount === "number"
-          ? toWalletAmount({
-              amount: rawAmount,
-              currency: sendingWalletDescriptor.currency,
-            })
+          ? convertMoneyAmount(
+              toUsdMoneyAmount(rawAmount),
+              sendingWalletDescriptor.currency,
+            )
           : rawAmount
 
       return {

--- a/app/screens/send-bitcoin-screen/payment-details/onchain.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/onchain.ts
@@ -3,6 +3,7 @@ import {
   BtcMoneyAmount,
   MoneyAmount,
   WalletOrDisplayCurrency,
+  toUsdMoneyAmount,
   toWalletAmount,
 } from "@app/types/amounts"
 import { PaymentType } from "@galoymoney/client"
@@ -96,17 +97,17 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
           variables: {
             walletId: sendingWalletDescriptor.id,
             address,
-            amount: settlementAmount.amount,
+            amount: convertMoneyAmount(settlementAmount, WalletCurrency.Usd).amount,
           },
         })
 
         const rawAmount = data?.onChainUsdTxFee.amount
         const amount =
           typeof rawAmount === "number" // FIXME: this branch is never taken? rawAmount is type number | undefined
-            ? toWalletAmount({
-                amount: rawAmount,
-                currency: sendingWalletDescriptor.currency,
-              })
+            ? convertMoneyAmount(
+                toUsdMoneyAmount(rawAmount),
+                sendingWalletDescriptor.currency,
+              )
             : rawAmount
 
         return {
@@ -192,7 +193,7 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
             input: {
               walletId: sendingWalletDescriptor.id,
               address,
-              amount: settlementAmount.amount,
+              amount: convertMoneyAmount(settlementAmount, WalletCurrency.Usd).amount,
             },
           },
         })
@@ -208,17 +209,17 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
           variables: {
             walletId: sendingWalletDescriptor.id,
             address,
-            amount: settlementAmount.amount,
+            amount: convertMoneyAmount(settlementAmount, WalletCurrency.Usd).amount,
           },
         })
 
         const rawAmount = data?.onChainUsdTxFee.amount
         const amount =
           typeof rawAmount === "number" // FIXME: this branch is never taken? rawAmount is type number | undefined
-            ? toWalletAmount({
-                amount: rawAmount,
-                currency: sendingWalletDescriptor.currency,
-              })
+            ? convertMoneyAmount(
+                toUsdMoneyAmount(rawAmount),
+                sendingWalletDescriptor.currency,
+              )
             : rawAmount
 
         return {
@@ -255,10 +256,10 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
         const rawAmount = data?.onChainUsdTxFeeAsBtcDenominated.amount
         const amount =
           typeof rawAmount === "number" // FIXME: this branch is never taken? rawAmount is type number | undefined
-            ? toWalletAmount({
-                amount: rawAmount,
-                currency: sendingWalletDescriptor.currency,
-              })
+            ? convertMoneyAmount(
+                toUsdMoneyAmount(rawAmount),
+                sendingWalletDescriptor.currency,
+              )
             : rawAmount
 
         return {
@@ -445,10 +446,10 @@ export const createAmountOnchainPaymentDetails = <T extends WalletCurrency>(
       const rawAmount = data?.onChainUsdTxFeeAsBtcDenominated.amount
       const amount =
         typeof rawAmount === "number"
-          ? toWalletAmount({
-              amount: rawAmount,
-              currency: sendingWalletDescriptor.currency,
-            })
+          ? convertMoneyAmount(
+              toUsdMoneyAmount(rawAmount),
+              sendingWalletDescriptor.currency,
+            )
           : rawAmount
 
       return {

--- a/app/screens/send-bitcoin-screen/payment-details/utils.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/utils.ts
@@ -9,6 +9,7 @@ import {
   BtcMoneyAmount,
   UsdMoneyAmount,
   greaterThan,
+  isCashWalletCurrency,
   isNonZeroMoneyAmount,
   lessThan,
   moneyAmountIsCurrencyType,
@@ -49,6 +50,8 @@ export const isValidAmount = ({
     } as const
   }
   const settlementAmount = paymentDetail.settlementAmount
+  const isCashSettlementAmount = isCashWalletCurrency(settlementAmount.currency)
+
   if (
     moneyAmountIsCurrencyType(settlementAmount, WalletCurrency.Btc) &&
     greaterThan({
@@ -63,25 +66,26 @@ export const isValidAmount = ({
     }
   }
 
-  if (
-    moneyAmountIsCurrencyType(settlementAmount, WalletCurrency.Usd) &&
-    greaterThan({
-      value: settlementAmount,
-      greaterThan: usdWalletAmount,
-    })
-  ) {
-    return {
-      validAmount: false,
-      invalidReason: AmountInvalidReason.InsufficientBalance,
-      balance: usdWalletAmount,
+  if (isCashSettlementAmount) {
+    const cashWalletAmount = paymentDetail.convertMoneyAmount(
+      usdWalletAmount,
+      settlementAmount.currency,
+    )
+
+    if (settlementAmount.amount > cashWalletAmount.amount) {
+      return {
+        validAmount: false,
+        invalidReason: AmountInvalidReason.InsufficientBalance,
+        balance: usdWalletAmount,
+      }
     }
   }
 
   if (
-    moneyAmountIsCurrencyType(settlementAmount, WalletCurrency.Usd) &&
+    isCashSettlementAmount &&
     paymentDetail.paymentType === PaymentType.Onchain &&
     lessThan({
-      value: settlementAmount,
+      value: paymentDetail.convertMoneyAmount(settlementAmount, WalletCurrency.Usd),
       lessThan: toUsdMoneyAmount(200),
     })
   ) {

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -25,12 +25,12 @@ import { useIsAuthed } from "@app/graphql/is-authed-context"
 import {
   addMoneyAmounts,
   DisplayCurrency,
+  isCashWalletCurrency,
   lessThanOrEqualTo,
   moneyAmountIsCurrencyType,
   toBtcMoneyAmount,
   toUsdMoneyAmount,
   ZeroBtcMoneyAmount,
-  ZeroUsdMoneyAmount,
 } from "@app/types/amounts"
 import {
   useNpubByUsernameLazyQuery,
@@ -136,19 +136,21 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
       setIsValidAmount(validAmount)
     }
 
-    if (
-      moneyAmountIsCurrencyType(settlementAmount, WalletCurrency.Usd) &&
-      usdBalanceMoneyAmount &&
-      !isSendingMax
-    ) {
-      const totalAmount = addMoneyAmounts({
-        a: settlementAmount,
-        b: fee.amount || ZeroUsdMoneyAmount,
-      })
-      const validAmount = lessThanOrEqualTo({
-        value: totalAmount,
-        lessThanOrEqualTo: usdBalanceMoneyAmount,
-      })
+    const isCashSettlementAmount = isCashWalletCurrency(settlementAmount.currency)
+
+    if (isCashSettlementAmount && usdBalanceMoneyAmount && !isSendingMax) {
+      const cashBalanceMoneyAmount = convertMoneyAmount(
+        usdBalanceMoneyAmount,
+        settlementAmount.currency,
+      )
+      const feeAmount = fee.amount
+        ? convertMoneyAmount(fee.amount, settlementAmount.currency).amount
+        : 0
+      const totalAmount = {
+        ...settlementAmount,
+        amount: settlementAmount.amount + feeAmount,
+      }
+      const validAmount = totalAmount.amount <= cashBalanceMoneyAmount.amount
       if (!validAmount) {
         const invalidAmountErrorMessage = LL.SendBitcoinScreen.amountExceed({
           balance: usdWalletText,

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -168,10 +168,18 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
         }
       } else {
         const estimatedFee = await getIbexFee(pd.getFee)
+        const cashBalanceMoneyAmount = pd.convertMoneyAmount(
+          usdBalanceMoneyAmount,
+          pd.settlementAmount.currency,
+        )
+        const estimatedFeeMoneyAmount = estimatedFee
+          ? pd.convertMoneyAmount(estimatedFee, pd.settlementAmount.currency)
+          : undefined
         if (
           _convertMoneyAmount &&
-          estimatedFee &&
-          pd.settlementAmount.amount + estimatedFee?.amount > usdBalanceMoneyAmount.amount
+          estimatedFeeMoneyAmount &&
+          pd.settlementAmount.amount + estimatedFeeMoneyAmount.amount >
+            cashBalanceMoneyAmount.amount
         ) {
           const amount = formatDisplayAndWalletAmount({
             displayAmount: _convertMoneyAmount(usdBalanceMoneyAmount, DisplayCurrency),

--- a/app/types/amounts.ts
+++ b/app/types/amounts.ts
@@ -18,6 +18,12 @@ export const moneyAmountIsCurrencyType = <T extends WalletOrDisplayCurrency>(
   return moneyAmount.currency === currency
 }
 
+// Cash wallets (USD and the USDT-backed cash wallet) settle in USD cents at the
+// GraphQL boundary, so they share balance-validation handling on the send flow.
+export const isCashWalletCurrency = (currency: WalletOrDisplayCurrency): boolean => {
+  return currency === WalletCurrency.Usd || currency === WalletCurrency.Usdt
+}
+
 export type MoneyAmount<T extends WalletOrDisplayCurrency> = {
   amount: number
   currency: T


### PR DESCRIPTION
## Summary
- fixes BUG-004 by treating backend cash wallet balances, fees, and payment mutation inputs as USD cents at GraphQL boundaries
- keeps USDT wallet settlement amounts in micros inside the mobile send flow
- converts backend cash fee responses back into the active wallet unit before display/balance validation

## UAT
- confirmed on MacMax physical-device UAT that SEND-01 and SEND-02 now pass
- verified send methods that share this path no longer throw the false `$1.23/$1.24 (amount+fee)` balance error for `$0.05` sends

## Tests
- `yarn test __tests__/payment-details __tests__/payment-destination --runInBand`
- `yarn tsc:check`
- `yarn graphql-check`
- `yarn check:codegen`
- `git diff --check`

Stacked against #621 (`feat/fygaro`).
