### PR TITLE
fix(mobile): address v0.6.0-beta user-test feedback (ENG-511)

### DIFF
--- a/__tests__/components/wallet-overview.spec.tsx
+++ b/__tests__/components/wallet-overview.spec.tsx
@@ -1,0 +1,89 @@
+import * as React from "react"
+import { createTheme, ThemeProvider } from "@rneui/themed"
+import { render, act } from "@testing-library/react-native"
+
+import { i18nObject } from "../../app/i18n/i18n-util"
+import WalletOverview from "../../app/components/wallet-overview/wallet-overview"
+
+// The display-currency converter is undefined until the realtime price query
+// resolves; that is the ENG-512 race. This handle lets each test drive it.
+const mockMoneyToDisplay = jest.fn()
+
+jest.mock("@app/hooks/use-display-currency", () => ({
+  useDisplayCurrency: () => ({
+    formatMoneyAmount: () => "1000 sats",
+    displayCurrency: "USD",
+    moneyAmountToDisplayCurrencyString: mockMoneyToDisplay,
+  }),
+}))
+jest.mock("@app/hooks", () => ({
+  useBreez: () => ({ btcWallet: { balance: 0 } }),
+  // A previously-linked card: lnurl + balance are restored from cached HTML on
+  // mount, so the flashcard row renders even before any live price/read.
+  useFlashcard: () => ({
+    lnurl: "lnurl1abc",
+    balanceInSats: 12345,
+    readFlashcard: jest.fn(),
+  }),
+}))
+jest.mock("@app/store/persistent-state", () => ({
+  usePersistentStateContext: () => ({
+    // Seeded from a previous session — the values that must survive the race.
+    // Cash "0" and card "$5.00" are distinct so we can tell the rows apart.
+    persistentState: {
+      isAdvanceMode: false,
+      cashDisplayBalance: "0",
+      cardDisplayBalance: "$5.00",
+    },
+    updateState: jest.fn(),
+  }),
+}))
+jest.mock("@app/graphql/is-authed-context", () => ({ useIsAuthed: () => true }))
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useWalletOverviewScreenQuery: () => ({
+    data: { me: { defaultAccount: { wallets: [] } } },
+  }),
+  useHideBalanceQuery: () => ({ data: { hideBalance: false } }),
+}))
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({ LL: i18nObject("en") }),
+}))
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: jest.fn() }),
+}))
+
+const renderOverview = () =>
+  render(
+    <ThemeProvider theme={createTheme({})}>
+      <WalletOverview setIsUnverifiedSeedModalVisible={jest.fn()} />
+    </ThemeProvider>,
+  )
+
+describe("WalletOverview flashcard balance (ENG-512)", () => {
+  afterEach(() => mockMoneyToDisplay.mockReset())
+
+  it("keeps the cached card balance when price conversion isn't ready", async () => {
+    // Converter not ready → returns undefined for every wallet, as on cold start.
+    mockMoneyToDisplay.mockReturnValue(undefined)
+
+    const screen = renderOverview()
+    await act(async () => {})
+
+    // Regression guard: a linked card must keep showing its persisted balance
+    // instead of blanking to the empty "Add Flashcard" state (only the card row
+    // carries $5.00, so this proves the card row specifically survived).
+    expect(screen.queryAllByText(/\$5\.00/).length).toBeGreaterThan(0)
+  })
+
+  it("updates the card balance once price conversion resolves", async () => {
+    mockMoneyToDisplay.mockReturnValue("$9.99")
+
+    const screen = renderOverview()
+    await act(async () => {})
+
+    // Once the price is ready the row refreshes off the stale cached value.
+    expect(screen.queryAllByText(/\$9\.99/).length).toBeGreaterThan(0)
+    expect(screen.queryByText(/\$5\.00/)).toBeNull()
+  })
+})

--- a/app/components/home-screen/QuickStart.tsx
+++ b/app/components/home-screen/QuickStart.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
-import { Dimensions, Linking, TouchableOpacity, View } from "react-native"
+import { Dimensions, TouchableOpacity, View } from "react-native"
 import { Icon, makeStyles, Text, useTheme } from "@rneui/themed"
 import { StackNavigationProp } from "@react-navigation/stack"
 import Carousel from "react-native-reanimated-carousel"
@@ -9,8 +9,6 @@ import * as Keychain from "react-native-keychain"
 // assets
 import Account from "@app/assets/illustrations/account.svg"
 import Dollar from "@app/assets/illustrations/dollar.svg"
-import Flashcard from "@app/assets/icons/empty-flashcard.svg"
-import NonCustodialWallet from "@app/assets/illustrations/non-custodial-wallet.svg"
 import GoldWallet from "@app/assets/illustrations/gold-wallet.svg"
 import SecureWallet from "@app/assets/illustrations/secure-wallet.svg"
 import SocialChat from "@app/assets/illustrations/social-chat.svg"
@@ -93,25 +91,6 @@ const QuickStart = () => {
       onPress: () => navigation.navigate("currency"),
     },
     {
-      type: "flashcard",
-      title: LL.HomeScreen.flashcardTitle(),
-      description: LL.HomeScreen.flashcardDesc(),
-      image: Flashcard,
-      onPress: () => navigation.navigate("Map"),
-    },
-    {
-      type: "nonCustodialWallet",
-      title: LL.HomeScreen.nonCustodialWalletTitle(),
-      description: LL.HomeScreen.nonCustodialWalletDesc(),
-      image: NonCustodialWallet,
-      onPress: () => {
-        onHide("nonCustodialWallet")
-        Linking.openURL(
-          "https://documentation.getflash.io/en/guides/non-custodial-wallets",
-        )
-      },
-    },
-    {
       type: "email",
       title: LL.HomeScreen.emailTitle(),
       description: LL.HomeScreen.emailDesc(),
@@ -152,15 +131,6 @@ const QuickStart = () => {
     persistentState?.closedQuickStartTypes?.includes("currency")
   ) {
     carouselData = carouselData.filter((el) => el.type !== "currency")
-  }
-  if (
-    persistentState.flashcardAdded ||
-    persistentState?.closedQuickStartTypes?.includes("flashcard")
-  ) {
-    carouselData = carouselData.filter((el) => el.type !== "flashcard")
-  }
-  if (persistentState?.closedQuickStartTypes?.includes("nonCustodialWallet")) {
-    carouselData = carouselData.filter((el) => el.type !== "nonCustodialWallet")
   }
   if (
     data?.me?.defaultAccount.level === AccountLevel.Zero ||

--- a/app/components/wallet-overview/wallet-overview.tsx
+++ b/app/components/wallet-overview/wallet-overview.tsx
@@ -75,34 +75,37 @@ const WalletOverview: React.FC<Props> = ({ setIsUnverifiedSeedModalVisible }) =>
 
   useEffect(() => {
     if (isAuthed) formatBalance()
-  }, [isAuthed, data?.me?.defaultAccount?.wallets, btcWallet?.balance, displayCurrency])
+  }, [
+    isAuthed,
+    data?.me?.defaultAccount?.wallets,
+    btcWallet?.balance,
+    displayCurrency,
+    // recompute once price conversion becomes ready so the balance isn't stuck blank/stale (ENG-512)
+    moneyAmountToDisplayCurrencyString,
+  ])
 
   const formatBalance = () => {
     const extBtcWalletBalance = toBtcMoneyAmount(btcWallet?.balance ?? NaN)
-    setBtcBalance(
-      formatMoneyAmount({
-        moneyAmount: extBtcWalletBalance,
-      }),
-    )
-    setBtcDisplayBalance(
-      moneyAmountToDisplayCurrencyString({
-        moneyAmount: extBtcWalletBalance,
-      }),
-    )
+    const btcAmount = formatMoneyAmount({ moneyAmount: extBtcWalletBalance })
+    const btcDisplay = moneyAmountToDisplayCurrencyString({
+      moneyAmount: extBtcWalletBalance,
+    })
+    // Only overwrite once we have a real value. On a fresh login the wallet
+    // query can resolve before price conversion is ready (or the Cash wallet
+    // is briefly missing mid USD→USDT cutover); writing the resulting
+    // ""/undefined would clobber the balance and render a blank card (ENG-512).
+    if (btcAmount) setBtcBalance(btcAmount)
+    if (btcDisplay) setBtcDisplayBalance(btcDisplay)
 
     if (data) {
       const extUsdWallet = getCashWallet(data?.me?.defaultAccount?.wallets)
       const extUsdWalletBalance = toUsdMoneyAmount(extUsdWallet?.balance ?? NaN)
-      setCashBalance(
-        formatMoneyAmount({
-          moneyAmount: extUsdWalletBalance,
-        }),
-      )
-      setCashDisplayBalance(
-        moneyAmountToDisplayCurrencyString({
-          moneyAmount: extUsdWalletBalance,
-        }),
-      )
+      const cashAmount = formatMoneyAmount({ moneyAmount: extUsdWalletBalance })
+      const cashDisplay = moneyAmountToDisplayCurrencyString({
+        moneyAmount: extUsdWalletBalance,
+      })
+      if (cashAmount) setCashBalance(cashAmount)
+      if (cashDisplay) setCashDisplayBalance(cashDisplay)
     }
   }
 
