### PR TITLE
fix(usdt): remove micros conversion - backend now returns cents

### DIFF
--- a/__tests__/payment-request/payment-request.spec.ts
+++ b/__tests__/payment-request/payment-request.spec.ts
@@ -17,7 +17,6 @@ import { createPaymentRequest } from "@app/screens/receive-bitcoin-screen/paymen
 import {
   MoneyAmount,
   toUsdMoneyAmount,
-  USDT_MICROS_PER_USD_CENT,
   WalletOrDisplayCurrency,
 } from "@app/types/amounts"
 import { receiveOnchainBreez, receivePaymentBreez } from "@app/utils/breez-sdk"
@@ -204,25 +203,20 @@ describe("payment request", () => {
   it("ln with usdt receiving wallet - set amount sends cents, not micros", async () => {
     // Regression for the $5.00 -> $50,583 USDT invoice bug. The price
     // conversion denominates USDT money amounts in smallest units (micros),
-    // which are USDT_MICROS_PER_USD_CENT (10,000x) smaller than a cent. The
-    // lnUsdInvoiceCreate mutation expects USD cents, so the receive flow must
     // convert USDT micros back to cents before calling it. Otherwise a $5.00
     // request (500 cents) is sent as 5,000,000 and the backend mints a
     // $50,000 invoice.
-    const convertToUsdtMicros = <T extends WalletOrDisplayCurrency>(
+    const convertToUsdtCents = <T extends WalletOrDisplayCurrency>(
       amount: MoneyAmount<WalletOrDisplayCurrency>,
       toCurrency: T,
     ): MoneyAmount<T> => {
-      const converted =
-        toCurrency === WalletCurrency.Usdt
-          ? amount.amount * USDT_MICROS_PER_USD_CENT
-          : amount.amount
+      const converted = amount.amount
       return { amount: converted, currency: toCurrency, currencyCode: toCurrency }
     }
 
     const prcd = createPaymentRequestCreationData({
       ...defaultParams,
-      convertMoneyAmount: convertToUsdtMicros,
+      convertMoneyAmount: convertToUsdtCents,
       receivingWalletDescriptor: usdtWalletDescriptor,
       // $5.00 entered as 500 USD cents in the unit of account
       unitOfAccountAmount: toUsdMoneyAmount(500),
@@ -230,7 +224,7 @@ describe("payment request", () => {
 
     // sanity: the settlement amount is in USDT micros (500 cents * 10,000)
     expect(prcd.settlementAmount?.currency).toBe(WalletCurrency.Usdt)
-    expect(prcd.settlementAmount?.amount).toBe(500 * USDT_MICROS_PER_USD_CENT)
+    expect(prcd.settlementAmount?.amount).toBe(500)
 
     const pr = createPaymentRequest({ creationData: prcd, mutations })
     const prNew = await pr.generateRequest()

--- a/app/hooks/use-display-currency.ts
+++ b/app/hooks/use-display-currency.ts
@@ -5,7 +5,6 @@ import {
   DisplayAmount,
   DisplayCurrency,
   MoneyAmount,
-  USDT_MICROS_PER_USDT,
   WalletAmount,
   WalletOrDisplayCurrency,
 } from "@app/types/amounts"
@@ -105,7 +104,7 @@ export const useDisplayCurrency = () => {
         case WalletCurrency.Usd:
           return moneyAmount.amount / 100
         case WalletCurrency.Usdt:
-          return moneyAmount.amount / USDT_MICROS_PER_USDT
+          return moneyAmount.amount / 100
         case DisplayCurrency:
           return moneyAmount.amount / 10 ** displayCurrencyInfo.fractionDigits
       }

--- a/app/hooks/use-price-conversion.ts
+++ b/app/hooks/use-price-conversion.ts
@@ -5,7 +5,6 @@ import {
   DisplayCurrency,
   MoneyAmount,
   moneyAmountIsCurrencyType,
-  USDT_MICROS_PER_USD_CENT,
   WalletOrDisplayCurrency,
 } from "@app/types/amounts"
 import { useMemo } from "react"
@@ -65,28 +64,27 @@ export const usePriceConversion = () => {
           [WalletCurrency.Usd]: displayCurrencyPerSat * (1 / displayCurrencyPerCent),
           [WalletCurrency.Usdt]:
             displayCurrencyPerSat *
-            (1 / displayCurrencyPerCent) *
-            USDT_MICROS_PER_USD_CENT,
+            (1 / displayCurrencyPerCent),
           [WalletCurrency.Btc]: 1,
         },
         [WalletCurrency.Usd]: {
           [DisplayCurrency]: displayCurrencyPerCent,
           [WalletCurrency.Btc]: displayCurrencyPerCent * (1 / displayCurrencyPerSat),
           [WalletCurrency.Usd]: 1,
-          [WalletCurrency.Usdt]: USDT_MICROS_PER_USD_CENT,
+          [WalletCurrency.Usdt]: 1,
         },
         [WalletCurrency.Usdt]: {
-          [DisplayCurrency]: displayCurrencyPerCent / USDT_MICROS_PER_USD_CENT,
+          [DisplayCurrency]: displayCurrencyPerCent ,
           [WalletCurrency.Btc]:
-            (displayCurrencyPerCent / USDT_MICROS_PER_USD_CENT) *
+            (displayCurrencyPerCent ) *
             (1 / displayCurrencyPerSat),
-          [WalletCurrency.Usd]: 1 / USDT_MICROS_PER_USD_CENT,
+          [WalletCurrency.Usd]: 1 ,
           [WalletCurrency.Usdt]: 1,
         },
         [DisplayCurrency]: {
           [WalletCurrency.Btc]: 1 / displayCurrencyPerSat,
           [WalletCurrency.Usd]: 1 / displayCurrencyPerCent,
-          [WalletCurrency.Usdt]: (1 / displayCurrencyPerCent) * USDT_MICROS_PER_USD_CENT,
+          [WalletCurrency.Usdt]: (1 / displayCurrencyPerCent),
           [DisplayCurrency]: 1,
         },
       }

--- a/app/hooks/use-unauthed-price-conversion.ts
+++ b/app/hooks/use-unauthed-price-conversion.ts
@@ -6,7 +6,6 @@ import {
   DisplayCurrency,
   MoneyAmount,
   moneyAmountIsCurrencyType,
-  USDT_MICROS_PER_USD_CENT,
   WalletOrDisplayCurrency,
 } from "@app/types/amounts"
 import { getCrashlytics } from "@react-native-firebase/crashlytics"
@@ -54,28 +53,27 @@ export const useUnauthedPriceConversion = () => {
           [WalletCurrency.Usd]: displayCurrencyPerSat * (1 / displayCurrencyPerCent),
           [WalletCurrency.Usdt]:
             displayCurrencyPerSat *
-            (1 / displayCurrencyPerCent) *
-            USDT_MICROS_PER_USD_CENT,
+            (1 / displayCurrencyPerCent),
           [WalletCurrency.Btc]: 1,
         },
         [WalletCurrency.Usd]: {
           [DisplayCurrency]: displayCurrencyPerCent,
           [WalletCurrency.Btc]: displayCurrencyPerCent * (1 / displayCurrencyPerSat),
           [WalletCurrency.Usd]: 1,
-          [WalletCurrency.Usdt]: USDT_MICROS_PER_USD_CENT,
+          [WalletCurrency.Usdt]: 1,
         },
         [WalletCurrency.Usdt]: {
-          [DisplayCurrency]: displayCurrencyPerCent / USDT_MICROS_PER_USD_CENT,
+          [DisplayCurrency]: displayCurrencyPerCent ,
           [WalletCurrency.Btc]:
-            (displayCurrencyPerCent / USDT_MICROS_PER_USD_CENT) *
+            (displayCurrencyPerCent ) *
             (1 / displayCurrencyPerSat),
-          [WalletCurrency.Usd]: 1 / USDT_MICROS_PER_USD_CENT,
+          [WalletCurrency.Usd]: 1 ,
           [WalletCurrency.Usdt]: 1,
         },
         [DisplayCurrency]: {
           [WalletCurrency.Btc]: 1 / displayCurrencyPerSat,
           [WalletCurrency.Usd]: 1 / displayCurrencyPerCent,
-          [WalletCurrency.Usdt]: (1 / displayCurrencyPerCent) * USDT_MICROS_PER_USD_CENT,
+          [WalletCurrency.Usdt]: (1 / displayCurrencyPerCent),
           [DisplayCurrency]: 1,
         },
       }

--- a/app/screens/receive-bitcoin-screen/payment/payment-request.ts
+++ b/app/screens/receive-bitcoin-screen/payment/payment-request.ts
@@ -8,7 +8,7 @@ import {
   PaymentRequestStateType,
   PaymentRequestInformation,
 } from "./index.types"
-import { BtcMoneyAmount, USDT_MICROS_PER_USD_CENT } from "@app/types/amounts"
+import { BtcMoneyAmount } from "@app/types/amounts"
 import { getPaymentRequestFullUri, prToDateString } from "./helpers"
 import { bech32 } from "bech32"
 
@@ -125,12 +125,9 @@ export const createPaymentRequest = (
           // lnUsdInvoiceCreate expects the amount in USD cents. USD settlement
           // amounts are already in cents, but USDT settlement amounts are
           // denominated in USDT smallest units (micros), which are
-          // USDT_MICROS_PER_USD_CENT (10,000x) smaller than a cent. Convert USDT
-          // micros back to cents at the mutation boundary so a $5.00 invoice is
-          // created for 500 cents, not 5,000,000.
           const amountInCents =
             pr.settlementAmount.currency === WalletCurrency.Usdt
-              ? Math.round(pr.settlementAmount.amount / USDT_MICROS_PER_USD_CENT)
+              ? pr.settlementAmount.amount
               : pr.settlementAmount.amount
           const { data, errors } = await mutations.lnUsdInvoiceCreate({
             variables: {

--- a/app/types/amounts.ts
+++ b/app/types/amounts.ts
@@ -1,9 +1,5 @@
 import { WalletCurrency } from "@app/graphql/generated"
 
-export const CENTS_PER_USD = 100
-export const USDT_MICROS_PER_USDT = 1_000_000
-export const USDT_MICROS_PER_USD_CENT = USDT_MICROS_PER_USDT / CENTS_PER_USD
-
 export const DisplayCurrency = "DisplayCurrency" as const
 export type DisplayCurrency = typeof DisplayCurrency
 
@@ -27,18 +23,11 @@ export type MoneyAmount<T extends WalletOrDisplayCurrency> = {
 export type WalletAmount<T extends WalletCurrency> = MoneyAmount<T>
 
 export type UsdMoneyAmount = WalletAmount<typeof WalletCurrency.Usd>
-export type UsdtMoneyAmount = WalletAmount<typeof WalletCurrency.Usdt>
 export type BtcMoneyAmount = WalletAmount<typeof WalletCurrency.Btc>
 
 export const ZeroUsdMoneyAmount: UsdMoneyAmount = {
   amount: 0,
   currency: WalletCurrency.Usd,
-  currencyCode: "USD",
-}
-
-export const ZeroUsdtMoneyAmount: UsdtMoneyAmount = {
-  amount: 0,
-  currency: WalletCurrency.Usdt,
   currencyCode: "USD",
 }
 
@@ -74,21 +63,6 @@ export const toUsdMoneyAmount = (amount: number | undefined | null): UsdMoneyAmo
   return {
     amount,
     currency: WalletCurrency.Usd,
-    currencyCode: "USD",
-  }
-}
-
-export const toUsdtMoneyAmount = (amount: number | undefined | null): UsdtMoneyAmount => {
-  if (amount === undefined || amount === null) {
-    return {
-      amount: NaN,
-      currency: WalletCurrency.Usdt,
-      currencyCode: "USD",
-    }
-  }
-  return {
-    amount,
-    currency: WalletCurrency.Usdt,
     currencyCode: "USD",
   }
 }


### PR DESCRIPTION
The backend fix (PR #413) now returns settlementAmount in cents, not micros. All micros-to-cents conversion on the mobile side is obsolete.

Removes:
- USDT_MICROS_PER_USDT, USDT_MICROS_PER_USD_CENT constants
- Micros division in use-display-currency.ts
- USDT_MICROS_PER_USD_CENT scaling in price conversion hooks
- Micros-to-cents conversion in payment-request.ts
- Related test assertions