### PR TITLE
feat(bank-accounts): update approved bank account — mobile [ENG-509]

### DIFF
--- a/app/graphql/front-end-mutations.ts
+++ b/app/graphql/front-end-mutations.ts
@@ -200,6 +200,16 @@ gql`
     }
   }
 
+  mutation bankAccountUpdateRequest($input: BankAccountUpdateRequestInput!) {
+    bankAccountUpdateRequest(input: $input) {
+      errors {
+        message
+        code
+      }
+      status
+    }
+  }
+
   mutation IdDocumentUploadUrlGenerate($input: IdDocumentUploadUrlGenerateInput!) {
     idDocumentUploadUrlGenerate(input: $input) {
       errors {

--- a/app/graphql/front-end-queries.ts
+++ b/app/graphql/front-end-queries.ts
@@ -360,6 +360,15 @@ gql`
         currency
         id
         isDefault
+        pendingUpdate {
+          status
+          bankName
+          bankBranch
+          accountType
+          accountNumber
+          currency
+          rejectionReason
+        }
       }
     }
   }

--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -410,6 +410,18 @@ mutation accountUpdateDisplayCurrency($input: AccountUpdateDisplayCurrencyInput!
   }
 }
 
+mutation bankAccountUpdateRequest($input: BankAccountUpdateRequestInput!) {
+  bankAccountUpdateRequest(input: $input) {
+    errors {
+      message
+      code
+      __typename
+    }
+    status
+    __typename
+  }
+}
+
 mutation businessAccountUpgradeRequest($input: BusinessAccountUpgradeRequestInput!) {
   businessAccountUpgradeRequest(input: $input) {
     errors {
@@ -1002,6 +1014,16 @@ query BankAccounts {
       currency
       id
       isDefault
+      pendingUpdate {
+        status
+        bankName
+        bankBranch
+        accountType
+        accountNumber
+        currency
+        rejectionReason
+        __typename
+      }
       __typename
     }
     __typename

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -312,6 +312,8 @@ export type BankAccount = {
   /** ERPNext bank account identifier */
   readonly id?: Maybe<Scalars['ID']['output']>;
   readonly isDefault: Scalars['Boolean']['output'];
+  /** An open request to change this account's details, awaiting review. Null when none is pending. */
+  readonly pendingUpdate?: Maybe<BankAccountUpdateRequest>;
 };
 
 export type BankAccountInput = {
@@ -320,6 +322,43 @@ export type BankAccountInput = {
   readonly bankBranch: Scalars['String']['input'];
   readonly bankName: Scalars['String']['input'];
   readonly currency: Scalars['String']['input'];
+};
+
+/** A pending request to change the details of an approved bank account, awaiting admin review. */
+export type BankAccountUpdateRequest = {
+  readonly __typename: 'BankAccountUpdateRequest';
+  /** Proposed new account number */
+  readonly accountNumber: Scalars['String']['output'];
+  /** Proposed new account type */
+  readonly accountType: Scalars['String']['output'];
+  /** Proposed new bank branch */
+  readonly bankBranch: Scalars['String']['output'];
+  /** Proposed new bank name */
+  readonly bankName: Scalars['String']['output'];
+  /** Account currency (unchanged from the current account) */
+  readonly currency: Scalars['String']['output'];
+  /** Reviewer note, set when status is Rejected */
+  readonly rejectionReason?: Maybe<Scalars['String']['output']>;
+  /** Pending | Approved | Rejected | Closed */
+  readonly status: Scalars['String']['output'];
+};
+
+export type BankAccountUpdateRequestInput = {
+  readonly accountNumber: Scalars['AccountNumber']['input'];
+  readonly accountType: Scalars['String']['input'];
+  /** ERPNext identifier of the account to update */
+  readonly bankAccountId: Scalars['ID']['input'];
+  readonly bankBranch: Scalars['String']['input'];
+  readonly bankName: Scalars['String']['input'];
+  /** Must match the account's current currency (currency is locked) */
+  readonly currency: Scalars['String']['input'];
+};
+
+export type BankAccountUpdateRequestPayload = {
+  readonly __typename: 'BankAccountUpdateRequestPayload';
+  readonly errors?: Maybe<ReadonlyArray<Maybe<Error>>>;
+  /** Status of the created request (Pending on success) */
+  readonly status?: Maybe<Scalars['String']['output']>;
 };
 
 export type BridgeAddExternalAccountPayload = {
@@ -1022,6 +1061,7 @@ export type Mutation = {
   readonly accountEnableNotificationChannel: AccountUpdateNotificationSettingsPayload;
   readonly accountUpdateDefaultWalletId: AccountUpdateDefaultWalletIdPayload;
   readonly accountUpdateDisplayCurrency: AccountUpdateDisplayCurrencyPayload;
+  readonly bankAccountUpdateRequest: BankAccountUpdateRequestPayload;
   readonly bridgeAddExternalAccount: BridgeAddExternalAccountPayload;
   readonly bridgeCancelWithdrawalRequest: BridgeCancelWithdrawalRequestPayload;
   readonly bridgeCreateExternalAccount: BridgeCreateExternalAccountPayload;
@@ -1185,6 +1225,11 @@ export type MutationAccountUpdateDefaultWalletIdArgs = {
 
 export type MutationAccountUpdateDisplayCurrencyArgs = {
   input: AccountUpdateDisplayCurrencyInput;
+};
+
+
+export type MutationBankAccountUpdateRequestArgs = {
+  input: BankAccountUpdateRequestInput;
 };
 
 
@@ -2609,6 +2654,13 @@ export type BusinessAccountUpgradeRequestMutationVariables = Exact<{
 
 export type BusinessAccountUpgradeRequestMutation = { readonly __typename: 'Mutation', readonly businessAccountUpgradeRequest: { readonly __typename: 'AccountUpgradePayload', readonly id?: string | null, readonly status?: string | null, readonly errors?: ReadonlyArray<{ readonly __typename: 'GraphQLApplicationError', readonly message: string, readonly code?: string | null } | null> | null } };
 
+export type BankAccountUpdateRequestMutationVariables = Exact<{
+  input: BankAccountUpdateRequestInput;
+}>;
+
+
+export type BankAccountUpdateRequestMutation = { readonly __typename: 'Mutation', readonly bankAccountUpdateRequest: { readonly __typename: 'BankAccountUpdateRequestPayload', readonly status?: string | null, readonly errors?: ReadonlyArray<{ readonly __typename: 'GraphQLApplicationError', readonly message: string, readonly code?: string | null } | null> | null } };
+
 export type IdDocumentUploadUrlGenerateMutationVariables = Exact<{
   input: IdDocumentUploadUrlGenerateInput;
 }>;
@@ -2789,7 +2841,7 @@ export type BridgeVirtualAccountQuery = { readonly __typename: 'Query', readonly
 export type BankAccountsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type BankAccountsQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly bankAccounts: ReadonlyArray<{ readonly __typename: 'BankAccount', readonly accountName?: string | null, readonly accountNumber: string, readonly accountType: string, readonly bankBranch: string, readonly bankName: string, readonly currency: string, readonly id?: string | null, readonly isDefault: boolean }> } | null };
+export type BankAccountsQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly bankAccounts: ReadonlyArray<{ readonly __typename: 'BankAccount', readonly accountName?: string | null, readonly accountNumber: string, readonly accountType: string, readonly bankBranch: string, readonly bankName: string, readonly currency: string, readonly id?: string | null, readonly isDefault: boolean, readonly pendingUpdate?: { readonly __typename: 'BankAccountUpdateRequest', readonly status: string, readonly bankName: string, readonly bankBranch: string, readonly accountType: string, readonly accountNumber: string, readonly currency: string, readonly rejectionReason?: string | null } | null }> } | null };
 
 export type BridgeExternalAccountsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -4346,6 +4398,43 @@ export function useBusinessAccountUpgradeRequestMutation(baseOptions?: Apollo.Mu
 export type BusinessAccountUpgradeRequestMutationHookResult = ReturnType<typeof useBusinessAccountUpgradeRequestMutation>;
 export type BusinessAccountUpgradeRequestMutationResult = Apollo.MutationResult<BusinessAccountUpgradeRequestMutation>;
 export type BusinessAccountUpgradeRequestMutationOptions = Apollo.BaseMutationOptions<BusinessAccountUpgradeRequestMutation, BusinessAccountUpgradeRequestMutationVariables>;
+export const BankAccountUpdateRequestDocument = gql`
+    mutation bankAccountUpdateRequest($input: BankAccountUpdateRequestInput!) {
+  bankAccountUpdateRequest(input: $input) {
+    errors {
+      message
+      code
+    }
+    status
+  }
+}
+    `;
+export type BankAccountUpdateRequestMutationFn = Apollo.MutationFunction<BankAccountUpdateRequestMutation, BankAccountUpdateRequestMutationVariables>;
+
+/**
+ * __useBankAccountUpdateRequestMutation__
+ *
+ * To run a mutation, you first call `useBankAccountUpdateRequestMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useBankAccountUpdateRequestMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [bankAccountUpdateRequestMutation, { data, loading, error }] = useBankAccountUpdateRequestMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useBankAccountUpdateRequestMutation(baseOptions?: Apollo.MutationHookOptions<BankAccountUpdateRequestMutation, BankAccountUpdateRequestMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<BankAccountUpdateRequestMutation, BankAccountUpdateRequestMutationVariables>(BankAccountUpdateRequestDocument, options);
+      }
+export type BankAccountUpdateRequestMutationHookResult = ReturnType<typeof useBankAccountUpdateRequestMutation>;
+export type BankAccountUpdateRequestMutationResult = Apollo.MutationResult<BankAccountUpdateRequestMutation>;
+export type BankAccountUpdateRequestMutationOptions = Apollo.BaseMutationOptions<BankAccountUpdateRequestMutation, BankAccountUpdateRequestMutationVariables>;
 export const IdDocumentUploadUrlGenerateDocument = gql`
     mutation IdDocumentUploadUrlGenerate($input: IdDocumentUploadUrlGenerateInput!) {
   idDocumentUploadUrlGenerate(input: $input) {
@@ -5651,6 +5740,15 @@ export const BankAccountsDocument = gql`
       currency
       id
       isDefault
+      pendingUpdate {
+        status
+        bankName
+        bankBranch
+        accountType
+        accountNumber
+        currency
+        rejectionReason
+      }
     }
   }
 }

--- a/app/graphql/public-schema.graphql
+++ b/app/graphql/public-schema.graphql
@@ -231,6 +231,11 @@ type BankAccount {
   """ERPNext bank account identifier"""
   id: ID
   isDefault: Boolean!
+
+  """
+  An open request to change this account's details, awaiting review. Null when none is pending.
+  """
+  pendingUpdate: BankAccountUpdateRequest
 }
 
 input BankAccountInput {
@@ -239,6 +244,52 @@ input BankAccountInput {
   bankBranch: String!
   bankName: String!
   currency: String!
+}
+
+"""
+A pending request to change the details of an approved bank account, awaiting admin review.
+"""
+type BankAccountUpdateRequest {
+  """Proposed new account number"""
+  accountNumber: String!
+
+  """Proposed new account type"""
+  accountType: String!
+
+  """Proposed new bank branch"""
+  bankBranch: String!
+
+  """Proposed new bank name"""
+  bankName: String!
+
+  """Account currency (unchanged from the current account)"""
+  currency: String!
+
+  """Reviewer note, set when status is Rejected"""
+  rejectionReason: String
+
+  """Pending | Approved | Rejected | Closed"""
+  status: String!
+}
+
+input BankAccountUpdateRequestInput {
+  accountNumber: AccountNumber!
+  accountType: String!
+
+  """ERPNext identifier of the account to update"""
+  bankAccountId: ID!
+  bankBranch: String!
+  bankName: String!
+
+  """Must match the account's current currency (currency is locked)"""
+  currency: String!
+}
+
+type BankAccountUpdateRequestPayload {
+  errors: [Error]
+
+  """Status of the created request (Pending on success)"""
+  status: String
 }
 
 type BridgeAddExternalAccountPayload {
@@ -1030,6 +1081,7 @@ type Mutation {
   bridgeInitiateKyc(input: BridgeInitiateKycInput!): BridgeInitiateKycPayload!
   bridgeInitiateWithdrawal(input: BridgeInitiateWithdrawalInput!): BridgeInitiateWithdrawalPayload!
   bridgeRequestWithdrawal(input: BridgeRequestWithdrawalInput!): BridgeRequestWithdrawalPayload!
+  bankAccountUpdateRequest(input: BankAccountUpdateRequestInput!): BankAccountUpdateRequestPayload!
   businessAccountUpgradeRequest(input: BusinessAccountUpgradeRequestInput!): AccountUpgradePayload!
   callbackEndpointAdd(input: CallbackEndpointAddInput!): CallbackEndpointAddPayload!
   callbackEndpointDelete(input: CallbackEndpointDeleteInput!): SuccessPayload!

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -152,6 +152,7 @@ const en: BaseTranslation = {
     confirmMessage:
       "Cash-outs keep going to your current account until the new details are approved.",
     updateSubmitted: "Update submitted for review",
+    lastRequestDeclined: "Your last request was declined: {reason: string}",
   },
   BridgeAddExternalAccount: {
     title: "Add Bank Account",

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -141,6 +141,17 @@ const en: BaseTranslation = {
     removingAccountsComingSoon: "Removing accounts is coming soon",
     accountEnding: "Account ending {last4: string}",
     defaultUpdated: "Default account updated",
+    updateDetails: "Update details",
+    editTitle: "Update bank account",
+    editSubtitle:
+      "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    currencyLocked:
+      "Currency can't be changed here. To use a different currency, add a new account.",
+    submitUpdate: "Submit for review",
+    confirmTitle: "Submit changes?",
+    confirmMessage:
+      "Cash-outs keep going to your current account until the new details are approved.",
+    updateSubmitted: "Update submitted for review",
   },
   BridgeAddExternalAccount: {
     title: "Add Bank Account",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -490,6 +490,38 @@ type RootTranslation = {
 		 * D​e​f​a​u​l​t​ ​a​c​c​o​u​n​t​ ​u​p​d​a​t​e​d
 		 */
 		defaultUpdated: string
+		/**
+		 * U​p​d​a​t​e​ ​d​e​t​a​i​l​s
+		 */
+		updateDetails: string
+		/**
+		 * U​p​d​a​t​e​ ​b​a​n​k​ ​a​c​c​o​u​n​t
+		 */
+		editTitle: string
+		/**
+		 * C​h​a​n​g​e​s​ ​a​r​e​ ​r​e​v​i​e​w​e​d​ ​b​e​f​o​r​e​ ​t​h​e​y​ ​t​a​k​e​ ​e​f​f​e​c​t​.​ ​C​a​s​h​-​o​u​t​s​ ​k​e​e​p​ ​g​o​i​n​g​ ​t​o​ ​y​o​u​r​ ​c​u​r​r​e​n​t​ ​d​e​t​a​i​l​s​ ​u​n​t​i​l​ ​t​h​e​n​.
+		 */
+		editSubtitle: string
+		/**
+		 * C​u​r​r​e​n​c​y​ ​c​a​n​'​t​ ​b​e​ ​c​h​a​n​g​e​d​ ​h​e​r​e​.​ ​T​o​ ​u​s​e​ ​a​ ​d​i​f​f​e​r​e​n​t​ ​c​u​r​r​e​n​c​y​,​ ​a​d​d​ ​a​ ​n​e​w​ ​a​c​c​o​u​n​t​.
+		 */
+		currencyLocked: string
+		/**
+		 * S​u​b​m​i​t​ ​f​o​r​ ​r​e​v​i​e​w
+		 */
+		submitUpdate: string
+		/**
+		 * S​u​b​m​i​t​ ​c​h​a​n​g​e​s​?
+		 */
+		confirmTitle: string
+		/**
+		 * C​a​s​h​-​o​u​t​s​ ​k​e​e​p​ ​g​o​i​n​g​ ​t​o​ ​y​o​u​r​ ​c​u​r​r​e​n​t​ ​a​c​c​o​u​n​t​ ​u​n​t​i​l​ ​t​h​e​ ​n​e​w​ ​d​e​t​a​i​l​s​ ​a​r​e​ ​a​p​p​r​o​v​e​d​.
+		 */
+		confirmMessage: string
+		/**
+		 * U​p​d​a​t​e​ ​s​u​b​m​i​t​t​e​d​ ​f​o​r​ ​r​e​v​i​e​w
+		 */
+		updateSubmitted: string
 	}
 	BridgeAddExternalAccount: {
 		/**
@@ -6382,6 +6414,38 @@ export type TranslationFunctions = {
 		 * Default account updated
 		 */
 		defaultUpdated: () => LocalizedString
+		/**
+		 * Update details
+		 */
+		updateDetails: () => LocalizedString
+		/**
+		 * Update bank account
+		 */
+		editTitle: () => LocalizedString
+		/**
+		 * Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.
+		 */
+		editSubtitle: () => LocalizedString
+		/**
+		 * Currency can't be changed here. To use a different currency, add a new account.
+		 */
+		currencyLocked: () => LocalizedString
+		/**
+		 * Submit for review
+		 */
+		submitUpdate: () => LocalizedString
+		/**
+		 * Submit changes?
+		 */
+		confirmTitle: () => LocalizedString
+		/**
+		 * Cash-outs keep going to your current account until the new details are approved.
+		 */
+		confirmMessage: () => LocalizedString
+		/**
+		 * Update submitted for review
+		 */
+		updateSubmitted: () => LocalizedString
 	}
 	BridgeAddExternalAccount: {
 		/**

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -522,6 +522,11 @@ type RootTranslation = {
 		 * U​p​d​a​t​e​ ​s​u​b​m​i​t​t​e​d​ ​f​o​r​ ​r​e​v​i​e​w
 		 */
 		updateSubmitted: string
+		/**
+		 * Y​o​u​r​ ​l​a​s​t​ ​r​e​q​u​e​s​t​ ​w​a​s​ ​d​e​c​l​i​n​e​d​:​ ​{​r​e​a​s​o​n​}
+		 * @param {string} reason
+		 */
+		lastRequestDeclined: RequiredParams<'reason'>
 	}
 	BridgeAddExternalAccount: {
 		/**
@@ -6446,6 +6451,10 @@ export type TranslationFunctions = {
 		 * Update submitted for review
 		 */
 		updateSubmitted: () => LocalizedString
+		/**
+		 * Your last request was declined: {reason}
+		 */
+		lastRequestDeclined: (arg: { reason: string }) => LocalizedString
 	}
 	BridgeAddExternalAccount: {
 		/**

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -131,7 +131,8 @@
         "submitUpdate": "Submit for review",
         "confirmTitle": "Submit changes?",
         "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
-        "updateSubmitted": "Update submitted for review"
+        "updateSubmitted": "Update submitted for review",
+        "lastRequestDeclined": "Your last request was declined: {reason: string}"
     },
     "BridgeAddExternalAccount": {
         "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -123,7 +123,15 @@
         "removeComingSoon": "Remove (coming soon)",
         "removingAccountsComingSoon": "Removing accounts is coming soon",
         "accountEnding": "Account ending {last4: string}",
-        "defaultUpdated": "Default account updated"
+        "defaultUpdated": "Default account updated",
+        "updateDetails": "Update details",
+        "editTitle": "Update bank account",
+        "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+        "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+        "submitUpdate": "Submit for review",
+        "confirmTitle": "Submit changes?",
+        "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+        "updateSubmitted": "Update submitted for review"
     },
     "BridgeAddExternalAccount": {
         "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -1630,7 +1630,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -1635,7 +1635,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -1635,7 +1635,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -1629,7 +1629,16 @@
     "removeComingSoon": "Remove (coming soon)",
     "removingAccountsComingSoon": "Removing accounts is coming soon",
     "accountEnding": "Account ending {last4: string}",
-    "defaultUpdated": "Default account updated"
+    "defaultUpdated": "Default account updated",
+    "updateDetails": "Update details",
+    "editTitle": "Update bank account",
+    "editSubtitle": "Changes are reviewed before they take effect. Cash-outs keep going to your current details until then.",
+    "currencyLocked": "Currency can't be changed here. To use a different currency, add a new account.",
+    "submitUpdate": "Submit for review",
+    "confirmTitle": "Submit changes?",
+    "confirmMessage": "Cash-outs keep going to your current account until the new details are approved.",
+    "updateSubmitted": "Update submitted for review",
+    "lastRequestDeclined": "Your last request was declined: {reason: string}"
   },
   "BridgeAddExternalAccount": {
     "title": "Add Bank Account",

--- a/app/navigation/root-navigator.tsx
+++ b/app/navigation/root-navigator.tsx
@@ -64,6 +64,7 @@ import { makeStyles, useTheme } from "@rneui/themed"
 import { ScanningQRCodeScreen } from "../screens/send-bitcoin-screen"
 import { SettingsScreen } from "../screens/settings-screen"
 import { BankAccountsScreen } from "@app/screens/settings-screen/bank-accounts/bank-accounts-screen"
+import { EditBankAccountScreen } from "@app/screens/settings-screen/bank-accounts/edit-bank-account-screen"
 import { LanguageScreen } from "../screens/settings-screen/language-screen"
 import { SecurityScreen } from "../screens/settings-screen/security-screen"
 import { TransactionDetailScreen } from "../screens/transaction-detail-screen"
@@ -369,6 +370,11 @@ export const RootStack = () => {
         name="BankAccounts"
         component={BankAccountsScreen}
         options={{ title: LL.BankAccountsScreen.title() }}
+      />
+      <RootNavigator.Screen
+        name="EditBankAccount"
+        component={EditBankAccountScreen}
+        options={{ title: LL.BankAccountsScreen.editTitle() }}
       />
       <RootNavigator.Screen
         name="defaultWallet"

--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -47,6 +47,7 @@ export type RootStackParamList = {
     accountType: string
     accountNumber: string
     currency: string
+    rejectionReason?: string
   }
   defaultWallet: undefined
   theme: undefined

--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -40,6 +40,14 @@ export type RootStackParamList = {
   settings: undefined
   addressScreen: undefined
   BankAccounts: undefined
+  EditBankAccount: {
+    accountId: string
+    bankName: string
+    bankBranch: string
+    accountType: string
+    accountNumber: string
+    currency: string
+  }
   defaultWallet: undefined
   theme: undefined
   sendBitcoinDestination: {

--- a/app/screens/settings-screen/bank-accounts/bank-accounts-screen.tsx
+++ b/app/screens/settings-screen/bank-accounts/bank-accounts-screen.tsx
@@ -392,6 +392,8 @@ export const BankAccountsScreen: React.FC = () => {
                       accountType: account.accountType ?? "",
                       accountNumber: account.accountNumber ?? "",
                       currency: account.currencyRaw ?? account.currency,
+                      rejectionReason:
+                        account.pendingUpdate?.rejectionReason ?? undefined,
                     })
                   }
                 />

--- a/app/screens/settings-screen/bank-accounts/bank-accounts-screen.tsx
+++ b/app/screens/settings-screen/bank-accounts/bank-accounts-screen.tsx
@@ -182,9 +182,10 @@ const StatusPill = ({ status }: { status: BankAccountStatus }) => {
 type WithdrawRowProps = {
   account: BankAccountVM
   onSetDefault: () => void
+  onEdit: () => void
 }
 
-const WithdrawRow = ({ account, onSetDefault }: WithdrawRowProps) => {
+const WithdrawRow = ({ account, onSetDefault, onEdit }: WithdrawRowProps) => {
   const styles = useStyles()
   const { colors } = useTheme().theme
   const { LL } = useI18nContext()
@@ -197,6 +198,9 @@ const WithdrawRow = ({ account, onSetDefault }: WithdrawRowProps) => {
     }[] = []
     if (account.canSetDefault && !account.isDefault) {
       options.push({ text: LL.BankAccountsScreen.setAsDefault(), onPress: onSetDefault })
+    }
+    if (account.source === "erpnext") {
+      options.push({ text: LL.BankAccountsScreen.updateDetails(), onPress: onEdit })
     }
     options.push({
       text: account.canRemove
@@ -380,6 +384,16 @@ export const BankAccountsScreen: React.FC = () => {
                       message: LL.BankAccountsScreen.defaultUpdated(),
                     })
                   }}
+                  onEdit={() =>
+                    navigation.navigate("EditBankAccount", {
+                      accountId: account.id,
+                      bankName: account.bankName,
+                      bankBranch: account.bankBranch ?? "",
+                      accountType: account.accountType ?? "",
+                      accountNumber: account.accountNumber ?? "",
+                      currency: account.currencyRaw ?? account.currency,
+                    })
+                  }
                 />
               ))}
             </View>

--- a/app/screens/settings-screen/bank-accounts/edit-bank-account-screen.tsx
+++ b/app/screens/settings-screen/bank-accounts/edit-bank-account-screen.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react"
-import { Alert, ScrollView } from "react-native"
+import { Alert, ScrollView, View } from "react-native"
 import { makeStyles, Text, useTheme } from "@rneui/themed"
 import { StackScreenProps } from "@react-navigation/stack"
 
@@ -20,6 +20,8 @@ const accountTypes = [
   { label: "Savings", value: "Savings" },
 ]
 
+const ALLOWED_ACCOUNT_TYPES = ["Chequing", "Savings"]
+
 type Props = StackScreenProps<RootStackParamList, "EditBankAccount">
 
 // Lets a user propose changes to an already-approved bank account. The change is
@@ -31,11 +33,15 @@ export const EditBankAccountScreen: React.FC<Props> = ({ route, navigation }) =>
   const { colors } = useTheme().theme
   const { LL } = useI18nContext()
 
-  const { accountId, currency } = route.params
+  const { accountId, currency, rejectionReason } = route.params
 
   const [bankName, setBankName] = useState(route.params.bankName)
   const [bankBranch, setBankBranch] = useState(route.params.bankBranch)
-  const [accountType, setAccountType] = useState(route.params.accountType)
+  const [accountType, setAccountType] = useState(
+    ALLOWED_ACCOUNT_TYPES.includes(route.params.accountType)
+      ? route.params.accountType
+      : "",
+  )
   const [accountNumber, setAccountNumber] = useState(route.params.accountNumber)
 
   const [nameErr, setNameErr] = useState<string>()
@@ -61,8 +67,8 @@ export const EditBankAccountScreen: React.FC<Props> = ({ route, navigation }) =>
       setBranchErr("Branch is required")
       ok = false
     }
-    if (!accountType) {
-      setAccountTypeErr("Account type is required")
+    if (!ALLOWED_ACCOUNT_TYPES.includes(accountType)) {
+      setAccountTypeErr("Account type must be Chequing or Savings")
       ok = false
     }
     if (!accountNumber || accountNumber.length < 4) {
@@ -123,6 +129,13 @@ export const EditBankAccountScreen: React.FC<Props> = ({ route, navigation }) =>
         <Text type="p3" color={colors.grey2} style={styles.subtitle}>
           {LL.BankAccountsScreen.editSubtitle()}
         </Text>
+        {rejectionReason ? (
+          <View style={styles.declinedBanner}>
+            <Text type="p3" color={colors.error}>
+              {LL.BankAccountsScreen.lastRequestDeclined({ reason: rejectionReason })}
+            </Text>
+          </View>
+        ) : null}
         <DropDownField
           label={LL.AccountUpgrade.bankName()}
           placeholder={LL.AccountUpgrade.bankNamePlaceholder()}
@@ -187,11 +200,18 @@ export const EditBankAccountScreen: React.FC<Props> = ({ route, navigation }) =>
 
 export default EditBankAccountScreen
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles(({ colors }) => ({
   container: {
     flex: 1,
     paddingVertical: 10,
     paddingHorizontal: 20,
+  },
+  declinedBanner: {
+    marginBottom: 16,
+    padding: 12,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: colors.error,
   },
   subtitle: {
     marginBottom: 16,

--- a/app/screens/settings-screen/bank-accounts/edit-bank-account-screen.tsx
+++ b/app/screens/settings-screen/bank-accounts/edit-bank-account-screen.tsx
@@ -1,0 +1,207 @@
+import React, { useMemo, useState } from "react"
+import { Alert, ScrollView } from "react-native"
+import { makeStyles, Text, useTheme } from "@rneui/themed"
+import { StackScreenProps } from "@react-navigation/stack"
+
+import { DropDownField, InputField } from "@app/components/account-upgrade-flow"
+import { Screen } from "@app/components/screen"
+import { PrimaryBtn } from "@app/components/buttons"
+import { RootStackParamList } from "@app/navigation/stack-param-lists"
+import { useI18nContext } from "@app/i18n/i18n-react"
+import { toastShow } from "@app/utils/toast"
+import {
+  useBankAccountUpdateRequestMutation,
+  useSupportedBanksQuery,
+} from "@app/graphql/generated"
+
+const accountTypes = [
+  { label: "Select account type", value: null },
+  { label: "Chequing", value: "Chequing" },
+  { label: "Savings", value: "Savings" },
+]
+
+type Props = StackScreenProps<RootStackParamList, "EditBankAccount">
+
+// Lets a user propose changes to an already-approved bank account. The change is
+// NOT applied immediately: it is submitted for admin review, and cash-outs keep
+// settling to the account's current details until it is approved. Currency is
+// locked (it drives the payout rail), so it is shown read-only.
+export const EditBankAccountScreen: React.FC<Props> = ({ route, navigation }) => {
+  const styles = useStyles()
+  const { colors } = useTheme().theme
+  const { LL } = useI18nContext()
+
+  const { accountId, currency } = route.params
+
+  const [bankName, setBankName] = useState(route.params.bankName)
+  const [bankBranch, setBankBranch] = useState(route.params.bankBranch)
+  const [accountType, setAccountType] = useState(route.params.accountType)
+  const [accountNumber, setAccountNumber] = useState(route.params.accountNumber)
+
+  const [nameErr, setNameErr] = useState<string>()
+  const [branchErr, setBranchErr] = useState<string>()
+  const [accountTypeErr, setAccountTypeErr] = useState<string>()
+  const [accountNumErr, setAccountNumErr] = useState<string>()
+
+  const { data } = useSupportedBanksQuery()
+  const supportedBanks = useMemo(
+    () => data?.supportedBanks.map((el) => ({ label: el.name, value: el.name })) ?? [],
+    [data?.supportedBanks],
+  )
+
+  const [submit, { loading }] = useBankAccountUpdateRequestMutation()
+
+  const validate = () => {
+    let ok = true
+    if (!bankName || bankName.length < 2) {
+      setNameErr("Bank name is required")
+      ok = false
+    }
+    if (!bankBranch || bankBranch.length < 2) {
+      setBranchErr("Branch is required")
+      ok = false
+    }
+    if (!accountType) {
+      setAccountTypeErr("Account type is required")
+      ok = false
+    }
+    if (!accountNumber || accountNumber.length < 4) {
+      setAccountNumErr("Account number is required")
+      ok = false
+    }
+    return ok
+  }
+
+  const onSubmit = async () => {
+    try {
+      const res = await submit({
+        variables: {
+          input: {
+            bankAccountId: accountId,
+            bankName,
+            bankBranch,
+            accountType,
+            currency,
+            accountNumber,
+          },
+        },
+      })
+      const errors = res.data?.bankAccountUpdateRequest.errors ?? []
+      if (errors.length) {
+        Alert.alert(
+          "",
+          errors
+            .map((e) => e?.message ?? "")
+            .filter(Boolean)
+            .join(", "),
+        )
+        return
+      }
+      toastShow({ type: "success", message: LL.BankAccountsScreen.updateSubmitted() })
+      navigation.goBack()
+    } catch (err) {
+      Alert.alert("", err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const onPressSubmit = () => {
+    if (loading) return
+    if (!validate()) return
+    Alert.alert(
+      LL.BankAccountsScreen.confirmTitle(),
+      LL.BankAccountsScreen.confirmMessage(),
+      [
+        { text: LL.common.cancel(), style: "cancel" },
+        { text: LL.BankAccountsScreen.submitUpdate(), onPress: onSubmit },
+      ],
+    )
+  }
+
+  return (
+    <Screen>
+      <ScrollView style={styles.container}>
+        <Text type="p3" color={colors.grey2} style={styles.subtitle}>
+          {LL.BankAccountsScreen.editSubtitle()}
+        </Text>
+        <DropDownField
+          label={LL.AccountUpgrade.bankName()}
+          placeholder={LL.AccountUpgrade.bankNamePlaceholder()}
+          data={supportedBanks}
+          value={bankName}
+          errorMsg={nameErr}
+          onChange={(val) => {
+            setNameErr(undefined)
+            setBankName(val)
+          }}
+        />
+        <InputField
+          label={LL.AccountUpgrade.bankBranch()}
+          placeholder={LL.AccountUpgrade.bankBranchPlaceholder()}
+          value={bankBranch}
+          errorMsg={branchErr}
+          onChangeText={(val) => {
+            setBranchErr(undefined)
+            setBankBranch(val)
+          }}
+          autoCapitalize="words"
+        />
+        <DropDownField
+          label={LL.AccountUpgrade.bankAccountType()}
+          placeholder={LL.AccountUpgrade.selectBankAccountType()}
+          data={accountTypes}
+          value={accountType}
+          errorMsg={accountTypeErr}
+          onChange={(val) => {
+            setAccountTypeErr(undefined)
+            setAccountType(val)
+          }}
+        />
+        <InputField
+          label={LL.AccountUpgrade.currency()}
+          value={currency}
+          editable={false}
+        />
+        <Text type="caption" color={colors.grey2} style={styles.lockNote}>
+          {LL.BankAccountsScreen.currencyLocked()}
+        </Text>
+        <InputField
+          label={LL.AccountUpgrade.accountNum()}
+          placeholder={LL.AccountUpgrade.accountNumPlaceholder()}
+          value={accountNumber}
+          errorMsg={accountNumErr}
+          onChangeText={(val) => {
+            setAccountNumErr(undefined)
+            setAccountNumber(val)
+          }}
+          keyboardType="number-pad"
+        />
+      </ScrollView>
+      <PrimaryBtn
+        label={LL.BankAccountsScreen.submitUpdate()}
+        btnStyle={styles.btn}
+        onPress={onPressSubmit}
+      />
+    </Screen>
+  )
+}
+
+export default EditBankAccountScreen
+
+const useStyles = makeStyles(() => ({
+  container: {
+    flex: 1,
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+  },
+  subtitle: {
+    marginBottom: 16,
+  },
+  lockNote: {
+    marginTop: -8,
+    marginBottom: 15,
+  },
+  btn: {
+    marginVertical: 10,
+    marginHorizontal: 20,
+  },
+}))

--- a/app/screens/settings-screen/bank-accounts/types.ts
+++ b/app/screens/settings-screen/bank-accounts/types.ts
@@ -40,6 +40,23 @@ export type BankAccountVM = {
   routingNumber?: string | null
   /** Provisioning still in flight (receive account not ready yet). */
   pending?: boolean
+
+  // Withdraw (ERPNext) extras — prefill the "update details" screen and surface
+  // an in-review change. Undefined for other rails.
+  bankBranch?: string
+  accountType?: string
+  /** Raw currency value as stored server-side (echoed back on update; currency is locked). */
+  currencyRaw?: string
+  /** Open request to change this account's details, awaiting review (null when none). */
+  pendingUpdate?: {
+    status: string
+    bankName: string
+    bankBranch: string
+    accountType: string
+    accountNumber: string
+    currency: string
+    rejectionReason?: string | null
+  } | null
 }
 
 export type WithdrawGroup = {

--- a/app/screens/settings-screen/bank-accounts/use-bank-accounts.ts
+++ b/app/screens/settings-screen/bank-accounts/use-bank-accounts.ts
@@ -165,11 +165,19 @@ export const useBankAccounts = (): UseBankAccounts => {
         bankName: bank.bankName,
         last4: last4Of(bank.accountNumber),
         currency: currencyKey(bank.currency) || "LOCAL",
-        status: "verified",
+        status: bank.pendingUpdate
+          ? normalizeStatus(bank.pendingUpdate.status)
+          : "verified",
         isDefault: false,
         canSetDefault: true, // interim client-side; server has no mutation yet
         canRemove: false,
         serverDefault: bank.isDefault,
+        // Prefill + in-review surface for the "update details" flow.
+        accountNumber: bank.accountNumber,
+        bankBranch: bank.bankBranch,
+        accountType: bank.accountType,
+        currencyRaw: bank.currency,
+        pendingUpdate: bank.pendingUpdate ?? null,
       })
     })
 


### PR DESCRIPTION
## What & why

Client side of **ENG-509** — lets a user update an approved Jamaican bank account from **Settings → Ways to get paid → Bank accounts**. (Companion PRs in `flash` and `frappe-flash-admin`.)

## Changes

- New **`EditBankAccount`** screen — reuses the upgrade-flow `DropDownField`/`InputField` + `SupportedBanks`, prefilled from the current account, **currency read-only (locked)**, with a confirm sheet: *"Cash-outs keep going to your current account until the new details are approved."*
- **"Update details"** entry in the `WithdrawRow` action sheet for ERPNext (`source: "erpnext"`) rows.
- `use-bank-accounts` now derives the row status pill from the account's `pendingUpdate` (shows Pending while under review) instead of a hardcoded `"verified"`.
- GraphQL: `bankAccountUpdateRequest` mutation + `pendingUpdate` selection on the `BankAccounts` query (regenerated `generated.ts` / `.gql` against the local `public-schema.graphql`).
- Navigation route + i18n strings.

## Testing

`yarn dev:codegen` ✓ · `yarn tsc:check` ✓ · `graphql-check` (operations valid vs schema) ✓ · `yarn update-translations` ✓ · eslint ✓.

## Depends on

The `flash` backend PR (mutation + `BankAccount.pendingUpdate`) must land for this to function end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