@@ -151,16 +154,18 @@ const WalletOverview: React.FC<Props> = ({ setIsUnverifiedSeedModalVisible }) =>
           rightIcon={persistentState.backedUpBtcWallet ? undefined : "warning"}
         />
       )}
-      <Balance
-        icon={!!formattedCardBalance ? "flashcard" : "cardAdd"}
-        title={LL.HomeScreen.flashcard()}
-        amount={formattedCardBalance}
-        currency={displayCurrency}
-        emptyText={LL.HomeScreen.addFlashcard()}
-        onPress={onPressFlashcard}
-        onPressRightBtn={() => readFlashcard(false)}
-        rightIcon={"sync"}
-      />
+      {lnurl && (
+        <Balance
+          icon={!!formattedCardBalance ? "flashcard" : "cardAdd"}
+          title={LL.HomeScreen.flashcard()}
+          amount={formattedCardBalance}
+          currency={displayCurrency}
+          emptyText={LL.HomeScreen.addFlashcard()}
+          onPress={onPressFlashcard}
+          onPressRightBtn={() => readFlashcard(false)}
+          rightIcon={"sync"}
+        />
+      )}
     </View>
   )
 }

--- a/app/components/wallet-overview/wallet-overview.tsx
+++ b/app/components/wallet-overview/wallet-overview.tsx
@@ -51,13 +51,17 @@ const WalletOverview: React.FC<Props> = ({ setIsUnverifiedSeedModalVisible }) =>
   const [cashDisplayBalance, setCashDisplayBalance] = useState<string | undefined>(
     persistentState?.cashDisplayBalance || "0",
   )
+  const [cardDisplayBalance, setCardDisplayBalance] = useState<string | undefined>(
+    persistentState?.cardDisplayBalance || undefined,
+  )
 
   useEffect(() => {
     if (
       persistentState.btcDisplayBalance !== btcDisplayBalance ||
       persistentState.cashDisplayBalance !== cashDisplayBalance ||
       persistentState.btcBalance !== btcBalance ||
-      persistentState.cashBalance !== cashBalance
+      persistentState.cashBalance !== cashBalance ||
+      persistentState.cardDisplayBalance !== cardDisplayBalance
     ) {
       updateState((state) => {
         if (state)
@@ -67,11 +71,12 @@ const WalletOverview: React.FC<Props> = ({ setIsUnverifiedSeedModalVisible }) =>
             cashDisplayBalance,
             btcBalance,
             cashBalance,
+            cardDisplayBalance,
           }
         return undefined
       })
     }
-  }, [btcDisplayBalance, cashDisplayBalance, btcBalance, cashBalance])
+  }, [btcDisplayBalance, cashDisplayBalance, btcBalance, cashBalance, cardDisplayBalance])
 
   useEffect(() => {
     if (isAuthed) formatBalance()
@@ -79,6 +84,7 @@ const WalletOverview: React.FC<Props> = ({ setIsUnverifiedSeedModalVisible }) =>
     isAuthed,
     data?.me?.defaultAccount?.wallets,
     btcWallet?.balance,
+    balanceInSats,
     displayCurrency,
     // recompute once price conversion becomes ready so the balance isn't stuck blank/stale (ENG-512)
     moneyAmountToDisplayCurrencyString,
@@ -107,6 +113,14 @@ const WalletOverview: React.FC<Props> = ({ setIsUnverifiedSeedModalVisible }) =>
       if (cashAmount) setCashBalance(cashAmount)
       if (cashDisplay) setCashDisplayBalance(cashDisplay)
     }
+
+    // Flashcard balance comes from the (cached) card HTML via useFlashcard and
+    // runs through the same price conversion — guard it identically so a linked
+    // card never flips to the "Add Flashcard" empty state mid-load (ENG-512).
+    const cardDisplay = moneyAmountToDisplayCurrencyString({
+      moneyAmount: toBtcMoneyAmount(balanceInSats ?? NaN),
+    })
+    if (cardDisplay) setCardDisplayBalance(cardDisplay)
   }
 
   const navigateHandler = (activeTab: string) => {
@@ -127,10 +141,6 @@ const WalletOverview: React.FC<Props> = ({ setIsUnverifiedSeedModalVisible }) =>
     if (lnurl) navigation.navigate("Card")
     else readFlashcard()
   }
