### PR TITLE
fix(mobile): keep QuickStart upgrade card tappable while upgrade request is pending [ENG-513]

### DIFF
--- a/__tests__/components/quick-start.spec.tsx
+++ b/__tests__/components/quick-start.spec.tsx
@@ -1,0 +1,99 @@
+import * as React from "react"
+import { createTheme, ThemeProvider } from "@rneui/themed"
+import { render, fireEvent } from "@testing-library/react-native"
+
+import { i18nObject } from "../../app/i18n/i18n-util"
+import QuickStart from "../../app/components/home-screen/QuickStart"
+
+const mockNavigate = jest.fn()
+
+// Driven per-test: the latestAccountUpgradeRequest status synced into redux.
+let mockUpgradeStatus: string | undefined
+
+jest.mock("@app/store/redux", () => ({
+  useAppSelector: (selector: (state: unknown) => unknown) =>
+    selector({ accountUpgrade: { status: mockUpgradeStatus } }),
+}))
+jest.mock("@app/hooks", () => ({
+  useAccountUpgrade: jest.fn(),
+}))
+jest.mock("@app/store/persistent-state", () => ({
+  usePersistentStateContext: () => ({
+    persistentState: {},
+    updateState: jest.fn(),
+  }),
+}))
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useHomeAuthedQuery: () => ({
+    data: { me: { defaultAccount: { level: "ONE" } } },
+    loading: false,
+  }),
+}))
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({ LL: i18nObject("en") }),
+}))
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}))
+jest.mock("react-native-keychain", () => ({
+  getInternetCredentials: jest.fn(() => Promise.resolve(false)),
+}))
+jest.mock("../../app/components/advanced-mode-modal", () => ({
+  AdvancedModeModal: () => null,
+}))
+// Flatten the carousel so every card renders synchronously without reanimated.
+jest.mock("react-native-reanimated-carousel", () => {
+  const ReactLib = jest.requireActual("react")
+  return {
+    __esModule: true,
+    default: ({
+      data,
+      renderItem,
+    }: {
+      data: unknown[]
+      renderItem: (info: { item: unknown; index: number }) => React.ReactElement
+    }) =>
+      ReactLib.createElement(
+        ReactLib.Fragment,
+        null,
+        data.map((item, index) => renderItem({ item, index })),
+      ),
+  }
+})
+
+const en = i18nObject("en")
+
+const renderQuickStart = () =>
+  render(
+    <ThemeProvider theme={createTheme({})}>
+      <QuickStart />
+    </ThemeProvider>,
+  )
+
+beforeEach(() => {
+  mockNavigate.mockClear()
+})
+
+describe("QuickStart upgrade card", () => {
+  it("navigates to the capability hub when no upgrade request is pending", () => {
+    mockUpgradeStatus = undefined
+    const { getAllByText } = renderQuickStart()
+
+    fireEvent.press(getAllByText(en.HomeScreen.upgradeTitle())[0])
+
+    expect(mockNavigate).toHaveBeenCalledWith("AccountType")
+  })
+
+  it("still navigates to the capability hub while an upgrade request is pending", () => {
+    // Regression: the pending card used to set disabled, stranding the user
+    // outside the hub where other capabilities (e.g. US virtual account)
+    // remain available.
+    mockUpgradeStatus = "Pending"
+    const { getAllByText } = renderQuickStart()
+
+    fireEvent.press(getAllByText(en.HomeScreen.upgradeTitlePending())[0])
+
+    expect(mockNavigate).toHaveBeenCalledWith("AccountType")
+  })
+})

