### PR TITLE
fix(send): support Spark LNURL-pay inputs

### DIFF
--- a/__tests__/utils/spark-lnurl-input.spec.ts
+++ b/__tests__/utils/spark-lnurl-input.spec.ts
@@ -1,0 +1,32 @@
+import { lnurlPayRequestDetailsFromInput } from "@app/utils/breez-sdk/spark"
+
+describe("lnurlPayRequestDetailsFromInput", () => {
+  const payRequest = {
+    callback: "https://example.com/lnurl/callback",
+    minSendable: BigInt(1),
+    maxSendable: BigInt(1000),
+    metadataStr: "[]",
+    commentAllowed: 0,
+    allowsNostr: false,
+    nostrPubkey: undefined,
+    payerData: undefined,
+  }
+
+  it("uses the pay request from a Spark lightning address input", () => {
+    const input = { tag: "LightningAddress", inner: [{ payRequest }] }
+
+    expect(lnurlPayRequestDetailsFromInput(input as never)).toBe(payRequest)
+  })
+
+  it("uses the pay request from an encoded Spark LNURL-pay input", () => {
+    const input = { tag: "LnurlPay", inner: [payRequest] }
+
+    expect(lnurlPayRequestDetailsFromInput(input as never)).toBe(payRequest)
+  })
+
+  it("returns null for non-LNURL pay inputs", () => {
+    const input = { tag: "Bolt11Invoice", inner: [{ invoice: "lnbc1..." }] }
+
+    expect(lnurlPayRequestDetailsFromInput(input as never)).toBeNull()
+  })
+})

--- a/app/utils/breez-sdk/spark.ts
+++ b/app/utils/breez-sdk/spark.ts
@@ -32,6 +32,7 @@ import type {
   Payment,
   Logger,
   LogEntry,
+  LnurlPayRequestDetails,
 } from "@breeztech/breez-sdk-spark-react-native"
 import { API_KEY, BREEZ_LNURL_DOMAIN } from "@env"
 import { appendLog, initLogBuffer } from "./log-buffer"
@@ -54,6 +55,20 @@ export const getSDKInstance = (): BreezSdkInterface => {
     throw new Error("Breez SDK not initialized. Call initializeBreezSDK first.")
   }
   return sdkInstance
+}
+
+export const lnurlPayRequestDetailsFromInput = (
+  input: InputType,
+): LnurlPayRequestDetails | null => {
+  if (input.tag === "LightningAddress") {
+    return input.inner[0].payRequest
+  }
+
+  if (input.tag === "LnurlPay") {
+    return input.inner[0]
+  }
+
+  return null
 }
 
 // SDK Initialization
@@ -263,11 +278,12 @@ export const fetchBreezFee = async (
 
     if (paymentType === "intraledger" || paymentType === "lnurl") {
       const parsed = await parse(paymentRequest)
+      const payRequest = lnurlPayRequestDetailsFromInput(parsed)
 
-      if (parsed.tag === InputType_Tags.LightningAddress) {
+      if (payRequest) {
         const prepareResponse = await sdk.prepareLnurlPay({
           amount: BigInt(amountSats),
-          payRequest: parsed.inner[0].payRequest,
+          payRequest,
           comment: undefined,
           validateSuccessActionUrl: undefined,
           tokenIdentifier: undefined,
@@ -413,10 +429,12 @@ export const payLnurlBreez = async (
     const sdk = getSDKInstance()
 
     const input = await sdk.parse(lnurl)
-    if (input.tag === InputType_Tags.LightningAddress) {
+    const payRequest = lnurlPayRequestDetailsFromInput(input)
+
+    if (payRequest) {
       const prepareResponse = await sdk.prepareLnurlPay({
         amount: BigInt(amountSats),
-        payRequest: input.inner[0].payRequest,
+        payRequest,
         comment: memo,
         validateSuccessActionUrl: true,
         tokenIdentifier: undefined,


### PR DESCRIPTION
## Summary
- accept both Spark `LightningAddress` and encoded `LnurlPay` parse results for BTC-wallet LNURL sends
- reuse the parsed pay request for fee probing and send execution
- add Jest coverage for both accepted Spark LNURL input shapes

## UAT Context
- fixes the `EXT-03` BTC-wallet LNURL path found during integrated UAT (`BUG-009`)
- local Flash-username sends depend on `.well-known/lnurlp` hostname routing, so the username path should be smoked in TEST/PROD where that routing exists

## Test Plan
- `yarn test __tests__/utils/spark-lnurl-input.spec.ts __tests__/payment-details/lnurl-payment-details.spec.ts __tests__/payment-destination/resolve-username-to-lnurl.spec.ts --runInBand`
- `yarn test __tests__/payment-details __tests__/payment-destination --runInBand`
- `yarn tsc:check`
- `git diff --check`