### PR TITLE
fix(modal): render remaining bottom-anchored modals inline (Android New-Arch sweep)

### DIFF
--- a/app/components/contact-modal/contact-modal.tsx
+++ b/app/components/contact-modal/contact-modal.tsx
@@ -116,6 +116,9 @@ const ContactModal: React.FC<Props> = ({
       backdropColor={colors.grey3}
       onBackdropPress={toggleModal}
       style={styles.modal}
+      // Bottom-anchored sheet; render inline to avoid the broken Fabric modal
+      // host on Android (see #545), which would push it off-screen.
+      coverScreen={false}
     >
       {contactOptionList.map((item) => {
         if (item.hidden) return null

--- a/app/components/home-screen/AccountCreateModal.tsx
+++ b/app/components/home-screen/AccountCreateModal.tsx
@@ -34,6 +34,9 @@ const AccountCreateModal: React.FC<Props> = ({ modalVisible, setModalVisible }) 
     <View>
       <Modal
         style={styles.modal}
+        // Content is bottom-pinned via a flex spacer; the broken Fabric modal
+        // host on Android (see #545) wrongly measures it off-screen. Render inline.
+        coverScreen={false}
         isVisible={modalVisible}
         swipeDirection={modalVisible ? ["down"] : ["up"]}
         onSwipeComplete={() => setModalVisible(false)}

--- a/app/components/modal-nfc/modal-nfc.tsx
+++ b/app/components/modal-nfc/modal-nfc.tsx
@@ -219,6 +219,9 @@ export const ModalNfc: React.FC<{
       swipeThreshold={50}
       propagateSwipe
       style={styles.modal}
+      // Content is bottom-pinned via a flex spacer; the broken Fabric modal
+      // host on Android (see #545) wrongly measures it off-screen. Render inline.
+      coverScreen={false}
     >
       <Pressable style={styles.flex} onPress={dismiss}></Pressable>
       <SafeAreaView style={styles.modalForeground}>

--- a/app/components/modal-tooltip/modal-tooltip.tsx
+++ b/app/components/modal-tooltip/modal-tooltip.tsx
@@ -66,7 +66,10 @@ export const ModalTooltip: React.FC<ModalTooltipProps> = ({
       <Modal
         isVisible={isVisible}
         onBackdropPress={toggleModal}
-        coverScreen
+        // RCTModalHostView wrongly measures under Fabric on Android, pushing this
+        // bottom-anchored (justifyContent: flex-end) sheet off-screen; render
+        // inline instead. See #545.
+        coverScreen={false}
         style={styles.modalStyle}
         backdropOpacity={0.3}
         backdropColor={colors.grey3}

--- a/app/components/reports-modal/reports-modal.tsx
+++ b/app/components/reports-modal/reports-modal.tsx
@@ -89,6 +89,9 @@ const ReportModal: React.FC<Props> = ({
       backdropColor={colors.grey3}
       onBackdropPress={toggleModal}
       style={styles.modal}
+      // Bottom-anchored sheet; render inline to avoid the broken Fabric modal
+      // host on Android (see #545), which would push it off-screen.
+      coverScreen={false}
     >
       <View style={styles.modalContent}>
         <View style={styles.datePickersContainer}>

--- a/app/screens/earns-screen/earns-quiz.tsx
+++ b/app/screens/earns-screen/earns-quiz.tsx
@@ -294,6 +294,9 @@ export const EarnQuiz = ({ route }: Props) => {
     <Screen backgroundColor={colors._lighterGrey} unsafe>
       <Modal
         style={{ marginHorizontal: 0, marginBottom: 0, flexGrow: 1 }}
+        // Quiz card is bottom-pinned via a flex spacer; the broken Fabric modal
+        // host on Android (see #545) wrongly measures it off-screen. Render inline.
+        coverScreen={false}
         isVisible={quizVisible}
         swipeDirection={quizVisible ? ["down"] : ["up"]}
         onSwipeComplete={() => setQuizVisible(false)}


### PR DESCRIPTION
## What & why

Companion sweep to #673 (the CashWalletCutoverModal login-freeze fix). Same root cause, remaining instances.

Under the New Architecture, `react-native-modal` renders through the core `RCTModalHostView`, which commit #545 documented as **broken on Android/Fabric** — it mis-measures the `flex:1` content host. Any **bottom-anchored** sheet (`justifyContent: "flex-end"`, or content bottom-pinned via a `flex:1` spacer) is positioned **off-screen** while its full-screen backdrop keeps capturing touches → unreachable controls, frozen app. #545 built a portal workaround for this and **removed it in the same series**, so these are unprotected.

The confirmed fix is `coverScreen={false}`, which takes react-native-modal's inline render path (`modal.js:536`) instead of the broken native host, so layout measures correctly.

## Changes — 6 confirmed bottom-anchored modals

| File | Why affected | Notable |
|------|--------------|---------|
| `modal-tooltip.tsx` | `flex-end` sheet | **Reused across many screens**; was `coverScreen={true}` |
| `contact-modal.tsx` | `flex-end` sheet | |
| `reports-modal.tsx` | `flex-end` sheet | |
| `home-screen/AccountCreateModal.tsx` | bottom-pinned via `flex:1` spacer | Shows on "need wallet" |
| `modal-nfc.tsx` | bottom-pinned via `flex:1` spacer | **Auto-shows on Android** during NFC scan |
| `earns-screen/earns-quiz.tsx` | bottom-pinned quiz card | |

Each change is a single `coverScreen={false}` prop with a short comment.

## Deliberately NOT changed

- **Centered modals** (library-default `justifyContent`, ~15 files): tolerate the mis-measurement, not affected.
- **`merchant-suggest-modal.tsx`**: top-anchored (`flex-start`) — stays on-screen even when mis-measured.
- **Core React Native `<Modal>` usages (~20)**: hit the same broken host but **cannot** take `coverScreen`. Several are bottom-sheets on core flows (receive, transfer). These need a different remedy (restore a portal, or migrate) and are tracked separately — **out of scope here**.

## Testing

Manual Android (New Arch) device pass — each modal opens on-screen with reachable controls and no freeze:
- [ ] Tooltip (any `?` info icon)
- [ ] Contact options modal
- [ ] Reports modal
- [ ] "Need wallet" create-account modal (home)
- [ ] NFC scan modal (Flashcard tap)
- [ ] Earns quiz modal

The defect is a native/Fabric layout measurement, so JS unit tests can't reproduce it; the on-device pass is the guard.

## Scope note

Pre-existing eslint debt in some of these files (unused vars, `no-alert`, `no-explicit-any`, unspaced comments) is left untouched to keep the diff to the fix. Verified: the added lines introduce no new lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7z7o9J18BWbUnYJcemMtg
