### PR TITLE
feat(invite): My Referrals screen — a user's own invite history + earnings

### DIFF
--- a/app/graphql/front-end-queries.ts
+++ b/app/graphql/front-end-queries.ts
@@ -286,6 +286,25 @@ gql`
     }
   }
 
+  query myReferrals($first: Int, $afterId: ID) {
+    myReferrals(first: $first, afterId: $afterId) {
+      totalInvites
+      acceptedCount
+      totalEarnedCents
+      pendingRewardCount
+      invites {
+        id
+        contact
+        method
+        status
+        createdAt
+        redeemedAt
+        myRewardCents
+        rewardPending
+      }
+    }
+  }
+
   query invitePreview($token: String!) {
     invitePreview(token: $token) {
       contact

--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -1543,6 +1543,27 @@ query myQuizQuestions {
   }
 }
 
+query myReferrals($first: Int, $afterId: ID) {
+  myReferrals(first: $first, afterId: $afterId) {
+    totalInvites
+    acceptedCount
+    totalEarnedCents
+    pendingRewardCount
+    invites {
+      id
+      contact
+      method
+      status
+      createdAt
+      redeemedAt
+      myRewardCents
+      rewardPending
+      __typename
+    }
+    __typename
+  }
+}
+
 query myUserId {
   me {
     id

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -1785,6 +1785,27 @@ export type MutationUserUpdateUsernameArgs = {
   input: UserUpdateUsernameInput;
 };
 
+export type MyReferralInvite = {
+  readonly __typename: 'MyReferralInvite';
+  readonly contact: Scalars['String']['output'];
+  readonly createdAt: Scalars['String']['output'];
+  readonly id: Scalars['ID']['output'];
+  readonly method: InviteMethod;
+  readonly myRewardCents?: Maybe<Scalars['Int']['output']>;
+  readonly redeemedAt?: Maybe<Scalars['String']['output']>;
+  readonly rewardPending: Scalars['Boolean']['output'];
+  readonly status: InviteStatus;
+};
+
+export type MyReferrals = {
+  readonly __typename: 'MyReferrals';
+  readonly acceptedCount: Scalars['Int']['output'];
+  readonly invites: ReadonlyArray<MyReferralInvite>;
+  readonly pendingRewardCount: Scalars['Int']['output'];
+  readonly totalEarnedCents: Scalars['Int']['output'];
+  readonly totalInvites: Scalars['Int']['output'];
+};
+
 export type MyUpdatesPayload = {
   readonly __typename: 'MyUpdatesPayload';
   readonly errors: ReadonlyArray<Error>;
@@ -2041,6 +2062,7 @@ export type Query = {
   readonly lnInvoicePaymentStatus: LnInvoicePaymentStatusPayload;
   readonly me?: Maybe<User>;
   readonly mobileVersions?: Maybe<ReadonlyArray<Maybe<MobileVersions>>>;
+  readonly myReferrals: MyReferrals;
   readonly npubByUsername?: Maybe<NpubByUsername>;
   readonly onChainTxFee: OnChainTxFee;
   readonly onChainUsdTxFee: OnChainUsdTxFee;
@@ -2091,6 +2113,12 @@ export type QueryIsFlashNpubArgs = {
 
 export type QueryLnInvoicePaymentStatusArgs = {
   input: LnInvoicePaymentStatusInput;
+};
+
+
+export type QueryMyReferralsArgs = {
+  afterId?: InputMaybe<Scalars['ID']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -3139,6 +3167,14 @@ export type NpubByUsernameQueryVariables = Exact<{
 
 
 export type NpubByUsernameQuery = { readonly __typename: 'Query', readonly npubByUsername?: { readonly __typename: 'npubByUsername', readonly npub?: string | null, readonly username?: string | null } | null };
+
+export type MyReferralsQueryVariables = Exact<{
+  first?: InputMaybe<Scalars['Int']['input']>;
+  afterId?: InputMaybe<Scalars['ID']['input']>;
+}>;
+
+
+export type MyReferralsQuery = { readonly __typename: 'Query', readonly myReferrals: { readonly __typename: 'MyReferrals', readonly totalInvites: number, readonly acceptedCount: number, readonly totalEarnedCents: number, readonly pendingRewardCount: number, readonly invites: ReadonlyArray<{ readonly __typename: 'MyReferralInvite', readonly id: string, readonly contact: string, readonly method: InviteMethod, readonly status: InviteStatus, readonly createdAt: string, readonly redeemedAt?: string | null, readonly myRewardCents?: number | null, readonly rewardPending: boolean }> } };
 
 export type InvitePreviewQueryVariables = Exact<{
   token: Scalars['String']['input'];
@@ -6004,6 +6040,55 @@ export function useNpubByUsernameLazyQuery(baseOptions?: Apollo.LazyQueryHookOpt
 export type NpubByUsernameQueryHookResult = ReturnType<typeof useNpubByUsernameQuery>;
 export type NpubByUsernameLazyQueryHookResult = ReturnType<typeof useNpubByUsernameLazyQuery>;
 export type NpubByUsernameQueryResult = Apollo.QueryResult<NpubByUsernameQuery, NpubByUsernameQueryVariables>;
+export const MyReferralsDocument = gql`
+    query myReferrals($first: Int, $afterId: ID) {
+  myReferrals(first: $first, afterId: $afterId) {
+    totalInvites
+    acceptedCount
+    totalEarnedCents
+    pendingRewardCount
+    invites {
+      id
+      contact
+      method
+      status
+      createdAt
+      redeemedAt
+      myRewardCents
+      rewardPending
+    }
+  }
+}
+    `;
+
+/**
+ * __useMyReferralsQuery__
+ *
+ * To run a query within a React component, call `useMyReferralsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMyReferralsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useMyReferralsQuery({
+ *   variables: {
+ *      first: // value for 'first'
+ *      afterId: // value for 'afterId'
+ *   },
+ * });
+ */
+export function useMyReferralsQuery(baseOptions?: Apollo.QueryHookOptions<MyReferralsQuery, MyReferralsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<MyReferralsQuery, MyReferralsQueryVariables>(MyReferralsDocument, options);
+      }
+export function useMyReferralsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MyReferralsQuery, MyReferralsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<MyReferralsQuery, MyReferralsQueryVariables>(MyReferralsDocument, options);
+        }
+export type MyReferralsQueryHookResult = ReturnType<typeof useMyReferralsQuery>;
+export type MyReferralsLazyQueryHookResult = ReturnType<typeof useMyReferralsLazyQuery>;
+export type MyReferralsQueryResult = Apollo.QueryResult<MyReferralsQuery, MyReferralsQueryVariables>;
 export const InvitePreviewDocument = gql`
     query invitePreview($token: String!) {
   invitePreview(token: $token) {

--- a/app/graphql/public-schema.graphql
+++ b/app/graphql/public-schema.graphql
@@ -1265,6 +1265,25 @@ type MobileVersions {
   platform: String!
 }
 
+type MyReferralInvite {
+  contact: String!
+  createdAt: String!
+  id: ID!
+  method: InviteMethod!
+  myRewardCents: Int
+  redeemedAt: String
+  rewardPending: Boolean!
+  status: InviteStatus!
+}
+
+type MyReferrals {
+  acceptedCount: Int!
+  invites: [MyReferralInvite!]!
+  pendingRewardCount: Int!
+  totalEarnedCents: Int!
+  totalInvites: Int!
+}
+
 type Mutation {
   accountCapabilityUpgradeRequest(input: AccountCapabilityUpgradeRequestInput!): AccountCapabilityUpgradeRequestPayload!
   accountDelete: AccountDeletePayload!
@@ -1698,6 +1717,7 @@ type Query {
   lnInvoicePaymentStatus(input: LnInvoicePaymentStatusInput!): LnInvoicePaymentStatusPayload!
   me: User
   mobileVersions: [MobileVersions]
+  myReferrals(afterId: ID, first: Int): MyReferrals!
   npubByUsername(username: Username!): npubByUsername
   onChainTxFee(address: OnChainAddress!, amount: SatAmount!, speed: PayoutSpeed = FAST, walletId: WalletId!): OnChainTxFee!
   onChainUsdTxFee(address: OnChainAddress!, amount: FractionalCentAmount!, speed: PayoutSpeed = FAST, walletId: WalletId!): OnChainUsdTxFee!

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -1054,6 +1054,20 @@ const en: BaseTranslation = {
     invitationSuccessTitle: "Invitation has been sent to {value: string}",
     done: "Done"
   },
+  MyReferrals: {
+    title: "My Referrals",
+    viewMine: "View my referrals",
+    totalEarned: "Total earned",
+    friendsJoined: "Friends joined",
+    pendingCount: "Pending rewards: {count: number}",
+    earned: "Joined — you earned {amount: string}",
+    joinedRewardPending: "Joined — reward pending",
+    joined: "Joined",
+    invited: "Invited",
+    expired: "Expired",
+    empty: "No invites yet — invite a friend to get started.",
+    loadFailed: "Couldn't load your referrals. Pull to retry."
+  },
   NotificationSettingsScreen: {
     title: "Notification Settings",
     pushNotifications: "Push Notifications",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -3501,6 +3501,58 @@ type RootTranslation = {
 		 */
 		done: string
 	}
+	MyReferrals: {
+		/**
+		 * M​y​ ​R​e​f​e​r​r​a​l​s
+		 */
+		title: string
+		/**
+		 * V​i​e​w​ ​m​y​ ​r​e​f​e​r​r​a​l​s
+		 */
+		viewMine: string
+		/**
+		 * T​o​t​a​l​ ​e​a​r​n​e​d
+		 */
+		totalEarned: string
+		/**
+		 * F​r​i​e​n​d​s​ ​j​o​i​n​e​d
+		 */
+		friendsJoined: string
+		/**
+		 * P​e​n​d​i​n​g​ ​r​e​w​a​r​d​s​:​ ​{​c​o​u​n​t​}
+		 * @param {number} count
+		 */
+		pendingCount: RequiredParams<'count'>
+		/**
+		 * J​o​i​n​e​d​ ​—​ ​y​o​u​ ​e​a​r​n​e​d​ ​{​a​m​o​u​n​t​}
+		 * @param {string} amount
+		 */
+		earned: RequiredParams<'amount'>
+		/**
+		 * J​o​i​n​e​d​ ​—​ ​r​e​w​a​r​d​ ​p​e​n​d​i​n​g
+		 */
+		joinedRewardPending: string
+		/**
+		 * J​o​i​n​e​d
+		 */
+		joined: string
+		/**
+		 * I​n​v​i​t​e​d
+		 */
+		invited: string
+		/**
+		 * E​x​p​i​r​e​d
+		 */
+		expired: string
+		/**
+		 * N​o​ ​i​n​v​i​t​e​s​ ​y​e​t​ ​—​ ​i​n​v​i​t​e​ ​a​ ​f​r​i​e​n​d​ ​t​o​ ​g​e​t​ ​s​t​a​r​t​e​d​.
+		 */
+		empty: string
+		/**
+		 * C​o​u​l​d​n​'​t​ ​l​o​a​d​ ​y​o​u​r​ ​r​e​f​e​r​r​a​l​s​.​ ​P​u​l​l​ ​t​o​ ​r​e​t​r​y​.
+		 */
+		loadFailed: string
+	}
 	NotificationSettingsScreen: {
 		/**
 		 * N​o​t​i​f​i​c​a​t​i​o​n​ ​S​e​t​t​i​n​g​s
@@ -9534,6 +9586,56 @@ export type TranslationFunctions = {
 		 * Done
 		 */
 		done: () => LocalizedString
+	}
+	MyReferrals: {
+		/**
+		 * My Referrals
+		 */
+		title: () => LocalizedString
+		/**
+		 * View my referrals
+		 */
+		viewMine: () => LocalizedString
+		/**
+		 * Total earned
+		 */
+		totalEarned: () => LocalizedString
+		/**
+		 * Friends joined
+		 */
+		friendsJoined: () => LocalizedString
+		/**
+		 * Pending rewards: {count}
+		 */
+		pendingCount: (arg: { count: number }) => LocalizedString
+		/**
+		 * Joined — you earned {amount}
+		 */
+		earned: (arg: { amount: string }) => LocalizedString
+		/**
+		 * Joined — reward pending
+		 */
+		joinedRewardPending: () => LocalizedString
+		/**
+		 * Joined
+		 */
+		joined: () => LocalizedString
+		/**
+		 * Invited
+		 */
+		invited: () => LocalizedString
+		/**
+		 * Expired
+		 */
+		expired: () => LocalizedString
+		/**
+		 * No invites yet — invite a friend to get started.
+		 */
+		empty: () => LocalizedString
+		/**
+		 * Couldn't load your referrals. Pull to retry.
+		 */
+		loadFailed: () => LocalizedString
 	}
 	NotificationSettingsScreen: {
 		/**

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -982,6 +982,20 @@
         "invitationSuccessTitle": "Invitation has been sent to {value: string}",
         "done": "Done"
     },
+    "MyReferrals": {
+        "title": "My Referrals",
+        "viewMine": "View my referrals",
+        "totalEarned": "Total earned",
+        "friendsJoined": "Friends joined",
+        "pendingCount": "Pending rewards: {count: number}",
+        "earned": "Joined — you earned {amount: string}",
+        "joinedRewardPending": "Joined — reward pending",
+        "joined": "Joined",
+        "invited": "Invited",
+        "expired": "Expired",
+        "empty": "No invites yet — invite a friend to get started.",
+        "loadFailed": "Couldn't load your referrals. Pull to retry."
+    },
     "NotificationSettingsScreen": {
         "title": "Notification Settings",
         "pushNotifications": "Push Notifications",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -1719,5 +1719,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -1724,5 +1724,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -1724,5 +1724,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -1718,5 +1718,19 @@
     "or": "OR",
     "invitationSuccessTitle": "Invitation has been sent to {value: string}",
     "done": "Done"
+  },
+  "MyReferrals": {
+    "title": "My Referrals",
+    "viewMine": "View my referrals",
+    "totalEarned": "Total earned",
+    "friendsJoined": "Friends joined",
+    "pendingCount": "Pending rewards: {count: number}",
+    "earned": "Joined — you earned {amount: string}",
+    "joinedRewardPending": "Joined — reward pending",
+    "joined": "Joined",
+    "invited": "Invited",
+    "expired": "Expired",
+    "empty": "No invites yet — invite a friend to get started.",
+    "loadFailed": "Couldn't load your referrals. Pull to retry."
   }
 }

--- a/app/navigation/root-navigator.tsx
+++ b/app/navigation/root-navigator.tsx
@@ -91,6 +91,7 @@ import {
   SignInViaQRCode,
   InviteFriend,
   InviteFriendSuccess,
+  MyReferrals,
 } from "@app/screens"
 import { usePersistentStateContext } from "@app/store/persistent-state"
 import { NotificationSettingsScreen } from "@app/screens/settings-screen/notifications-screen"
@@ -731,6 +732,11 @@ export const RootStack = () => {
           name="InviteFriendSuccess"
           component={InviteFriendSuccess}
           options={{ headerShown: false }}
+        />
+        <RootNavigator.Screen
+          name="MyReferrals"
+          component={MyReferrals}
+          options={{ headerShown: true, title: "My Referrals" }}
         />
       </RootNavigator.Group>
     </RootNavigator.Navigator>

--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -168,6 +168,7 @@ export type RootStackParamList = {
   SignInViaQRCode: undefined
   Nip29GroupChat: { groupId: string }
   InviteFriend: undefined
+  MyReferrals: undefined
   InviteFriendSuccess?: {
     contact: string
     method: string

--- a/app/screens/invite-friend/InviteFriend.tsx
+++ b/app/screens/invite-friend/InviteFriend.tsx
@@ -353,6 +353,16 @@ const InviteFriend: React.FC<Props> = ({ navigation }) => {
         btnStyle={styles.submitButton}
       />
 
+      {/* The user's own invite history + earnings */}
+      <TouchableOpacity
+        style={styles.myReferralsLink}
+        onPress={() => navigation.navigate("MyReferrals")}
+      >
+        <Text type="p2" bold color={colors.primary}>
+          {LL.MyReferrals.viewMine()}
+        </Text>
+      </TouchableOpacity>
+
       {/* Contact Picker Modal */}
       <ContactPicker
         visible={showContactPicker}
@@ -493,6 +503,10 @@ const useStyles = makeStyles(({ colors }) => ({
     color: colors.grey3,
     textAlign: "center",
     paddingHorizontal: 16,
+  },
+  myReferralsLink: {
+    alignItems: "center",
+    paddingVertical: 14,
   },
   submitButton: {
     marginBottom: 10,

--- a/app/screens/invite-friend/MyReferrals.tsx
+++ b/app/screens/invite-friend/MyReferrals.tsx
@@ -1,0 +1,167 @@
+import React from "react"
+import { ActivityIndicator, FlatList, View } from "react-native"
+import { Text, makeStyles, useTheme } from "@rneui/themed"
+
+import { Screen } from "@app/components/screen"
+import { useI18nContext } from "@app/i18n/i18n-react"
+import {
+  useMyReferralsQuery,
+  InviteStatus,
+  MyReferralsQuery,
+} from "@app/graphql/generated"
+import { useReferralRewardFlag } from "@app/hooks"
+
+// A user's own referral history: every invite they sent, what happened to it,
+// and — only while referral rewards are enabled instance-wide — what they
+// earned. Reward copy is gated on the same backend flag as the home-screen
+// invite card so this screen can never promise money the backend won't pay.
+
+const formatCents = (cents: number) => `$${(cents / 100).toFixed(2)}`
+
+type ReferralRow = NonNullable<MyReferralsQuery["myReferrals"]>["invites"][number]
+
+export const MyReferrals: React.FC = () => {
+  const styles = useStyles()
+  const {
+    theme: { colors },
+  } = useTheme()
+  const { LL } = useI18nContext()
+  const { referralRewardEnabled } = useReferralRewardFlag()
+  const { data, loading, error, refetch } = useMyReferralsQuery({
+    fetchPolicy: "cache-and-network",
+  })
+
+  const referrals = data?.myReferrals
+
+  const statusLine = (row: ReferralRow): { label: string; tone: "ok" | "muted" } => {
+    if (row.status === InviteStatus.Accepted) {
+      if (referralRewardEnabled && row.myRewardCents) {
+        return {
+          label: LL.MyReferrals.earned({ amount: formatCents(row.myRewardCents) }),
+          tone: "ok",
+        }
+      }
+      if (referralRewardEnabled && row.rewardPending) {
+        return { label: LL.MyReferrals.joinedRewardPending(), tone: "ok" }
+      }
+      return { label: LL.MyReferrals.joined(), tone: "ok" }
+    }
+    if (row.status === InviteStatus.Expired) {
+      return { label: LL.MyReferrals.expired(), tone: "muted" }
+    }
+    // SENT — and PENDING (created, delivery unconfirmed) reads as invited too:
+    // the distinction is an ops concern, not the user's.
+    return { label: LL.MyReferrals.invited(), tone: "muted" }
+  }
+
+  const renderRow = ({ item }: { item: ReferralRow }) => {
+    const { label, tone } = statusLine(item)
+    return (
+      <View style={styles.row}>
+        <View style={styles.rowText}>
+          <Text type="p1" numberOfLines={1}>
+            {item.contact}
+          </Text>
+          <Text type="p3" color={tone === "ok" ? colors.green : colors.grey3}>
+            {label}
+          </Text>
+        </View>
+      </View>
+    )
+  }
+
+  return (
+    <Screen preset="fixed">
+      <View style={styles.container}>
+        {referrals && (
+          <View style={styles.header}>
+            {referralRewardEnabled ? (
+              <>
+                <Text type="caption" color={colors.grey3}>
+                  {LL.MyReferrals.totalEarned()}
+                </Text>
+                <Text style={styles.headline} type="h1" bold>
+                  {formatCents(referrals.totalEarnedCents)}
+                </Text>
+                {referrals.pendingRewardCount > 0 && (
+                  <Text type="p3" color={colors.grey3}>
+                    {LL.MyReferrals.pendingCount({
+                      count: referrals.pendingRewardCount,
+                    })}
+                  </Text>
+                )}
+              </>
+            ) : (
+              <>
+                <Text type="caption" color={colors.grey3}>
+                  {LL.MyReferrals.friendsJoined()}
+                </Text>
+                <Text style={styles.headline} type="h1" bold>
+                  {referrals.acceptedCount}
+                </Text>
+              </>
+            )}
+          </View>
+        )}
+
+        {loading && !referrals && <ActivityIndicator style={styles.spinner} />}
+        {Boolean(error) && !referrals && (
+          <Text type="p2" color={colors.grey3} style={styles.empty}>
+            {LL.MyReferrals.loadFailed()}
+          </Text>
+        )}
+
+        {referrals && referrals.invites.length === 0 && (
+          <Text type="p2" color={colors.grey3} style={styles.empty}>
+            {LL.MyReferrals.empty()}
+          </Text>
+        )}
+
+        {referrals && referrals.invites.length > 0 && (
+          <FlatList
+            data={referrals.invites}
+            keyExtractor={(item) => item.id}
+            renderItem={renderRow}
+            onRefresh={refetch}
+            refreshing={false}
+            contentContainerStyle={styles.list}
+          />
+        )}
+      </View>
+    </Screen>
+  )
+}
+
+const useStyles = makeStyles(({ colors }) => ({
+  container: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+  header: {
+    alignItems: "center",
+    paddingVertical: 24,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.grey5,
+  },
+  headline: {
+    marginVertical: 4,
+  },
+  spinner: {
+    marginTop: 32,
+  },
+  empty: {
+    textAlign: "center",
+    marginTop: 32,
+  },
+  list: {
+    paddingVertical: 8,
+  },
+  row: {
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.grey5,
+  },
+  rowText: {
+    gap: 2,
+  },
+}))

--- a/app/screens/invite-friend/__tests__/InviteFriend.test.tsx
+++ b/app/screens/invite-friend/__tests__/InviteFriend.test.tsx
@@ -12,6 +12,9 @@ import InviteFriend from "../InviteFriend"
 jest.mock("@app/i18n/i18n-react", () => ({
   useI18nContext: () => ({
     LL: {
+      MyReferrals: {
+        viewMine: () => "View my referrals",
+      },
       InviteFriend: {
         title: () => "Invite a friend to Flash!",
         subtitle: () => "Enter a phone number or email address to invite a friend.",

--- a/app/screens/invite-friend/__tests__/MyReferrals.test.tsx
+++ b/app/screens/invite-friend/__tests__/MyReferrals.test.tsx
@@ -123,10 +123,10 @@ describe("MyReferrals screen", () => {
   })
 
   it("shows a pending-reward row and the pending count", () => {
-    withData(
-      [invite({ id: "p", status: InviteStatus.Accepted, rewardPending: true })],
-      { pendingRewardCount: 1, acceptedCount: 1 },
-    )
+    withData([invite({ id: "p", status: InviteStatus.Accepted, rewardPending: true })], {
+      pendingRewardCount: 1,
+      acceptedCount: 1,
+    })
     const screen = renderScreen()
     expect(screen.getByText("Joined — reward pending")).toBeTruthy()
     expect(screen.getByText("Pending rewards: 1")).toBeTruthy()

--- a/app/screens/invite-friend/__tests__/MyReferrals.test.tsx
+++ b/app/screens/invite-friend/__tests__/MyReferrals.test.tsx
@@ -1,0 +1,187 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+import { ThemeProvider } from "@rneui/themed"
+import theme from "@app/rne-theme/theme"
+
+// Mock i18n so LL.* resolves synchronously.
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({
+    LL: {
+      MyReferrals: {
+        totalEarned: () => "Total earned",
+        friendsJoined: () => "Friends joined",
+        pendingCount: ({ count }: { count: number }) => `Pending rewards: ${count}`,
+        earned: ({ amount }: { amount: string }) => `Joined — you earned ${amount}`,
+        joinedRewardPending: () => "Joined — reward pending",
+        joined: () => "Joined",
+        invited: () => "Invited",
+        expired: () => "Expired",
+        empty: () => "No invites yet — invite a friend to get started.",
+        loadFailed: () => "Couldn't load your referrals. Pull to retry.",
+      },
+    },
+  }),
+}))
+
+jest.mock("react-native-safe-area-context", () => {
+  const actual = jest.requireActual("react-native-safe-area-context")
+  return {
+    ...actual,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  }
+})
+
+const mockUseMyReferralsQuery = jest.fn()
+jest.mock("@app/graphql/generated", () => {
+  const actual = jest.requireActual("@app/graphql/generated")
+  return {
+    InviteStatus: actual.InviteStatus,
+    InviteMethod: actual.InviteMethod,
+    useMyReferralsQuery: (...a: unknown[]) => mockUseMyReferralsQuery(...a),
+  }
+})
+
+const mockUseReferralRewardFlag = jest.fn()
+jest.mock("@app/hooks", () => ({
+  useReferralRewardFlag: () => mockUseReferralRewardFlag(),
+}))
+
+import { MyReferrals } from "../MyReferrals"
+import { InviteStatus, InviteMethod } from "@app/graphql/generated"
+
+const invite = (over: Record<string, unknown>) => ({
+  __typename: "MyReferralInvite",
+  id: String(over.id ?? "i1"),
+  contact: "friend@x.com",
+  method: InviteMethod.Email,
+  status: InviteStatus.Sent,
+  createdAt: "2026-08-01T00:00:00.000Z",
+  redeemedAt: null,
+  myRewardCents: null,
+  rewardPending: false,
+  ...over,
+})
+
+const withData = (
+  invites: unknown[],
+  stats: Partial<{
+    totalInvites: number
+    acceptedCount: number
+    totalEarnedCents: number
+    pendingRewardCount: number
+  }> = {},
+) => {
+  mockUseMyReferralsQuery.mockReturnValue({
+    data: {
+      myReferrals: {
+        totalInvites: invites.length,
+        acceptedCount: 0,
+        totalEarnedCents: 0,
+        pendingRewardCount: 0,
+        ...stats,
+        invites,
+      },
+    },
+    loading: false,
+    error: undefined,
+    refetch: jest.fn(),
+  })
+}
+
+const renderScreen = () =>
+  render(
+    <ThemeProvider theme={theme}>
+      <MyReferrals />
+    </ThemeProvider>,
+  )
+
+describe("MyReferrals screen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseReferralRewardFlag.mockReturnValue({
+      referralRewardEnabled: true,
+      loading: false,
+    })
+  })
+
+  it("shows total earnings and an earned row when rewards are enabled", () => {
+    withData(
+      [
+        invite({
+          id: "paid",
+          status: InviteStatus.Accepted,
+          myRewardCents: 500,
+          contact: "bob@x.com",
+        }),
+      ],
+      { totalEarnedCents: 500, acceptedCount: 1 },
+    )
+    const screen = renderScreen()
+    expect(screen.getByText("Total earned")).toBeTruthy()
+    expect(screen.getByText("$5.00")).toBeTruthy()
+    expect(screen.getByText("Joined — you earned $5.00")).toBeTruthy()
+  })
+
+  it("shows a pending-reward row and the pending count", () => {
+    withData(
+      [invite({ id: "p", status: InviteStatus.Accepted, rewardPending: true })],
+      { pendingRewardCount: 1, acceptedCount: 1 },
+    )
+    const screen = renderScreen()
+    expect(screen.getByText("Joined — reward pending")).toBeTruthy()
+    expect(screen.getByText("Pending rewards: 1")).toBeTruthy()
+  })
+
+  it("never renders money copy when rewards are disabled", () => {
+    mockUseReferralRewardFlag.mockReturnValue({
+      referralRewardEnabled: false,
+      loading: false,
+    })
+    withData(
+      [
+        invite({
+          id: "paid",
+          status: InviteStatus.Accepted,
+          myRewardCents: 500,
+          rewardPending: false,
+        }),
+      ],
+      { totalEarnedCents: 500, acceptedCount: 1 },
+    )
+    const screen = renderScreen()
+    // Gated: joined-count header instead of earnings; row shows plain "Joined".
+    expect(screen.getByText("Friends joined")).toBeTruthy()
+    expect(screen.queryByText("Total earned")).toBeNull()
+    expect(screen.queryByText(/earned/)).toBeNull()
+    expect(screen.getByText("Joined")).toBeTruthy()
+  })
+
+  it("labels sent and expired invites as lifecycle rows", () => {
+    withData([
+      invite({ id: "s", status: InviteStatus.Sent, contact: "+18765550000" }),
+      invite({ id: "e", status: InviteStatus.Expired, contact: "old@x.com" }),
+    ])
+    const screen = renderScreen()
+    expect(screen.getByText("Invited")).toBeTruthy()
+    expect(screen.getByText("Expired")).toBeTruthy()
+  })
+
+  it("shows the empty state when there are no invites", () => {
+    withData([])
+    const screen = renderScreen()
+    expect(
+      screen.getByText("No invites yet — invite a friend to get started."),
+    ).toBeTruthy()
+  })
+
+  it("shows the failure message when the query errors with no cache", () => {
+    mockUseMyReferralsQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: new Error("network"),
+      refetch: jest.fn(),
+    })
+    const screen = renderScreen()
+    expect(screen.getByText("Couldn't load your referrals. Pull to retry.")).toBeTruthy()
+  })
+})

--- a/app/screens/invite-friend/index.ts
+++ b/app/screens/invite-friend/index.ts
@@ -2,3 +2,4 @@ import InviteFriend from "./InviteFriend"
 import InviteFriendSuccess from "./InviteFriendSuccess"
 
 export { InviteFriend, InviteFriendSuccess }
+export * from "./MyReferrals"


### PR DESCRIPTION
## What
The Circles-style fast-follow: **Invite a friend** gains a *View my referrals* link opening a new **MyReferrals** screen backed by the authed `myReferrals` query (**flash #468**).

- Every invite the user sent, newest first: contact + status line (*Invited / Joined / Expired*)
- **Rewards-gated copy** — while backend `referralRewardEnabled` is on: lifetime-earnings header, per-row *"Joined — you earned $X"* (the inviter's leg only) and pending-reward count. Flag off → joined-count header, zero money copy. Same gate as the home-screen invite card: **this screen can never promise a reward the backend won't pay.**
- Empty + error states; pull-to-refresh.

## Implementation
- `public-schema.graphql` + front-end query + regenerated codegen (deterministic); row type derived from the generated query
- i18n: `MyReferrals` section added in `en/index.ts` (the hand-edited source), exported `en.json`, propagated to all 23 locales — drift check green
- 6 screen tests incl. the rewards-disabled gating case; full suite **278/278**; tsc + lint-changed clean

## ⚠️ Merge/deploy ordering
**flash #468 must be merged + deployed to TEST before this merges** — dev builds hit TEST, and an unknown `myReferrals` field fails the whole query server-side (same rule as `referralRewardEnabled`). Ships in the **next store cut** after the current P3 bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)