### PR TITLE
fix(topup): pass dataDetectorTypes as array to fix Android card-payment crash

### DIFF
--- a/app/screens/topup-cashout-flow/CardPayment.tsx
+++ b/app/screens/topup-cashout-flow/CardPayment.tsx
@@ -272,7 +272,7 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
               ? "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
               : undefined
           }
-          dataDetectorTypes="none"
+          dataDetectorTypes={["none"]}
           /**
            * Pre-content JavaScript injection for early zoom prevention.
            *


### PR DESCRIPTION
## Problem

On **Android**, `Transfer → Topup → Debit/Credit Card → enter amount → Continue` crashes with:

> Error: Exception in HostFunction TypeError: expected dynamic type 'array', but had type 'string'

## Root cause

Tapping **Continue** navigates to `CardPayment.tsx`, which mounts the Fygaro `<WebView>`. That WebView passed `dataDetectorTypes="none"` — a **string**.

Under the New Architecture (`newArchEnabled=true`), react-native-webview's Fabric codegen spec declares `dataDetectorTypes` as an **array** (`ReadonlyArray<'address'|…|'none'>`). The Fabric C++ prop parser receives a string where it expects an array → the `HostFunction` throw above, on WebView mount (i.e. right after Continue).

**Why Android only:** the library's iOS JS wrapper auto-wraps a scalar into an array (`!v || Array.isArray(v) ? v : [v]`), so `"none"` silently becomes `["none"]`. The Android wrapper has no such normalization and forwards the prop raw to the native component, so the string reaches the parser and crashes.

**Why now:** the string value has existed since the top-up flow was added; it was harmless until the New Architecture was enabled, which introduced strict codegen prop typing.

## Fix

```diff
- dataDetectorTypes="none"
+ dataDetectorTypes={["none"]}
```

- Type-valid: the public prop is `DataDetectorTypes | DataDetectorTypes[]`.
- Satisfies the native array requirement, fixing the Android crash.
- This is the **only** string-literal `dataDetectorTypes` in the app — no sibling occurrences to fix. Other WebViews (Bridge KYC, Bridge external account, iris-browser, featured-profile) don't set the prop.

## Testing

- [ ] Android device/emulator (New Arch): the card top-up flow reaches the Fygaro form without crashing.
- [ ] iOS regression: card top-up still loads (behavior unchanged — iOS already normalized the value).

The regression lives in Fabric's native prop-marshalling layer, so a JS unit test can't reproduce it; the meaningful guard is the on-device smoke test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7z7o9J18BWbUnYJcemMtg