--- a/__tests__/screens/upgrade-trial-account.spec.tsx
+++ b/__tests__/screens/upgrade-trial-account.spec.tsx
@@ -1,0 +1,70 @@
+import * as React from "react"
+import { createTheme, ThemeProvider } from "@rneui/themed"
+import { render, fireEvent } from "@testing-library/react-native"
+
+import { i18nObject } from "../../app/i18n/i18n-util"
+import { UpgradeTrialAccount } from "../../app/screens/settings-screen/account/settings/upgrade-trial-account"
+
+const mockNavigate = jest.fn()
+
+// Driven per-test: the latestAccountUpgradeRequest status synced into redux.
+let mockUpgradeStatus: string | undefined
+
+jest.mock("@app/store/redux", () => ({
+  useAppSelector: (selector: (state: unknown) => unknown) =>
+    selector({ accountUpgrade: { status: mockUpgradeStatus } }),
+}))
+jest.mock("@app/graphql/level-context", () => ({
+  ...jest.requireActual("@app/graphql/level-context"),
+  // Level One: past trial, below Three — the branch that renders the
+  // request/edit upgrade button.
+  useLevel: () => ({ currentLevel: "ONE" }),
+}))
+jest.mock(
+  "../../app/screens/settings-screen/account/show-warning-secure-account-hook",
+  () => ({
+    useShowWarningSecureAccount: () => false,
+  }),
+)
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({ LL: i18nObject("en") }),
+}))
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}))
+
+const en = i18nObject("en")
+
+const renderUpgrade = () =>
+  render(
+    <ThemeProvider theme={createTheme({})}>
+      <UpgradeTrialAccount />
+    </ThemeProvider>,
+  )
+
+beforeEach(() => {
+  mockNavigate.mockClear()
+})
+
+describe("UpgradeTrialAccount button", () => {
+  it("navigates to the capability hub when no upgrade request is pending", () => {
+    mockUpgradeStatus = undefined
+    const { getAllByText } = renderUpgrade()
+
+    fireEvent.press(getAllByText(en.TransactionLimitsScreen.requestUpgrade())[0])
+
+    expect(mockNavigate).toHaveBeenCalledWith("AccountType")
+  })
+
+  it("navigates to the capability hub while an upgrade request is pending", () => {
+    // Regression: the pending state used to reroute around the hub to
+    // PersonalInformation, hiding the other capabilities (e.g. US virtual
+    // account) that remain available.
+    mockUpgradeStatus = "Pending"
+    const { getAllByText } = renderUpgrade()
+
+    fireEvent.press(getAllByText(en.TransactionLimitsScreen.editRequest())[0])
+
+    expect(mockNavigate).toHaveBeenCalledWith("AccountType")
+  })
+})

--- a/app/components/home-screen/QuickStart.tsx
+++ b/app/components/home-screen/QuickStart.tsx
@@ -80,7 +80,6 @@ const QuickStart = () => {
         : LL.HomeScreen.upgradePendingDesc(),
       image: Account,
       pending: upgradePending,
-      disabled: upgradePending,
       onPress: () => navigation.navigate("AccountType"),
     },
     {

--- a/app/screens/settings-screen/account/settings/upgrade-trial-account.tsx
+++ b/app/screens/settings-screen/account/settings/upgrade-trial-account.tsx
@@ -1,3 +1,4 @@
+import React from "react"
 import { View } from "react-native"
 import { makeStyles, Text } from "@rneui/themed"
 import { StackNavigationProp } from "@react-navigation/stack"
@@ -57,9 +58,7 @@ export const UpgradeTrialAccount: React.FC = () => {
             : LL.TransactionLimitsScreen.editRequest()
         }
         btnStyle={upgradePending ? { backgroundColor: "#FF7e1c" } : {}}
-        onPress={() =>
-          navigation.navigate(upgradePending ? "PersonalInformation" : "AccountType")
-        }
+        onPress={() => navigation.navigate("AccountType")}
       />
     )
   } else {


### PR DESCRIPTION
## Bug

Pressing the QuickStart **Upgrade your account** card opens the AccountType capability hub. But after submitting a bank-account upgrade request, the card flips to **Upgrade request is pending** and becomes completely inert — `disabled: upgradePending` in `QuickStart.tsx` swallows the press. The user is stranded: there is no way back to the hub from QuickStart to start the still-available capabilities (e.g. the US virtual USD account, whose status is independent of the bank-upgrade request).

The settings screen had the same pre-revamp assumption: `upgrade-trial-account.tsx` rerouted to `PersonalInformation` instead of the hub while a request was pending.

## Fix

- **QuickStart card**: drop the `disabled` flag. The card keeps its pending title, description, and orange styling, but pressing it always navigates to the `AccountType` hub — which already renders per-row pending state (ENG-513) and leaves unaffected rows tappable.
- **Settings upgrade button**: always navigate to `AccountType` (label/styling unchanged). A `React` import was added because the jest tsconfig compiles classic JSX; runtime behavior is unchanged.

## Tests

New `__tests__/components/quick-start.spec.tsx` and `__tests__/screens/upgrade-trial-account.spec.tsx`:
- not-pending → navigates to `AccountType`
- **regression**: pending → still navigates to `AccountType` — both verified to fail against the previous code and pass with the fix

`yarn tsc:check` clean; eslint clean on all new/touched lines (both components' pre-existing lint errors are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXnQYUbKQe5wUCWEvdAau7