### PR TITLE
ci: lint only changed lines, not whole files

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -31,11 +31,12 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      # Lint only the JS/TS files this PR/push changes. The repo carries a large
-      # amount of pre-existing lint debt, so a whole-repo `eslint .` gate would
-      # fail on unrelated files; scope it to changed files to catch new issues
-      # without blocking on legacy debt.
-      - name: Lint changed JS/TS files
+      # Lint only the lines this PR/push changes. The repo carries a large amount
+      # of pre-existing lint debt, so a whole-repo (or whole-file) `eslint` gate fails
+      # on untouched legacy code as soon as a PR edits any part of such a file.
+      # scripts/ci/lint-changed.mjs runs ESLint on the changed files but only fails
+      # on errors that land on added/modified lines.
+      - name: Lint changed JS/TS lines
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE="${{ github.event.pull_request.base.sha }}"
@@ -45,14 +46,7 @@ jobs:
           if [ -z "$BASE" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
             BASE="$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"
           fi
-          FILES=$(git diff --name-only --diff-filter=ACMR "$BASE...HEAD" -- '*.js' '*.jsx' '*.ts' '*.tsx')
-          if [ -z "$FILES" ]; then
-            echo "No JS/TS files changed; skipping ESLint."
-            exit 0
-          fi
-          echo "Linting changed files:"
-          echo "$FILES"
-          yarn eslint $FILES
+          BASE_SHA="$BASE" node scripts/ci/lint-changed.mjs
 
   ios-build:
     name: iOS Build Check

--- a/scripts/ci/lint-changed.mjs
+++ b/scripts/ci/lint-changed.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Lint only the lines a PR/push actually changes.
+//
+// The repo carries a large amount of pre-existing lint debt, so a whole-file
+// (or whole-repo) `eslint` gate fails on untouched legacy code the moment a PR
+// edits any part of such a file. This runs ESLint on the changed files but only
+// fails on error-severity messages that land on added/modified lines, so a PR
+// is judged solely on the code it introduces.
+//
+// Base commit comes from $BASE_SHA (the workflow computes it for PR vs push).
+import { execSync } from "node:child_process"
+
+const base = process.env.BASE_SHA
+if (!base) {
+  console.error("BASE_SHA is not set")
+  process.exit(1)
+}
+
+const sh = (cmd) => execSync(cmd, { encoding: "utf8", maxBuffer: 256 * 1024 * 1024 })
+
+const files = sh(
+  `git diff --name-only --diff-filter=ACMR ${base}...HEAD -- "*.js" "*.jsx" "*.ts" "*.tsx"`,
+)
+  .split("\n")
+  .filter(Boolean)
+
+if (files.length === 0) {
+  console.log("No JS/TS files changed; skipping ESLint.")
+  process.exit(0)
+}
+console.log("Changed JS/TS files:\n" + files.map((f) => "  " + f).join("\n"))
+
+// Added/modified line numbers (new side) per file, parsed from a zero-context diff.
+const changedLines = {}
+for (const f of files) {
+  const diff = sh(`git diff --unified=0 ${base}...HEAD -- "${f}"`)
+  const set = new Set()
+  const re = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/gm
+  let m
+  while ((m = re.exec(diff))) {
+    const start = Number(m[1])
+    const count = m[2] === undefined ? 1 : Number(m[2])
+    for (let i = 0; i < count; i++) set.add(start + i)
+  }
+  changedLines[f] = set
+}
+
+// Run ESLint over the changed files and read JSON, regardless of exit code
+// (ESLint exits non-zero when it finds problems; the JSON is still on stdout).
+let results = []
+const eslintCmd = `yarn --silent eslint --format json ${files.map((f) => `"${f}"`).join(" ")}`
+try {
+  const out = sh(eslintCmd)
+  results = JSON.parse(out.slice(out.indexOf("[")))
+} catch (e) {
+  const out = (e.stdout || "").toString()
+  const start = out.indexOf("[")
+  if (start < 0) {
+    console.error("ESLint did not produce JSON output (config error or crash):")
+    console.error((e.stderr || "").toString() || out)
+    process.exit(1)
+  }
+  results = JSON.parse(out.slice(start))
+}
+
+const cwd = process.cwd()
+let failures = 0
+for (const r of results) {
+  const rel = r.filePath.startsWith(cwd) ? r.filePath.slice(cwd.length + 1) : r.filePath
+  const lines = changedLines[rel]
+  if (!lines) continue
+  for (const msg of r.messages) {
+    if (msg.severity === 2 && lines.has(msg.line)) {
+      failures++
+      console.log(
+        `::error file=${rel},line=${msg.line},col=${msg.column}::${msg.ruleId || "eslint"}: ${msg.message}`,
+      )
+    }
+  }
+}
+
+if (failures > 0) {
+  console.log(`\n${failures} ESLint error(s) on changed lines.`)
+  process.exit(1)
+}
+console.log("\nNo ESLint errors on changed lines.")


### PR DESCRIPTION
## Problem

The `Lint` gate (added in #671) runs `eslint` on whole changed **files**. Because the repo carries ~1,400 pre-existing lint errors, any PR that edits *any part* of a file with existing debt fails on untouched lines — e.g. a one-line modal fix in a file that already has an unused import. That punishes normal changes and pressures unrelated cleanup into focused PRs.

## Change

Lint only the **added/modified lines**. `scripts/ci/lint-changed.mjs`:
1. lists changed `.js/.jsx/.ts/.tsx` files (`git diff --diff-filter=ACMR BASE...HEAD`),
2. parses a zero-context diff for the exact new-side line numbers,
3. runs `eslint --format json` on those files,
4. fails only on **error**-severity messages whose line is in the changed set (emitting `::error` annotations); no-ops when nothing JS/TS changed.

No new dependencies or marketplace actions — just node + the existing eslint + git.

## Verified locally

- **Pass:** run against PR #674 (touches 6 modal files with 17 pre-existing errors among them) → `No ESLint errors on changed lines`, exit 0.
- **Fail:** inject `const x: any = null` on a new line → exit 1 with `::error … no-explicit-any` on that exact line. The gate can still catch newly-introduced problems.

## Note

Merge this before the open fix PRs (#672/#673 are unaffected; **#674's Lint stays red until this merges**, then passes on re-run).
