### PR TITLE
feat(topup): gate card + bank-transfer top-up behind topupEnabled

### DIFF
--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -1343,6 +1343,13 @@ query feedbackModalShown {
   feedbackModalShown @client
 }
 
+query globals {
+  globals {
+    topupEnabled
+    __typename
+  }
+}
+
 query hasPromptedSetDefaultAccount {
   hasPromptedSetDefaultAccount @client
 }

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -678,6 +678,12 @@ export type Globals = {
   readonly nodesIds: ReadonlyArray<Scalars['String']['output']>;
   /** A list of countries and their supported auth channels */
   readonly supportedCountries: ReadonlyArray<Country>;
+  /**
+   * Whether wallet top-up entry points (card webview and
+   * bank-transfer-to-support) should be shown to the user. Controlled by the
+   * instance-wide topup feature flag.
+   */
+  readonly topupEnabled: Scalars['Boolean']['output'];
 };
 
 export type GraphQlApplicationError = Error & {
@@ -3149,6 +3155,11 @@ export type AccountLimitsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type AccountLimitsQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly limits: { readonly __typename: 'AccountLimits', readonly withdrawal: ReadonlyArray<{ readonly __typename: 'OneDayAccountLimit', readonly totalLimit: number, readonly remainingLimit?: number | null, readonly interval?: number | null }>, readonly internalSend: ReadonlyArray<{ readonly __typename: 'OneDayAccountLimit', readonly totalLimit: number, readonly remainingLimit?: number | null, readonly interval?: number | null }>, readonly convert: ReadonlyArray<{ readonly __typename: 'OneDayAccountLimit', readonly totalLimit: number, readonly remainingLimit?: number | null, readonly interval?: number | null }> } } } | null };
+
+export type GlobalsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GlobalsQuery = { readonly __typename: 'Query', readonly globals?: { readonly __typename: 'Globals', readonly topupEnabled: boolean } | null };
 
 export type TotpRegistrationScreenQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -8077,6 +8088,40 @@ export function useAccountLimitsLazyQuery(baseOptions?: Apollo.LazyQueryHookOpti
 export type AccountLimitsQueryHookResult = ReturnType<typeof useAccountLimitsQuery>;
 export type AccountLimitsLazyQueryHookResult = ReturnType<typeof useAccountLimitsLazyQuery>;
 export type AccountLimitsQueryResult = Apollo.QueryResult<AccountLimitsQuery, AccountLimitsQueryVariables>;
+export const GlobalsDocument = gql`
+    query globals {
+  globals {
+    topupEnabled
+  }
+}
+    `;
+
+/**
+ * __useGlobalsQuery__
+ *
+ * To run a query within a React component, call `useGlobalsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGlobalsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGlobalsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGlobalsQuery(baseOptions?: Apollo.QueryHookOptions<GlobalsQuery, GlobalsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GlobalsQuery, GlobalsQueryVariables>(GlobalsDocument, options);
+      }
+export function useGlobalsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GlobalsQuery, GlobalsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GlobalsQuery, GlobalsQueryVariables>(GlobalsDocument, options);
+        }
+export type GlobalsQueryHookResult = ReturnType<typeof useGlobalsQuery>;
+export type GlobalsLazyQueryHookResult = ReturnType<typeof useGlobalsLazyQuery>;
+export type GlobalsQueryResult = Apollo.QueryResult<GlobalsQuery, GlobalsQueryVariables>;
 export const TotpRegistrationScreenDocument = gql`
     query totpRegistrationScreen {
   me {

--- a/app/graphql/public-schema.graphql
+++ b/app/graphql/public-schema.graphql
@@ -623,6 +623,13 @@ type Globals {
 
   """A list of countries and their supported auth channels"""
   supportedCountries: [Country!]!
+
+  """
+  Whether wallet top-up entry points (card webview and
+  bank-transfer-to-support) should be shown to the user. Controlled by the
+  instance-wide topup feature flag.
+  """
+  topupEnabled: Boolean!
 }
 
 type GraphQLApplicationError implements Error {

--- a/app/screens/topup-cashout-flow/TopupCashout.tsx
+++ b/app/screens/topup-cashout-flow/TopupCashout.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useState } from "react"
 import { Alert, RefreshControl, ScrollView, TouchableOpacity, View } from "react-native"
+import { gql } from "@apollo/client"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
 import { Icon, Text, makeStyles, useTheme } from "@rneui/themed"
 import { StackScreenProps } from "@react-navigation/stack"
@@ -25,9 +26,18 @@ import {
   useBridgeExternalAccountsQuery,
   useBridgeInitiateKycMutation,
   useBridgeKycStatusQuery,
+  useGlobalsQuery,
 } from "@app/graphql/generated"
 import { useActivityIndicator } from "@app/hooks"
 import { useLevel } from "@app/graphql/level-context"
+
+gql`
+  query globals {
+    globals {
+      topupEnabled
+    }
+  }
+`
 
 type Props = StackScreenProps<RootStackParamList, "TopupCashout">
 
@@ -53,6 +63,12 @@ const TopupCashout: React.FC<Props> = ({ navigation }) => {
     useBridgeExternalAccountsQuery({
       fetchPolicy: "cache-and-network",
     })
+
+  // Card (webview) and bank-transfer (support) top-up entry points are gated by
+  // the instance-wide topup feature flag. International top-up is gated server-side
+  // by the bridge feature flag, so it stays available independently.
+  const { data: globalsData } = useGlobalsQuery({ fetchPolicy: "cache-and-network" })
+  const topupEnabled = globalsData?.globals?.topupEnabled ?? false
 
   useFocusEffect(
     useCallback(() => {
@@ -147,39 +163,54 @@ const TopupCashout: React.FC<Props> = ({ navigation }) => {
     ],
   )
 
-  const topupOptions: TransferOption[] = useMemo(
-    () => [
-      {
-        icon: "card",
-        title: LL.TopUpScreen.debitCreditCard(),
-        description: LL.TopUpScreen.debitCreditCardDesc(),
-        onPress: () => {
-          setTopupModalVisible(false)
-          checkAccountLevel("card")
+  const topupOptions: TransferOption[] = useMemo(() => {
+    const options: TransferOption[] = []
+
+    // Gated by the topup feature flag (card webview + bank-transfer-to-support).
+    if (topupEnabled) {
+      options.push(
+        {
+          icon: "card",
+          title: LL.TopUpScreen.debitCreditCard(),
+          description: LL.TopUpScreen.debitCreditCardDesc(),
+          onPress: () => {
+            setTopupModalVisible(false)
+            checkAccountLevel("card")
+          },
         },
-      },
-      {
-        icon: "business",
-        title: LL.TopUpScreen.bankTransfer(),
-        description: LL.TopUpScreen.bankTransferDesc(),
-        onPress: () => {
-          setTopupModalVisible(false)
-          checkAccountLevel("bankTransfer")
+        {
+          icon: "business",
+          title: LL.TopUpScreen.bankTransfer(),
+          description: LL.TopUpScreen.bankTransferDesc(),
+          onPress: () => {
+            setTopupModalVisible(false)
+            checkAccountLevel("bankTransfer")
+          },
         },
+      )
+    }
+
+    // International top-up flows through the bridge and is gated server-side by
+    // the bridge feature flag, so it stays available regardless of topupEnabled.
+    options.push({
+      icon: "globe",
+      title: LL.TransferScreen.internationalBankTransfer(),
+      description: LL.TransferScreen.internationalBankTransferDesc(),
+      pending: kycStatusData?.bridgeKycStatus === "pending",
+      onPress: () => {
+        setTopupModalVisible(false)
+        checkBridgeKyc("topup")
       },
-      {
-        icon: "globe",
-        title: LL.TransferScreen.internationalBankTransfer(),
-        description: LL.TransferScreen.internationalBankTransferDesc(),
-        pending: kycStatusData?.bridgeKycStatus === "pending",
-        onPress: () => {
-          setTopupModalVisible(false)
-          checkBridgeKyc("topup")
-        },
-      },
-    ],
-    [LL, checkAccountLevel, checkBridgeKyc, kycStatusData?.bridgeKycStatus],
-  )
+    })
+
+    return options
+  }, [
+    LL,
+    checkAccountLevel,
+    checkBridgeKyc,
+    kycStatusData?.bridgeKycStatus,
+    topupEnabled,
+  ])
 
   const settleOptions: TransferOption[] = useMemo(
     () => [


### PR DESCRIPTION
## Summary

Consumes the new backend **`Globals.topupEnabled`** feature flag (lnflash/flash **#421**) to show/hide the two top-up entry points the mobile owns:

- **Credit card** (Fygaro webview)
- **Bank transfer** (handoff to support)

When `topupEnabled` is `false`, both are removed from the top-up options menu in `TopupCashout`. **International bank top-up stays in place** — it flows through the bridge and is gated server-side by `bridge.enabled`, so it's controlled independently.

This lets top-up be killed/enabled via backend YAML + rolling restart (the v0.6.0 `KILL_MONEY` SOP) with no app release.

### Changes
| File | Change |
|------|--------|
| `app/screens/topup-cashout-flow/TopupCashout.tsx` | add `query globals { globals { topupEnabled } }`, consume via `useGlobalsQuery` (`cache-and-network`), conditionally include card + bank-transfer options |
| `app/graphql/public-schema.graphql` | add `Globals.topupEnabled: Boolean!` (mirrors backend SDL) |
| `app/graphql/generated.ts`, `generated.gql` | regenerated via `yarn dev:codegen` |

### Behavior
- `topupEnabled` defaults to `false` client-side (`?? false`), so if the field/flag is missing or the backend is old, the card + bank entries are hidden (fail-safe).
- Downstream `TopupDetails → CardPayment/BankTransfer` is only reachable through the gated menu, so no separate gating is needed there (verified: no other entry points navigate into those screens).

### Verification
- `yarn tsc:check` ✅
- `yarn graphql-check` ✅ (all documents valid)
- `eslint` ✅

### Dependency / sequencing
Depends on backend **#421** (`Globals.topupEnabled`) being merged + deployed. Until then `topupEnabled` resolves to `false` (entries hidden) — which is the intended default-OFF state anyway. Safe to merge in either order; the flag only does something once the backend serves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
