### PR TITLE
fix(android): bump versionCode to 85 to clear Play collision

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -95,7 +95,7 @@ android {
         applicationId "com.lnflash"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 84
+        versionCode 85
         versionName "0.6.1"
 
         // use google-service.dev.json if google-service.json is not exits


### PR DESCRIPTION
The v0.6.2 deploy uploaded versionCode **85** to Play, but its version-bump push-back failed (the detached-HEAD bug fixed in #676), so `build.gradle` never advanced past 84. Every deploy since re-increments 84→85 and Play rejects it: `Version code 85 has already been used`.

Sets `versionCode 85` so the lane's `increment_android_version_code` lands on **86** (free). With #676 merged, the post-deploy bump now persists, so versionCode self-maintains going forward.

**After merge:** re-point the `android/v0.6.3` tag to the new main HEAD to re-run the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7z7o9J18BWbUnYJcemMtg