### PR TITLE
ci: fix version-bump push-back in deploy workflows

### DIFF
--- a/.github/workflows/android-deploy.yml
+++ b/.github/workflows/android-deploy.yml
@@ -19,6 +19,10 @@ concurrency:
   group: android-deploy
   cancel-in-progress: false
 
+# The deploy pushes a version-bump commit + tag back to the repo.
+permissions:
+  contents: write
+
 jobs:
   deploy:
     name: Deploy Android
@@ -114,10 +118,12 @@ jobs:
       - name: Push version bump
         if: success() && steps.lane.outputs.lane != 'promote_to_beta'
         run: |
-          BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          # Tag-triggered runs check out in detached HEAD, so resolve the target
+          # branch explicitly (git rev-parse --abbrev-ref HEAD would give "HEAD").
+          BRANCH="${{ github.event.repository.default_branch }}"
           git fetch origin "$BRANCH"
-          git rebase -X theirs --autostash origin/"$BRANCH"
-          git push origin "$BRANCH" --follow-tags
+          git rebase -X theirs --autostash "origin/$BRANCH"
+          git push origin "HEAD:$BRANCH" --follow-tags
 
       - name: Clean up sensitive files
         if: always()

--- a/.github/workflows/ios-alt-deploy.yml
+++ b/.github/workflows/ios-alt-deploy.yml
@@ -18,6 +18,10 @@ concurrency:
   group: ios-alt-deploy
   cancel-in-progress: false
 
+# The deploy pushes a version-bump commit + tag back to the repo.
+permissions:
+  contents: write
+
 jobs:
   deploy:
     name: Deploy iOS Alt
@@ -94,10 +98,12 @@ jobs:
       - name: Push version bump
         if: success()
         run: |
-          BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          # Tag-triggered runs check out in detached HEAD, so resolve the target
+          # branch explicitly (git rev-parse --abbrev-ref HEAD would give "HEAD").
+          BRANCH="${{ github.event.repository.default_branch }}"
           git fetch origin "$BRANCH"
-          git rebase -X theirs --autostash origin/"$BRANCH"
-          git push origin "$BRANCH" --follow-tags
+          git rebase -X theirs --autostash "origin/$BRANCH"
+          git push origin "HEAD:$BRANCH" --follow-tags
 
       - name: Upload artifacts on failure
         if: failure()

--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -18,6 +18,10 @@ concurrency:
   group: ios-deploy
   cancel-in-progress: false
 
+# The deploy pushes a version-bump commit + tag back to the repo.
+permissions:
+  contents: write
+
 jobs:
   deploy:
     name: Deploy iOS
@@ -92,10 +96,12 @@ jobs:
       - name: Push version bump
         if: success()
         run: |
-          BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          # Tag-triggered runs check out in detached HEAD, so resolve the target
+          # branch explicitly (git rev-parse --abbrev-ref HEAD would give "HEAD").
+          BRANCH="${{ github.event.repository.default_branch }}"
           git fetch origin "$BRANCH"
-          git rebase -X theirs --autostash origin/"$BRANCH"
-          git push origin "$BRANCH" --follow-tags
+          git rebase -X theirs --autostash "origin/$BRANCH"
+          git push origin "HEAD:$BRANCH" --follow-tags
 
       - name: Upload artifacts on failure
         if: failure()


### PR DESCRIPTION
## Problem

The tag-triggered deploy workflows (`android-deploy`, `ios-deploy`, `ios-alt-deploy`) build the app and upload it, then **fail at the final "Push version bump" step** — so the workflow reports **failure even though the app was uploaded**.

Confirmed on the prior `android/v0.6.2` run: every step through **"Run Fastlane" succeeded** (the AAB was built and uploaded to Play internal); only **"Push version bump"** failed. Left unfixed, every tag deploy goes red at this step and the version-bump commit / `…/v{name}-{code}` tag never lands.

## Root cause (same in all three workflows)

```yaml
BRANCH=$(git rev-parse --abbrev-ref HEAD)   # → "HEAD" on a tag push (detached HEAD)
git fetch origin "$BRANCH"                   # fetches bogus ref "HEAD"
git rebase ... origin/"$BRANCH"
git push origin "$BRANCH" --follow-tags      # pushes to bogus ref "HEAD"
```

1. **Detached HEAD:** a tag push checks out the tag commit, not a branch, so `git rev-parse --abbrev-ref HEAD` returns `HEAD`, and the fetch/rebase/push all target a nonexistent ref.
2. **No write permission:** none of the workflows declare `permissions:`, so the default `GITHUB_TOKEN` may be read-only and the push is rejected.

## Fix

In each of the three deploy workflows:

```yaml
permissions:
  contents: write
```

```yaml
# Tag-triggered runs check out in detached HEAD, so resolve the target
# branch explicitly (git rev-parse --abbrev-ref HEAD would give "HEAD").
BRANCH="${{ github.event.repository.default_branch }}"
git fetch origin "$BRANCH"
git rebase -X theirs --autostash "origin/$BRANCH"
git push origin "HEAD:$BRANCH" --follow-tags
```

`HEAD:$BRANCH` pushes the rebased version-bump commit to the default branch from detached HEAD; `--follow-tags` carries the new version tag.

## Notes

- YAML validated for all three files.
- Deploy workflows only trigger on tags, so this PR can't exercise them directly — the fix is verified by inspection against the confirmed failure mode. After merge, the next `android/v*` / `ios/v*` tag should complete green (upload **and** push-back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7z7o9J18BWbUnYJcemMtg
