### PR TITLE
docs: add SECURITY.md with security contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+Flash takes the security of our software and our users seriously, and we appreciate responsible disclosure.
+
+## Reporting a Vulnerability
+
+Please email **security@getflash.io**.
+
+Include as much of the following as you can:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce (proof of concept, affected versions or endpoints)
+- Any suggested remediation
+
+Please do **not** open a public GitHub issue for security vulnerabilities.
+
+## What to Expect
+
+- We aim to acknowledge reports within 2 business days.
+- We will keep you informed as we investigate and remediate.
+- Please allow us a reasonable window to fix the issue before public disclosure.
+
+## Scope
+
+This policy applies to all public repositories in the [lnflash](https://github.com/lnflash) organization and to the Flash app and services (getflash.io, flashapp.me).


### PR DESCRIPTION
Adds a standard security policy with a vulnerability-reporting contact (security@getflash.io), so researchers running ecosystem audits (e.g. Bitcoin Red Team) have a disclosure channel.

Docs-only change — no code, no tests needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcEjF6SS3Ci5D4CzZqdPjb