### PR TITLE
fix(modal): render cutover modal inline to fix Android New-Arch login freeze

### DIFF
--- a/app/components/topup-cashout-flow/CashWalletCutoverModal.tsx
+++ b/app/components/topup-cashout-flow/CashWalletCutoverModal.tsx
@@ -54,6 +54,16 @@ const CashWalletCutoverModal = () => {
       swipeDirection={["down"]}
       style={styles.modal}
       useNativeDriverForBackdrop
+      /**
+       * Render inline instead of through the native modal host. RCTModalHostView
+       * is broken under Fabric/New Architecture on Android (see #545): it
+       * wrongly measures the flex:1 content container, so this bottom-anchored
+       * (justifyContent: "flex-end") sheet is positioned off-screen while its
+       * full-screen backdrop keeps capturing touches — the dismiss button
+       * becomes unreachable and the app appears frozen. coverScreen={false}
+       * takes react-native-modal's inline render path and measures correctly.
+       */
+      coverScreen={false}
     >
       <View style={styles.sheet}>
         <View style={styles.handle} />


### PR DESCRIPTION
## Problem

On **Android**, immediately after login the app shows a distorted modal whose dismiss button is off-screen; its backdrop keeps capturing touches, so the **entire app freezes**. Only killing and relaunching clears it.

## Root cause

`CashWalletCutoverModal` auto-shows once after login for any account created before the cash-wallet cutover (`CashWalletCutoverModal.tsx:35`, mounted at `home-screen.tsx:163`). It's a **bottom-anchored** `react-native-modal` — `style: { justifyContent: "flex-end", margin: 0 }`.

Under the New Architecture, `react-native-modal` (`coverScreen` defaults to `true`) renders through the core `RCTModalHostView`. Commit #545 (New-Arch enablement) already documented this component as **"broken on Android with Fabric (RN 0.76.9)"**: it mis-measures the `flex:1` content container. With `justifyContent: "flex-end"` the sheet is positioned **below the visible viewport**, while the full-screen backdrop still renders on top and swallows every touch → distorted, unreachable OK button, frozen app. A restart skips the login→home transition during which the host is mis-measured, which is why it appears to "fix" itself.

Centered modals tolerate the mis-measurement (a centered card stays roughly on-screen); only bottom-anchored sheets get pushed off.

## Fix

```diff
+ coverScreen={false}
```

This takes `react-native-modal`'s **inline render path** (`modal.js:536`, `if (!coverScreen …)`) instead of the broken native host, so layout measures correctly and the sheet stays on-screen and dismissable. A library bump won't help — `14.0.0-rc.1` is already the latest and has no Fabric fix.

## Wider context (not fixed here)

#545 originally added a portal-based workaround for this exact Fabric bug and then **removed it** in the same series (`* remove ModalPortal`). So other **bottom-anchored** `react-native-modal` usages across the app are likely affected too. This PR fixes the one that auto-fires on login (highest impact — every returning pre-cutover user hits it); the rest are tracked as a separate modal-audit sweep.

## Testing

- [ ] Android device (New Arch), account created before cutover, `hasSeenCashWalletCutoverModal` unset: log in → the sheet renders on-screen and is dismissable; app not frozen.
- [ ] iOS regression: modal still appears and dismisses (behavior unchanged).

The defect is a native/Fabric layout measurement, so a JS unit test can't reproduce it; the on-device check above is the meaningful guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7z7o9J18BWbUnYJcemMtg