-
-  const formattedCardBalance = moneyAmountToDisplayCurrencyString({
-    moneyAmount: toBtcMoneyAmount(balanceInSats ?? NaN),
-  })
 
   return (
     <View style={{ marginHorizontal: 20 }}>
@@ -156,13 +166,13 @@ const WalletOverview: React.FC<Props> = ({ setIsUnverifiedSeedModalVisible }) =>
       )}
       {lnurl && (
         <Balance
-          icon={!!formattedCardBalance ? "flashcard" : "cardAdd"}
+          icon={cardDisplayBalance ? "flashcard" : "cardAdd"}
           title={LL.HomeScreen.flashcard()}
-          amount={formattedCardBalance}
+          amount={cardDisplayBalance}
           currency={displayCurrency}
           emptyText={LL.HomeScreen.addFlashcard()}
           onPress={onPressFlashcard}
-          onPressRightBtn={() => readFlashcard(false)}
+          onPressRightBtn={() => readFlashcard()}
           rightIcon={"sync"}
         />
       )}

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -663,10 +663,6 @@ const en: BaseTranslation = {
     upgradePendingDesc: "Your account upgrade request is under review.",
     currencyTitle:"Change to your local currency",
     currencyDesc: "Review our available currency list and select your currency.",
-    flashcardTitle: "Get a Flashcard",
-    flashcardDesc: "Find a Flashpoint and get a Flashcard to use in daily life.",
-    nonCustodialWalletTitle: "Non-custodial wallets",
-    nonCustodialWalletDesc: "Learn more about non-custodial wallets.",
     emailTitle: "Email address",
     emailDesc: "Add your email address to secure your account and login using email address.",
     btcWalletTitle: "Enable BTC wallet",
@@ -982,6 +978,7 @@ const en: BaseTranslation = {
 		maxAmountConvertError: "The conversion amount is greater than maximum amount {amount: number}"
   },
   SettingsScreen: {
+    flashcard: "Flashcard",
     staticQr: "Printable Static QR Code",
     staticQrCopied: "Your static QR code link has been copied",
     setByOs: "Set by OS",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -2124,22 +2124,6 @@ type RootTranslation = {
 		 */
 		currencyDesc: string
 		/**
-		 * G​e​t​ ​a​ ​F​l​a​s​h​c​a​r​d
-		 */
-		flashcardTitle: string
-		/**
-		 * F​i​n​d​ ​a​ ​F​l​a​s​h​p​o​i​n​t​ ​a​n​d​ ​g​e​t​ ​a​ ​F​l​a​s​h​c​a​r​d​ ​t​o​ ​u​s​e​ ​i​n​ ​d​a​i​l​y​ ​l​i​f​e​.
-		 */
-		flashcardDesc: string
-		/**
-		 * N​o​n​-​c​u​s​t​o​d​i​a​l​ ​w​a​l​l​e​t​s
-		 */
-		nonCustodialWalletTitle: string
-		/**
-		 * L​e​a​r​n​ ​m​o​r​e​ ​a​b​o​u​t​ ​n​o​n​-​c​u​s​t​o​d​i​a​l​ ​w​a​l​l​e​t​s​.
-		 */
-		nonCustodialWalletDesc: string
-		/**
 		 * E​m​a​i​l​ ​a​d​d​r​e​s​s
 		 */
 		emailTitle: string
@@ -3240,6 +3224,10 @@ type RootTranslation = {
 		maxAmountConvertError: RequiredParams<'amount'>
 	}
 	SettingsScreen: {
+		/**
+		 * F​l​a​s​h​c​a​r​d
+		 */
+		flashcard: string
 		/**
 		 * P​r​i​n​t​a​b​l​e​ ​S​t​a​t​i​c​ ​Q​R​ ​C​o​d​e
 		 */
@@ -8046,22 +8034,6 @@ export type TranslationFunctions = {
 		 */
 		currencyDesc: () => LocalizedString
 		/**
-		 * Get a Flashcard
-		 */
-		flashcardTitle: () => LocalizedString
-		/**
-		 * Find a Flashpoint and get a Flashcard to use in daily life.
-		 */
-		flashcardDesc: () => LocalizedString
-		/**
-		 * Non-custodial wallets
-		 */
-		nonCustodialWalletTitle: () => LocalizedString
-		/**
-		 * Learn more about non-custodial wallets.
-		 */
-		nonCustodialWalletDesc: () => LocalizedString
-		/**
 		 * Email address
 		 */
 		emailTitle: () => LocalizedString
@@ -9117,6 +9089,10 @@ export type TranslationFunctions = {
 		maxAmountConvertError: (arg: { amount: number }) => LocalizedString
 	}
 	SettingsScreen: {
+		/**
+		 * Flashcard
+		 */
+		flashcard: () => LocalizedString
 		/**
 		 * Printable Static QR Code
 		 */

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -623,10 +623,6 @@
         "upgradePendingDesc": "Your account upgrade request is under review.",
         "currencyTitle": "Change to your local currency",
         "currencyDesc": "Review our available currency list and select your currency.",
-        "flashcardTitle": "Get a Flashcard",
-        "flashcardDesc": "Find a Flashpoint and get a Flashcard to use in daily life.",
-        "nonCustodialWalletTitle": "Non-custodial wallets",
-        "nonCustodialWalletDesc": "Learn more about non-custodial wallets.",
         "emailTitle": "Email address",
         "emailDesc": "Add your email address to secure your account and login using email address.",
         "btcWalletTitle": "Enable BTC wallet",
@@ -914,6 +910,7 @@
         "maxAmountConvertError": "The conversion amount is greater than maximum amount {amount: number}"
     },
     "SettingsScreen": {
+        "flashcard": "Flashcard",
         "staticQr": "Printable Static QR Code",
         "staticQrCopied": "Your static QR code link has been copied",
         "setByOs": "Set by OS",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -491,10 +491,6 @@
     "emailDesc": "Add your email address to secure your account and login using email address.",
     "emailTitle": "Email address",
     "flashcard": "Flashcard",
-    "flashcardDesc": "Find a Flashpoint and get a Flashcard to use in daily life.",
-    "flashcardTitle": "Get a Flashcard",
-    "nonCustodialWalletDesc": "Learn more about non-custodial wallets.",
-    "nonCustodialWalletTitle": "Non-custodial wallets",
     "pay": "Pay",
     "reload": "Reload Card",
     "showQrCode": "Topup via QR",
@@ -748,7 +744,8 @@
     "showNostrSecret": "Chat Settings",
     "showSeedPhrase": "Reveal recovery phrase",
     "staticQr": "Printable Static QR Code",
-    "staticQrCopied": "Your static QR code link has been copied"
+    "staticQrCopied": "Your static QR code link has been copied",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Notaverstellings",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -483,10 +483,6 @@
     "emailDesc": "Add your email address to secure your account and login using email address.",
     "emailTitle": "Email address",
     "flashcard": "Flashcard",
-    "flashcardDesc": "Find a Flashpoint and get a Flashcard to use in daily life.",
-    "flashcardTitle": "Get a Flashcard",
-    "nonCustodialWalletDesc": "Learn more about non-custodial wallets.",
-    "nonCustodialWalletTitle": "Non-custodial wallets",
     "pay": "Pay",
     "reload": "Reload Card",
     "showQrCode": "Topup via QR",
@@ -742,7 +738,8 @@
     "showNostrSecret": "Chat Settings",
     "showSeedPhrase": "Reveal recovery phrase",
     "staticQr": "Printable Static QR Code",
-    "staticQrCopied": "Your static QR code link has been copied"
+    "staticQrCopied": "Your static QR code link has been copied",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Notification Settings",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "La teva sol·licitud d'actualització de compte està en fase d'examen.",
     "currencyTitle": "Canvia a la teva moneda local",
     "currencyDesc": "Revisar la nostra llista de monedes disponibles i seleccionar la seva moneda.",
-    "flashcardTitle": "Obtenir un Flashcard",
-    "flashcardDesc": "Trobar una Flashpoint i obtenir una Flashcard per utilitzar-la en la vida diària.",
-    "nonCustodialWalletTitle": "Els carts no custodials",
-    "nonCustodialWalletDesc": "Descobreix més sobre les carteres no custodials.",
     "emailTitle": "L'adreça de correu electrònic",
     "emailDesc": "Agrega la teva adreça de correu electrònic per protegir el teu compte i iniciar sesión utilitzant l'adreça de correu electrònic.",
     "btcWalletTitle": "Enable BTC wallet",
@@ -787,7 +783,8 @@
     "advanceMode": "Enable Bitcoin Account (Advanced Mode)",
     "keysManagement": "Backup de cartera",
     "showBtcAccount": "Mostreu el compte Bitcoin",
-    "hideBtcAccount": "Escondir un compte Bitcoin"
+    "hideBtcAccount": "Escondir un compte Bitcoin",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Configuració de notificacions",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "Vaše žádost o aktualizaci účtu je přezkoumána.",
     "currencyTitle": "Změňte měnu na svou místní měnu",
     "currencyDesc": "Podívejte se na náš seznam dostupných měn a vyberte si svou měnu.",
-    "flashcardTitle": "Získejte Flashcard",
-    "flashcardDesc": "Najděte Flashpoint a získejte Flashcard k použití v každodenním životě.",
-    "nonCustodialWalletTitle": "Non-custodial peněženky",
-    "nonCustodialWalletDesc": "Přečtěte si více o peněženkách, které nejsou ve vazbě.",
     "emailTitle": "E-mailová adresa",
     "emailDesc": "Přidejte svou e-mailovou adresu k zajištění vašeho účtu a přihlaste se pomocí e-mailové adresy.",
     "btcWalletTitle": "Aktivovat peněženku BTC",
@@ -787,7 +783,8 @@
     "advanceMode": "Aktivujte účet Bitcoin (pokročilý režim)",
     "keysManagement": "Záložní záloha peněženky",
     "showBtcAccount": "Zobrazit Bitcoin účet",
-    "hideBtcAccount": "Schovat účet Bitcoin"
+    "hideBtcAccount": "Schovat účet Bitcoin",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Notification Settings",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "Din kontoopgraderingsanmodning er under gennemgang.",
     "currencyTitle": "Skift til din lokale valuta",
     "currencyDesc": "Gennemgå vores liste over tilgængelige valutaer og vælg din valuta.",
-    "flashcardTitle": "Få en Flashcard",
-    "flashcardDesc": "Find en Flashpoint og få en Flashcard til brug i dagligdagen.",
-    "nonCustodialWalletTitle": "Ikke-custodial tegnebøger",
-    "nonCustodialWalletDesc": "Læs mere om ikke-bevaringsmæssige tegnebøger.",
     "emailTitle": "E-mailadresse",
     "emailDesc": "Tilføj din e-mailadresse for at sikre din konto og log in ved hjælp af en e-mailadresse.",
     "btcWalletTitle": "Aktiver BTC tegnebog",
@@ -787,7 +783,8 @@
     "advanceMode": "Aktiver Bitcoin Account (Advanced Mode)",
     "keysManagement": "Bankmandskabs sikkerhedskopiering",
     "showBtcAccount": "Vis Bitcoin konto",
-    "hideBtcAccount": "Hide Bitcoin konto"
+    "hideBtcAccount": "Hide Bitcoin konto",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Notifikationsindstillinger",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "Ihre Account-Upgrade-Anforderung wird überprüft.",
     "currencyTitle": "Wechseln Sie zu Ihrer lokalen Währung",
     "currencyDesc": "Überprüfen Sie unsere verfügbare Währungsliste und wählen Sie Ihre Währung aus.",
-    "flashcardTitle": "Holen Sie sich einen Flashcard",
-    "flashcardDesc": "Finden Sie einen Flashpoint und holen Sie sich einen Flashcard zum Gebrauch im täglichen Leben.",
-    "nonCustodialWalletTitle": "Nicht-verpflichtige Brieftaschen",
-    "nonCustodialWalletDesc": "Erfahren Sie mehr über nicht-verpflichtige Brieftaschen.",
     "emailTitle": "E-Mail-Adresse",
     "emailDesc": "Fügen Sie Ihre E-Mail-Adresse hinzu, um Ihr Konto zu sichern und mit E-Mail-Adresse einloggen zu können.",
     "btcWalletTitle": "Aktivieren Sie BTC Wallet",
@@ -787,7 +783,8 @@
     "advanceMode": "Aktivieren Sie Bitcoin Account (Advanced Mode)",
     "keysManagement": "Wallet-Backup",
     "showBtcAccount": "Zeigen Sie das Bitcoin-Konto",
-    "hideBtcAccount": "Verstecken Sie das Bitcoin-Konto"
+    "hideBtcAccount": "Verstecken Sie das Bitcoin-Konto",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Notification Settings",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "Το αίτημα αναβάθμισης του λογαριασμού σας εξετάζεται.",
     "currencyTitle": "Αλλαγή σε τοπικό νόμισμα",
     "currencyDesc": "Εξετάστε τη λίστα των διαθέσιμων νομισμάτων και επιλέξτε το νόμισμά σας.",
-    "flashcardTitle": "Πάρτε ένα Flashcard",
-    "flashcardDesc": "Βρείτε ένα Flashpoint και πάρετε ένα Flashcard για να το χρησιμοποιήσετε στην καθημερινή σας ζωή.",
-    "nonCustodialWalletTitle": "Τα μη φυλακισμένα πορτοφόλια",
-    "nonCustodialWalletDesc": "Μάθετε περισσότερα σχετικά με τα μη φυλακισμένα πορτοφόλια.",
     "emailTitle": "Η διεύθυνση ηλεκτρονικού ταχυδρομείου",
     "emailDesc": "Προσθέστε τη διεύθυνση ηλεκτρονικού ταχυδρομείου σας για να προστατεύσετε το λογαριασμό σας και να συνδεθείτε χρησιμοποιώντας τη διεύθυνση ηλεκτρονικού ταχυδρομείου.",
     "btcWalletTitle": "Επιτρέψτε το BTC wallet",
@@ -787,7 +783,8 @@
     "advanceMode": "Επιτρέψτε το λογαριασμό Bitcoin (Advanced Mode)",
     "keysManagement": "Υποστήριξη του πορτοφόλι",
     "showBtcAccount": "Δείξτε λογαριασμό Bitcoin",
-    "hideBtcAccount": "Κρύψτε το λογαριασμό Bitcoin"
+    "hideBtcAccount": "Κρύψτε το λογαριασμό Bitcoin",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Ρυθμίσεις ειδοποιήσεων",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "Su solicitud de actualización de cuenta está siendo revisada.",
     "currencyTitle": "Cambiar a su moneda local",
     "currencyDesc": "Revise nuestra lista de monedas disponibles y seleccione su moneda.",
-    "flashcardTitle": "Obtenga un Flashcard",
-    "flashcardDesc": "Encuentra un Flashpoint y consigue un Flashcard para usar en la vida diaria.",
-    "nonCustodialWalletTitle": "Carteras no custodial",
-    "nonCustodialWalletDesc": "Obtenga más información sobre las billeteras no custodial.",
     "emailTitle": "La dirección de correo electrónico",
     "emailDesc": "Agregue su dirección de correo electrónico para asegurar su cuenta y iniciar sesión utilizando la dirección de correo electrónico.",
     "btcWalletTitle": "Habilitar la billetera BTC",
@@ -787,7 +783,8 @@
     "advanceMode": "Habilitar la cuenta Bitcoin (modo avanzado)",
     "keysManagement": "Backup de billetera",
     "showBtcAccount": "Muestre su cuenta Bitcoin",
-    "hideBtcAccount": "Ocultar la cuenta Bitcoin"
+    "hideBtcAccount": "Ocultar la cuenta Bitcoin",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Configuración de Notificaciones ",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "Votre demande de mise à niveau de votre compte est en cours d'examen.",
     "currencyTitle": "Changez à votre monnaie locale",
     "currencyDesc": "Consultez notre liste de devises disponibles et sélectionnez votre devise.",
-    "flashcardTitle": "Obtenez un Flashcard",
-    "flashcardDesc": "Trouvez un Flashpoint et obtenez un Flashcard à utiliser dans la vie quotidienne.",
-    "nonCustodialWalletTitle": "Les portefeuilles non custodiels",
-    "nonCustodialWalletDesc": "En savoir plus sur les portefeuilles non custodiels.",
     "emailTitle": "Adresse e-mail ",
     "emailDesc": "Ajoutez votre adresse e-mail pour sécuriser votre compte et connectez-vous à l'aide d'une adresse e-mail.",
     "btcWalletTitle": "Activer le portefeuille BTC",
@@ -787,7 +783,8 @@
     "advanceMode": "Activer le compte Bitcoin (mode avancé)",
     "keysManagement": "Une sauvegarde de portefeuille",
     "showBtcAccount": "Afficher le compte Bitcoin",
-    "hideBtcAccount": "Hide le compte Bitcoin"
+    "hideBtcAccount": "Hide le compte Bitcoin",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Réglages des notifications",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "Vaš zahtjev za nadogradnju računa je pod razmatranjem.",
     "currencyTitle": "Promjenite se u lokalnu valutu",
     "currencyDesc": "Provjerite naš popis raspoloživih valuta i odaberite svoju valutu.",
-    "flashcardTitle": "Uzmi Flashcard",
-    "flashcardDesc": "Nađi Flashpoint i nabavi Flashcard za korištenje u svakodnevnom životu.",
-    "nonCustodialWalletTitle": "Ne-zadužnički novčaniki",
-    "nonCustodialWalletDesc": "Saznajte više o novčanicama koje nisu u pritvoru.",
     "emailTitle": "E-mail adresa",
     "emailDesc": "Dodajte svoju e-mail adresu kako biste osigurali svoj račun i prijavljivali se koristeći e-mail adresu.",
     "btcWalletTitle": "Aktivirajte BTC novčanik",
@@ -787,7 +783,8 @@
     "advanceMode": "Aktivirajte Bitcoin račun (napredni način)",
     "keysManagement": "Zaštita novčanika ",
     "showBtcAccount": "Pokažite Bitcoin račun",
-    "hideBtcAccount": "Sakrij račun Bitcoin"
+    "hideBtcAccount": "Sakrij račun Bitcoin",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Postavke obavijesti",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "A fiókja felújítási kérése felülvizsgálat alatt áll.",
     "currencyTitle": "Cserélj a helyi pénznemben",
     "currencyDesc": "Tekintse át a rendelkezésre álló valuták listáját, és válassza ki a pénznemeit.",
-    "flashcardTitle": "Kapjon egy Flashcard",
-    "flashcardDesc": "Találj egy Flashpoint-t, és szerezz egy Flashcard-t a mindennapi életben.",
-    "nonCustodialWalletTitle": "Nem őrizetbeli pénztárcák",
-    "nonCustodialWalletDesc": "Tudjon meg többet a nem őrizetbeli pénztárcákról.",
     "emailTitle": "E-mail cím",
     "emailDesc": "Adja hozzá az e-mail címét, hogy biztosítsa a fiókját, és lépjen be az e-mail cím használatával.",
     "btcWalletTitle": "Az BTC pénztárca engedélyezése",
@@ -787,7 +783,8 @@
     "advanceMode": "Lehetővé tegye az Bitcoin fiókot (Advanced Mode)",
     "keysManagement": "Cseppártyás biztonsági mentés",
     "showBtcAccount": "Mutasd meg a Bitcoin fiókot",
-    "hideBtcAccount": "Elrejtse az Bitcoin fiókot"
+    "hideBtcAccount": "Elrejtse az Bitcoin fiókot",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Értesítési beállítások",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "Ձեր հաշիվի թարմացման խնդրանքն վերանայվում է:",
     "currencyTitle": "Փոխեք ձեր տեղական արժույթը",
     "currencyDesc": "Վերանայեք մեր մատչելի արժույթի ցուցակը եւ ընտրեք ձեր արժույթը:",
-    "flashcardTitle": "Ստացեք Flashcard",
-    "flashcardDesc": "Գտեք Flashpoint եւ ձեռք բերեք Flashcard, որը կօգտագործեք ամենօրյա կյանքում:",
-    "nonCustodialWalletTitle": "Ոչ խնամակալական դրամապանակները",
-    "nonCustodialWalletDesc": "Կարդացեք ավելին ոչ խնամակալական դրամապանակների մասին:",
     "emailTitle": "Էլեկտրոնային հասցեն",
     "emailDesc": "Ավելացրեք ձեր էլ.փոստի հասցեն, որպեսզի ապահովեք ձեր հաշիվը եւ մուտք գործեք էլ.փոստի հասցեն օգտագործելով:",
     "btcWalletTitle": "Հնարավորացնել BTC դրամապանակ",
@@ -787,7 +783,8 @@
     "advanceMode": "Աջակցեք Bitcoin հաշիվը (Ադվանսացված ռեժիմ) ",
     "keysManagement": "Հարցաթղթադրամների կրկնօրինակում",
     "showBtcAccount": "Ցույց տուր Bitcoin հաշիվ",
-    "hideBtcAccount": "Թաքցնել Bitcoin հաշիվ"
+    "hideBtcAccount": "Թաքցնել Bitcoin հաշիվ",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Notification Settings",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "La tua richiesta di aggiornamento dell'account è in fase di revisione.",
     "currencyTitle": "Cambia la tua valuta locale",
     "currencyDesc": "Rivedi la nostra lista delle valute disponibili e seleziona la tua valuta.",
-    "flashcardTitle": "Ottieni un Flashcard",
-    "flashcardDesc": "Trova una Flashpoint e prendi una Flashcard da usare nella vita quotidiana.",
-    "nonCustodialWalletTitle": "Portafogli non custodiali",
-    "nonCustodialWalletDesc": "Scopri di più sui portafogli non custodiali.",
     "emailTitle": "Indirizzo e-mail",
     "emailDesc": "Aggiungi il tuo indirizzo e-mail per proteggere il tuo account e accedere utilizzando l'indirizzo e-mail.",
     "btcWalletTitle": "Abilitare il portafoglio BTC",
@@ -787,7 +783,8 @@
     "advanceMode": "Abilita l'account Bitcoin (Modo avanzato)",
     "keysManagement": "Backup del portafoglio",
     "showBtcAccount": "Mostra l'account Bitcoin",
-    "hideBtcAccount": "Nascondere un account Bitcoin"
+    "hideBtcAccount": "Nascondere un account Bitcoin",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Notification Settings",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "Permintaan peningkatan akaun anda sedang dikaji.",
     "currencyTitle": "Ubah ke mata wang tempatan anda",
     "currencyDesc": "Lihat senarai mata wang kami yang tersedia dan pilih mata wang anda.",
-    "flashcardTitle": "Dapatkan Flashcard",
-    "flashcardDesc": "Cari Flashpoint dan dapatkan Flashcard untuk digunakan dalam kehidupan seharian.",
-    "nonCustodialWalletTitle": "Dompet bukan tahanan",
-    "nonCustodialWalletDesc": "Ketahui lebih lanjut mengenai dompet bukan tahanan.",
     "emailTitle": "Alamat e-mel",
     "emailDesc": "Tambah alamat e-mel anda untuk mengamankan akaun anda dan log masuk menggunakan alamat e-mel.",
     "btcWalletTitle": "Membolehkan dompet BTC",
@@ -787,7 +783,8 @@
     "advanceMode": "Membolehkan Akaun Bitcoin (Mod Lanjutan)",
     "keysManagement": "Cadangan simpanan dompet",
     "showBtcAccount": "Tunjukkan akaun Bitcoin",
-    "hideBtcAccount": "Sembunyikan akaun Bitcoin"
+    "hideBtcAccount": "Sembunyikan akaun Bitcoin",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Tetapan Notifikasi",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "Uw account upgrade aanvraag is onder review.",
     "currencyTitle": "Verander naar uw lokale valuta",
     "currencyDesc": "Bekijk onze beschikbare valutalijst en selecteer uw valuta.",
-    "flashcardTitle": "Krijg een Flashcard",
-    "flashcardDesc": "Zoek een Flashpoint en krijg een Flashcard om in het dagelijks leven te gebruiken.",
-    "nonCustodialWalletTitle": "Niet-custodiële portemonnees",
-    "nonCustodialWalletDesc": "Leer meer over niet-verzorgingsbeurzen.",
     "emailTitle": "E-mailadres",
     "emailDesc": "Voeg uw e-mailadres toe om uw account te beveiligen en login met behulp van een e-mailadres.",
     "btcWalletTitle": "Enable BTC wallet",
@@ -787,7 +783,8 @@
     "advanceMode": "Enable Bitcoin Account (Advanced Mode) ",
     "keysManagement": "Back-up van het portemonnee",
     "showBtcAccount": "Toon Bitcoin-account",
-    "hideBtcAccount": "Hide Bitcoin account"
+    "hideBtcAccount": "Hide Bitcoin account",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Notificatie instellingen",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "Seu pedido de atualização da conta está em revisão.",
     "currencyTitle": "Mude para a sua moeda local",
     "currencyDesc": "Reveja nossa lista de moedas disponíveis e selecione sua moeda.",
-    "flashcardTitle": "Obtenha um Flashcard",
-    "flashcardDesc": "Encontre um Flashpoint e obtenha um Flashcard para usar na vida diária.",
-    "nonCustodialWalletTitle": "Carteiras não custodiáveis",
-    "nonCustodialWalletDesc": "Saiba mais sobre carteiras não custodiáveis.",
     "emailTitle": "Endereço de e-mail",
     "emailDesc": "Adicione seu endereço de e-mail para proteger sua conta e fazer login usando o endereço de e-mail.",
     "btcWalletTitle": "Enable BTC wallet",
@@ -787,7 +783,8 @@
     "advanceMode": "Enable Bitcoin Account (Modo Avançado)",
     "keysManagement": "Backup de carteira",
     "showBtcAccount": "Mostre a conta Bitcoin",
-    "hideBtcAccount": "Esconda a conta Bitcoin"
+    "hideBtcAccount": "Esconda a conta Bitcoin",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Configurações de Notificação",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "Paykunapa contranpi llamk'anankupaq mañakusqankuqa qhawarisqa kashan.",
     "currencyTitle": "Qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi qhichwa simipi",
     "currencyDesc": "Ñoqanchispa qolqeta qhawaychis, chaymantataq qollqeta ajllaychis.",
-    "flashcardTitle": "Qawasun Flashcard",
-    "flashcardDesc": "Flashpoint-ta tarinki, chaymantataq sapa p'unchawpaqmi Flashcard-ta tarinki.",
-    "nonCustodialWalletTitle": "Mana custodial qollqekunaqa",
-    "nonCustodialWalletDesc": "Commons nisqapi suyukunata uyarinakunatapas tarinki kaymantam: Wallet non-custodial.",
     "emailTitle": "E-mail address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address: Email address",
     "emailDesc": "Imaynatá qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki, qhelqasunki.",
     "btcWalletTitle": "BTC qollqeta atiy",
@@ -787,7 +783,8 @@
     "advanceMode": "Bitcoin Account (Advanced Mode) sutiyuq katiguriyapi llamk'apuy",
     "keysManagement": "Qhapaq qollqeta kutichinapaq (wallet backup)",
     "showBtcAccount": "Show Bitcoin cuenta",
-    "hideBtcAccount": "Hide Bitcoin cuenta"
+    "hideBtcAccount": "Hide Bitcoin cuenta",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Notification Settings",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "Ваш захтев за надоградњу рачуна је под обзиром.",
     "currencyTitle": "Промените се у своју локалну валуту",
     "currencyDesc": "Прегледајте нашу листу доступних валута и одаберете своју валуту.",
-    "flashcardTitle": "Добијте Flashcard",
-    "flashcardDesc": "Нађите Flashpoint и добијте Flashcard за употребу у свакодневном животу.",
-    "nonCustodialWalletTitle": "Не-кустодијални новчаници",
-    "nonCustodialWalletDesc": "Сазнајте више о новчаницима који нису чувани.",
     "emailTitle": "Имејловни адрес",
     "emailDesc": "Додајте своју е-поштену адресу како бисте обезбедили свој рачун и пријавили се користећи е-поштену адресу.",
     "btcWalletTitle": "Омогућити BTC новчаник",
@@ -787,7 +783,8 @@
     "advanceMode": "Активише Bitcoin рачуна (Авансрен режим)",
     "keysManagement": "Резерван новчаника ",
     "showBtcAccount": "Показати Bitcoin рачун",
-    "hideBtcAccount": "Скријте рачун Bitcoin"
+    "hideBtcAccount": "Скријте рачун Bitcoin",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Notification Settings",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -483,10 +483,6 @@
     "emailDesc": "Add your email address to secure your account and login using email address.",
     "emailTitle": "Email address",
     "flashcard": "Flashcard",
-    "flashcardDesc": "Find a Flashpoint and get a Flashcard to use in daily life.",
-    "flashcardTitle": "Get a Flashcard",
-    "nonCustodialWalletDesc": "Learn more about non-custodial wallets.",
-    "nonCustodialWalletTitle": "Non-custodial wallets",
     "pay": "Pay",
     "reload": "Reload Card",
     "showQrCode": "Topup via QR",
@@ -742,7 +738,8 @@
     "showNostrSecret": "Chat Settings",
     "showSeedPhrase": "Reveal recovery phrase",
     "staticQr": "Printable Static QR Code",
-    "staticQrCopied": "Your static QR code link has been copied"
+    "staticQrCopied": "Your static QR code link has been copied",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Mipangilio ya Arifa",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "การขอปรับปรุงบัญชีของคุณกําลังถูกพิจารณา",
     "currencyTitle": "เปลี่ยนไปยังเงินของท้องถิ่นของคุณ",
     "currencyDesc": "ตรวจสอบรายการสกุลเงินที่เรามี และเลือกสกุลเงินของคุณ",
-    "flashcardTitle": "รับ Flashcard",
-    "flashcardDesc": "ค้นหา Flashpoint และใช้ Flashcard ในชีวิตประจําวัน",
-    "nonCustodialWalletTitle": "กระเป๋าเปลือกที่ไม่ใช่ของฝ่ายปกครอง",
-    "nonCustodialWalletDesc": "เรียนรู้เพิ่มเติมเกี่ยวกับกระเป๋าเปลือกที่ไม่ใช่ของฝ่ายปกครอง",
     "emailTitle": "ที่อยู่อีเมล",
     "emailDesc": "เพิ่มเติมที่อยู่อีเมลของคุณเพื่อคุ้มครองบัญชี และเข้าใช้บริการด้วยที่อยู่อีเมล",
     "btcWalletTitle": "Enable BTC wallet",
@@ -787,7 +783,8 @@
     "advanceMode": "Enable Bitcoin Account (Advanced Mode) ",
     "keysManagement": "การสํารอง Wallet ",
     "showBtcAccount": "แสดงบัญชี Bitcoin",
-    "hideBtcAccount": "ซ่อนบัญชี Bitcoin"
+    "hideBtcAccount": "ซ่อนบัญชี Bitcoin",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Notification Settings",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "Hesap yükseltme talebiniz gözden geçiriliyor.",
     "currencyTitle": "Yerel para birimine değişin",
     "currencyDesc": "Kullanılabilir para birimi listesini inceleyin ve para birimini seçin.",
-    "flashcardTitle": "Bir Flashcard alın",
-    "flashcardDesc": "Bir Flashpoint bulun ve günlük yaşamda kullanabileceğiniz bir Flashcard alın.",
-    "nonCustodialWalletTitle": "Koruma dışı cüzdanlar",
-    "nonCustodialWalletDesc": "Koruma dışı cüzdanlar hakkında daha fazla bilgi edinin.",
     "emailTitle": "E-posta adresi",
     "emailDesc": "Hesabınızı güvence altına almak ve e-posta adresini kullanarak giriş yapmak için e-posta adresinizi ekleyin.",
     "btcWalletTitle": "BTC cüzdanı etkinleştirin",
@@ -787,7 +783,8 @@
     "advanceMode": "Bitcoin Hesabını (Gelişmiş Mod) etkinleştirin",
     "keysManagement": "Cüzdan yedekleme",
     "showBtcAccount": "Bitcoin hesabını göster",
-    "hideBtcAccount": "Bitcoin hesabını gizleyin"
+    "hideBtcAccount": "Bitcoin hesabını gizleyin",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Bildirim Ayarları",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "Yêu cầu nâng cấp tài khoản của bạn đang được xem xét.",
     "currencyTitle": "Thay đổi sang tiền tệ địa phương của bạn",
     "currencyDesc": "Xem lại danh sách tiền tệ có sẵn của chúng tôi và chọn tiền tệ của bạn.",
-    "flashcardTitle": "Nhận được một Flashcard",
-    "flashcardDesc": "Tìm một chiếc Flashpoint và mua một chiếc Flashcard để sử dụng trong cuộc sống hàng ngày.",
-    "nonCustodialWalletTitle": "Những ví không có quyền bảo vệ",
-    "nonCustodialWalletDesc": "Tìm hiểu thêm về ví không có quyền bảo vệ.",
     "emailTitle": "Địa chỉ email",
     "emailDesc": "Thêm địa chỉ email của bạn để bảo mật tài khoản và đăng nhập bằng địa chỉ email.",
     "btcWalletTitle": "Enable BTC wallet",
@@ -787,7 +783,8 @@
     "advanceMode": "Enable Bitcoin Account (Advanced Mode)",
     "keysManagement": "Căn khoán dự phòng ví",
     "showBtcAccount": "Xem tài khoản Bitcoin",
-    "hideBtcAccount": "ẩn tài khoản Bitcoin"
+    "hideBtcAccount": "ẩn tài khoản Bitcoin",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Notification Settings",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -534,10 +534,6 @@
     "upgradePendingDesc": "Isicelo sakho sokuphucula iakhawunti sihlaziywa.",
     "currencyTitle": "Tshintshela kwiimali zakho zasekuhlaleni",
     "currencyDesc": "Jonga uluhlu lwethu lweemali ezikhoyo kwaye ukhethe imali yakho.",
-    "flashcardTitle": "Fumana i-Flashcard",
-    "flashcardDesc": "Fumana i-Flashpoint kwaye ufumane i-Flashcard yokusebenzisa kubomi bemihla ngemihla.",
-    "nonCustodialWalletTitle": "Izipaji ezingezizo ezikhuselweyo",
-    "nonCustodialWalletDesc": "Funda okungakumbi malunga nee-wallets ezingezizo ze-custodial.",
     "emailTitle": "Idilesi ye-imeyile",
     "emailDesc": "Yongeza idilesi yakho ye-imeyile ukuze ukhusele iakhawunti yakho kwaye ungene ngemvume usebenzisa idilesi ye-imeyile.",
     "btcWalletTitle": "Qinisekisa i-BTC wallet",
@@ -787,7 +783,8 @@
     "advanceMode": "Vumela i-akhawunti ye-Bitcoin (imowudi ephuculweyo)",
     "keysManagement": "Isipele seWallets ",
     "showBtcAccount": "Bonisa i-akhawunti ye-Bitcoin",
-    "hideBtcAccount": "Fihla iakhawunti ye-Bitcoin"
+    "hideBtcAccount": "Fihla iakhawunti ye-Bitcoin",
+    "flashcard": "Flashcard"
   },
   "NotificationSettingsScreen": {
     "title": "Izilungiselelo Zokwazisa",

--- a/app/screens/account-upgrade-flow/PersonalInformation.tsx
+++ b/app/screens/account-upgrade-flow/PersonalInformation.tsx
@@ -130,6 +130,7 @@ const PersonalInformation: React.FC<Props> = ({ navigation }) => {
           placeholder="John Doe"
           value={fullName}
           errorMsg={fullNameErr}
+          autoCapitalize="words"
           onChangeText={(val) => {
             setFullNameErr(undefined)
             dispatch(setPersonalInfo({ fullName: val }))

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -13,6 +13,7 @@ import { AccountStaticQR } from "./settings/account-static-qr"
 import { TxLimits } from "./settings/account-tx-limits"
 import { PhoneSetting } from "./account/settings/phone"
 import { AccountPOS } from "./settings/account-pos"
+import { AccountFlashcard } from "./settings/account-flashcard"
 import { DefaultWallet } from "./settings/account-default-wallet"
 import { LanguageSetting } from "./settings/preferences-language"
 import { CurrencySetting } from "./settings/preferences-currency"
@@ -61,7 +62,13 @@ gql`
 const items = {
   account: [AccountLevelSetting, TxLimits],
   loginMethods: [EmailSetting, PhoneSetting],
-  waysToGetPaid: [AccountLNAddress, BankAccountsSetting, AccountPOS, AccountStaticQR],
+  waysToGetPaid: [
+    AccountLNAddress,
+    BankAccountsSetting,
+    AccountPOS,
+    AccountStaticQR,
+    AccountFlashcard,
+  ],
   reports: [GenerateReportsSetting],
   wallet: [BackupWallet, ImportWallet],
   preferences: [

--- a/app/screens/settings-screen/settings/account-flashcard.tsx
+++ b/app/screens/settings-screen/settings/account-flashcard.tsx
@@ -1,0 +1,27 @@
+import { useNavigation } from "@react-navigation/native"
+import { StackNavigationProp } from "@react-navigation/stack"
+
+import { RootStackParamList } from "@app/navigation/stack-param-lists"
+import { useFlashcard } from "@app/hooks"
+import { useI18nContext } from "@app/i18n/i18n-react"
+
+import { SettingsRow } from "../row"
+
+export const AccountFlashcard: React.FC = () => {
+  const { LL } = useI18nContext()
+  const navigation = useNavigation<StackNavigationProp<RootStackParamList>>()
+  const { lnurl, readFlashcard } = useFlashcard()
+
+  const onPressFlashcard = () => {
+    if (lnurl) navigation.navigate("Card")
+    else readFlashcard()
+  }
+
+  return (
+    <SettingsRow
+      title={LL.HomeScreen.flashcard()}
+      leftIcon="card"
+      action={onPressFlashcard}
+    />
+  )
+}

--- a/app/screens/settings-screen/settings/account-flashcard.tsx
+++ b/app/screens/settings-screen/settings/account-flashcard.tsx
@@ -19,7 +19,7 @@ export const AccountFlashcard: React.FC = () => {
 
   return (
     <SettingsRow
-      title={LL.HomeScreen.flashcard()}
+      title={LL.SettingsScreen.flashcard()}
       leftIcon="card"
       action={onPressFlashcard}
     />

--- a/app/screens/topup-cashout-flow/BridgeAddExternalAccount.tsx
+++ b/app/screens/topup-cashout-flow/BridgeAddExternalAccount.tsx
@@ -155,6 +155,7 @@ const BridgeAddExternalAccount: React.FC<Props> = ({ navigation, route }) => {
               style={styles.input}
               value={bankName}
               onChangeText={setBankName}
+              autoCapitalize="words"
               placeholder={LL.BridgeAddExternalAccount.bankNamePlaceholder()}
               placeholderTextColor={theme.colors.grey3}
             />
@@ -168,6 +169,7 @@ const BridgeAddExternalAccount: React.FC<Props> = ({ navigation, route }) => {
               style={styles.input}
               value={accountOwnerName}
               onChangeText={setAccountOwnerName}
+              autoCapitalize="words"
               placeholder={LL.BridgeAddExternalAccount.accountOwnerNamePlaceholder()}
               placeholderTextColor={theme.colors.grey3}
             />
@@ -253,6 +255,7 @@ const BridgeAddExternalAccount: React.FC<Props> = ({ navigation, route }) => {
               style={styles.input}
               value={streetLine1}
               onChangeText={setStreetLine1}
+              autoCapitalize="words"
               placeholder={LL.BridgeAddExternalAccount.streetAddressPlaceholder()}
               placeholderTextColor={theme.colors.grey3}
             />
@@ -265,6 +268,7 @@ const BridgeAddExternalAccount: React.FC<Props> = ({ navigation, route }) => {
                 style={styles.input}
                 value={city}
                 onChangeText={setCity}
+                autoCapitalize="words"
                 placeholder={LL.BridgeAddExternalAccount.cityPlaceholder()}
                 placeholderTextColor={theme.colors.grey3}
               />
@@ -275,6 +279,7 @@ const BridgeAddExternalAccount: React.FC<Props> = ({ navigation, route }) => {
                 style={styles.input}
                 value={state}
                 onChangeText={setState}
+                autoCapitalize="characters"
                 placeholder={LL.BridgeAddExternalAccount.statePlaceholder()}
                 placeholderTextColor={theme.colors.grey3}
                 maxLength={2}
@@ -301,6 +306,7 @@ const BridgeAddExternalAccount: React.FC<Props> = ({ navigation, route }) => {
                 style={styles.input}
                 value={country}
                 onChangeText={setCountry}
+                autoCapitalize="characters"
                 placeholder={LL.BridgeAddExternalAccount.countryPlaceholder()}
                 placeholderTextColor={theme.colors.grey3}
                 maxLength={3}

--- a/app/screens/topup-cashout-flow/BridgeAddExternalAccount.tsx
+++ b/app/screens/topup-cashout-flow/BridgeAddExternalAccount.tsx
@@ -66,16 +66,19 @@ const BridgeAddExternalAccount: React.FC<Props> = ({ navigation, route }) => {
       const res = await createExternalAccount({
         variables: {
           input: {
-            bankName,
-            accountOwnerName,
-            routingNumber,
-            accountNumber,
+            bankName: bankName.trim(),
+            accountOwnerName: accountOwnerName.trim(),
+            routingNumber: routingNumber.trim(),
+            accountNumber: accountNumber.trim(),
             checkingOrSavings,
-            streetLine1,
-            city,
-            state,
-            postalCode,
-            country,
+            streetLine1: streetLine1.trim(),
+            city: city.trim(),
+            // Bridge expects ISO codes — 2-char state, 3-char country.
+            // autoCapitalize is only a keyboard hint (autofill and hardware
+            // keyboards ignore it), so normalize here rather than trust casing.
+            state: state.trim().toUpperCase(),
+            postalCode: postalCode.trim(),
+            country: country.trim().toUpperCase(),
           },
         },
       })

--- a/app/store/persistent-state/state-migrations.ts
+++ b/app/store/persistent-state/state-migrations.ts
@@ -65,6 +65,7 @@ type PersistentState_7 = {
   cashBalance?: string
   btcDisplayBalance?: string
   cashDisplayBalance?: string
+  cardDisplayBalance?: string
   mergedTransactions?: UnifiedTransaction[]
   btcTransactions?: BreezTransaction[]
   defaultWallet?: WalletBalance


### PR DESCRIPTION
In-the-wild user testing on v0.6.0-beta surfaced several first-impression issues. This bundles the quick wins with the blank Cash Wallet bug. Tracked under ENG-511.

## Changes

### ENG-512 — never render a blank Cash Wallet (bug)
`formatBalance` in `wallet-overview.tsx` overwrote the Cash balance with `""`/`undefined` when the price-conversion query lost a race on fresh login (or the Cash wallet was briefly missing mid USD→USDT cutover). The Cash `<Balance>` has no `emptyText`, so it collapsed to an empty box — looking broken on the very first screen after login. Now we only write a real value (keeping the cached/`"0"` balance otherwise) and recompute once price conversion resolves.

### Home-screen noise (#2, #3)
- Removed the **"Non-custodial wallets"** and **"Get a Flashcard"** QuickStart cards.
- Moved the **"Add Flashcard"** action into **Settings → Ways to get paid → Flashcard**. The home wallet-overview Flashcard row now only renders when a card is linked, so the "Add Flashcard" prompt no longer adds noise for users without one (card-holders still see their balance).

### Auto-capitalize name/address fields (#8)
`autoCapitalize="words"` on Full Name, Bank Name, Account Owner, Street, City; `"characters"` on US State/Country codes — in the account-upgrade and Bridge external-account forms. Email/username/number fields left untouched.

## Verification
- `tsc -p .` passes. No new eslint errors introduced (the touched files carry pre-existing lint debt unrelated to this change; eslint is not part of the `check-code` CI gate).
- ⚠️ **ENG-512 is a timing bug fixed by code reasoning — not yet verified on-device.** Worth a QA pass on a slow/flaky connection (fresh login) and on mid-cutover accounts before closing ENG-512.

Refs ENG-511, ENG-512

🤖 Generated with [Claude Code](https://claude.com/claude-code)
