### PR TITLE
fix: block self-send conversion in cash mode

### DIFF
--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -21,6 +21,7 @@ import {
 } from "@app/graphql/generated"
 import { useActivityIndicator, useAppConfig } from "@app/hooks"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
+import { usePersistentStateContext } from "@app/store/persistent-state"
 
 // types
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
@@ -60,6 +61,7 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ navigation, route }) =>
   const styles = usestyles()
   const { appConfig } = useAppConfig()
   const { toggleActivityIndicator } = useActivityIndicator()
+  const { persistentState } = usePersistentStateContext()
   const { lnAddressHostname: lnDomain } = appConfig.galoyInstance
 
   const [destinationState, dispatchDestinationStateAction] = useReducer(
@@ -202,13 +204,24 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ navigation, route }) =>
 
       if (destination.valid === false) {
         if (destination.invalidReason === InvalidDestinationReason.SelfPayment) {
+          if (persistentState.isAdvanceMode) {
+            dispatchDestinationStateAction({
+              type: SendBitcoinActions.SetUnparsedDestination,
+              payload: {
+                unparsedDestination: rawInput,
+              },
+            })
+            navigation.navigate("conversionDetails")
+            return
+          }
+
           dispatchDestinationStateAction({
-            type: SendBitcoinActions.SetUnparsedDestination,
+            type: SendBitcoinActions.SetInvalid,
             payload: {
+              invalidDestination: destination,
               unparsedDestination: rawInput,
             },
           })
-          navigation.navigate("conversionDetails")
           return
         }
 
@@ -279,6 +292,7 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ navigation, route }) =>
     destinationState.destinationState,
     accountDefaultWalletQuery,
     lnDomain,
+    persistentState.isAdvanceMode,
     dispatchDestinationStateAction,
     navigation,
   ])


### PR DESCRIPTION
## Summary
- fixes BUG-005 by keeping beginner/cash-only self-send on the destination screen as an invalid self-payment
- preserves the existing conversion flow for advanced mode users
- keeps this change separate from the BUG-004 cash amount unit fix

## UAT
- confirmed on MacMax physical-device UAT that SEND-04 now passes

## Tests
- `yarn test __tests__/payment-destination --runInBand`
- `yarn tsc:check`

Stacked against #621 (`feat/fygaro`).
