### PR TITLE
fix(topup): send Fygaro custom_reference so card top-ups are attributable

### DIFF
--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -704,7 +704,8 @@ const en: BaseTranslation = {
     btcWallet: "BTC Wallet",
     invalidEmail: "Please enter a valid email address",
     invalidAmount: "Please enter a valid amount",
-    minimumAmount: "Minimum amount is $1.00"
+    minimumAmount: "Minimum amount is $1.00",
+    usdOnlyNotice: "Card payments top up your USD wallet"
   },
   BridgeKyc: {
     title: "USD Account",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -2269,6 +2269,10 @@ type RootTranslation = {
 		 * M​i​n​i​m​u​m​ ​a​m​o​u​n​t​ ​i​s​ ​$​1​.​0​0
 		 */
 		minimumAmount: string
+		/**
+		 * C​a​r​d​ ​p​a​y​m​e​n​t​s​ ​t​o​p​ ​u​p​ ​y​o​u​r​ ​U​S​D​ ​w​a​l​l​e​t
+		 */
+		usdOnlyNotice: string
 	}
 	BridgeKyc: {
 		/**
@@ -8404,6 +8408,10 @@ export type TranslationFunctions = {
 		 * Minimum amount is $1.00
 		 */
 		minimumAmount: () => LocalizedString
+		/**
+		 * Card payments top up your USD wallet
+		 */
+		usdOnlyNotice: () => LocalizedString
 	}
 	BridgeKyc: {
 		/**

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -663,7 +663,8 @@
         "btcWallet": "BTC Wallet",
         "invalidEmail": "Please enter a valid email address",
         "invalidAmount": "Please enter a valid amount",
-        "minimumAmount": "Minimum amount is $1.00"
+        "minimumAmount": "Minimum amount is $1.00",
+        "usdOnlyNotice": "Card payments top up your USD wallet"
     },
     "BridgeKyc": {
         "title": "USD Account",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -1559,7 +1559,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "USD-rekening",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -1564,7 +1564,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "حساب بالدولار",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "Compte en USD",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "USD účet",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "USD-konto",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "USD-Konto",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "Λογαριασμός USD",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "Cuenta en USD",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "Compte en USD",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "USD račun",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "USD-számla",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "USD հաշիվ",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "Conto in USD",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "Akaun USD",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "USD-rekening",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "Conta em USD",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "USD cuenta",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "USD рачун",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -1564,7 +1564,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "Akaunti ya USD",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "บัญชี USD",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "USD hesabı",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "Tài khoản USD",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -1558,7 +1558,8 @@
     "btcWallet": "BTC Wallet",
     "invalidEmail": "Please enter a valid email address",
     "invalidAmount": "Please enter a valid amount",
-    "minimumAmount": "Minimum amount is $1.00"
+    "minimumAmount": "Minimum amount is $1.00",
+    "usdOnlyNotice": "Card payments top up your USD wallet"
   },
   "BridgeKyc": {
     "title": "I-akhawunti ye-USD",

--- a/app/screens/topup-cashout-flow/CardPayment.tsx
+++ b/app/screens/topup-cashout-flow/CardPayment.tsx
@@ -37,19 +37,33 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
   const [error, setError] = useState(false)
 
   // Get authenticated user data to extract username for webhook processing
-  const { data } = useHomeAuthedQuery({ skip: !isAuthed, fetchPolicy: "cache-first" })
+  const { data, loading: usernameLoading } = useHomeAuthedQuery({
+    skip: !isAuthed,
+    fetchPolicy: "cache-first",
+  })
   const { amount, wallet } = route.params
-  const username = data?.me?.username || "user"
+  const username = data?.me?.username
 
   /**
    * Build Fygaro payment URL with critical parameters:
    * - amount: The payment amount in USD
-   * - client_reference: Flash username (CRITICAL: used by webhook to identify user)
+   * - custom_reference: Flash username (CRITICAL: ties the payment to a Flash
+   *   account — Fygaro's checkout reads `custom_reference`; the previously used
+   *   `client_reference` is silently ignored and left every payment unattributed)
+   * - client_note: target wallet (always USD — card top-ups are USD-only)
+   *
+   * The URL is only built once the username is known: a payment without a real
+   * username cannot be credited to anyone, so the WebView must never load with
+   * a placeholder reference.
    *
    * NOTE: The user will enter their email directly on Fygaro's form to avoid
    * double entry. The email is only for Fygaro's records, not for Flash processing.
    */
-  const paymentUrl = `https://fygaro.com/en/pb/bd4a34c1-3d24-4315-a2b8-627518f70916?amount=${amount}&client_reference=${username}`
+  const paymentUrl = username
+    ? `https://fygaro.com/en/pb/bd4a34c1-3d24-4315-a2b8-627518f70916?amount=${amount}&custom_reference=${encodeURIComponent(
+        username,
+      )}&client_note=${encodeURIComponent(`wallet:${wallet}`)}`
+    : null
 
   /**
    * Domain whitelist for security.
@@ -153,7 +167,10 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
     webViewRef.current?.reload()
   }
 
-  if (error) {
+  // A settled account query with no username means the payment could never be
+  // attributed to an account — treat it like a load failure instead of letting
+  // an unattributable charge go through.
+  if (error || (!usernameLoading && !paymentUrl)) {
     return (
       <Screen>
         <View style={styles.centerContainer}>
@@ -173,7 +190,7 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
   return (
     <Screen>
       <View style={styles.container}>
-        {isLoading && (
+        {(isLoading || !paymentUrl) && (
           <View style={styles.loadingContainer}>
             <ActivityIndicator size="large" color={colors.primary} />
             <Text type="p1" style={styles.loadingText}>
@@ -181,126 +198,127 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
             </Text>
           </View>
         )}
-        <WebView
-          ref={webViewRef}
-          source={{ uri: paymentUrl }}
-          onNavigationStateChange={handleNavigationStateChange}
-          onLoadEnd={() => {
-            setIsLoading(false)
-            setError(false)
-          }}
-          onError={() => {
-            setIsLoading(false)
-            setError(true)
-          }}
-          /**
-           * URL navigation filter for security and iOS compatibility.
-           *
-           * This callback determines which URLs the WebView can navigate to.
-           * Platform-specific logic:
-           *
-           * iOS:
-           * - Allows about:, blob:, data: schemes (prevents warnings)
-           * - Allows all HTTPS URLs (PayPal requires many domains)
-           * - Blocks HTTP to enforce encryption
-           *
-           * Android:
-           * - Uses strict domain whitelist
-           * - More restrictive but more secure
-           *
-           * The iOS approach is less restrictive due to PayPal's complex
-           * redirect flow that uses many subdomains not in our whitelist.
-           */
-          onShouldStartLoadWithRequest={({ url }) => {
-            // Allow about: URLs (used for iframes) to prevent iOS warnings
-            if (url.startsWith("about:")) {
-              return true
-            }
+        {paymentUrl && (
+          <WebView
+            ref={webViewRef}
+            source={{ uri: paymentUrl }}
+            onNavigationStateChange={handleNavigationStateChange}
+            onLoadEnd={() => {
+              setIsLoading(false)
+              setError(false)
+            }}
+            onError={() => {
+              setIsLoading(false)
+              setError(true)
+            }}
+            /**
+             * URL navigation filter for security and iOS compatibility.
+             *
+             * This callback determines which URLs the WebView can navigate to.
+             * Platform-specific logic:
+             *
+             * iOS:
+             * - Allows about:, blob:, data: schemes (prevents warnings)
+             * - Allows all HTTPS URLs (PayPal requires many domains)
+             * - Blocks HTTP to enforce encryption
+             *
+             * Android:
+             * - Uses strict domain whitelist
+             * - More restrictive but more secure
+             *
+             * The iOS approach is less restrictive due to PayPal's complex
+             * redirect flow that uses many subdomains not in our whitelist.
+             */
+            onShouldStartLoadWithRequest={({ url }) => {
+              // Allow about: URLs (used for iframes) to prevent iOS warnings
+              if (url.startsWith("about:")) {
+                return true
+              }
 
-            // Allow blob: and data: URLs for embedded content
-            if (url.startsWith("blob:") || url.startsWith("data:")) {
-              return true
-            }
+              // Allow blob: and data: URLs for embedded content
+              if (url.startsWith("blob:") || url.startsWith("data:")) {
+                return true
+              }
 
-            // iOS: Allow HTTPS and internal URLs
-            // Less restrictive due to PayPal's complex domain requirements
-            if (Platform.OS === "ios") {
-              return url.startsWith("https://") || !url.startsWith("http")
-            }
+              // iOS: Allow HTTPS and internal URLs
+              // Less restrictive due to PayPal's complex domain requirements
+              if (Platform.OS === "ios") {
+                return url.startsWith("https://") || !url.startsWith("http")
+              }
 
-            // Android: Use domain whitelist for stricter security
-            return isAllowedDomain(url)
-          }}
-          style={styles.webView}
-          javaScriptEnabled
-          domStorageEnabled
-          startInLoadingState
-          scalesPageToFit={false}
-          bounces={false}
-          scrollEnabled
-          allowsBackForwardNavigationGestures
-          allowsInlineMediaPlayback
-          allowsFullscreenVideo={false}
-          allowFileAccess={false}
-          allowUniversalAccessFromFileURLs={false}
-          mixedContentMode="never"
-          originWhitelist={["https://*", "http://*", "about:*", "data:*", "blob:*"]}
-          sharedCookiesEnabled
-          thirdPartyCookiesEnabled
-          cacheEnabled
-          incognito={false}
-          webviewDebuggingEnabled={__DEV__}
-          automaticallyAdjustContentInsets={false}
-          contentInsetAdjustmentBehavior="never"
-          allowsLinkPreview={false}
-          injectedJavaScriptForMainFrameOnly
-          /**
-           * Custom User Agent for iOS to prevent zoom issues.
-           *
-           * CRITICAL: This desktop user agent prevents iOS WebView from:
-           * - Auto-zooming when users tap input fields
-           * - Showing mobile-specific layouts that break
-           * - Triggering viewport zoom on focus
-           *
-           * Without this, iOS WebView zooms in when users tap the
-           * payment form fields, creating a poor user experience.
-           *
-           * Android doesn't need this workaround.
-           */
-          userAgent={
-            Platform.OS === "ios"
-              ? "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-              : undefined
-          }
-          dataDetectorTypes={["none"]}
-          /**
-           * Pre-content JavaScript injection for early zoom prevention.
-           *
-           * Executes BEFORE the page content loads to:
-           * - Force viewport meta tag with no zoom
-           * - Set touch-action CSS to prevent pinch zoom
-           * - Run on multiple events to catch dynamic content
-           *
-           * This is the first line of defense against iOS zoom issues.
-           */
-          injectedJavaScriptBeforeContentLoaded={`(function(){const forceViewport=()=>{const content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no';document.querySelectorAll('meta[name="viewport"]').forEach(m=>m.remove());const meta=document.createElement('meta');meta.name='viewport';meta.content=content;if(document.head){document.head.insertBefore(meta,document.head.firstChild)}else{document.documentElement.appendChild(meta)}};forceViewport();document.addEventListener('DOMContentLoaded',forceViewport);window.addEventListener('load',forceViewport);if(document.documentElement){document.documentElement.style.touchAction='pan-x pan-y'}true})();`}
-          /**
-           * Post-content JavaScript injection for comprehensive zoom prevention.
-           *
-           * This aggressive approach handles:
-           * 1. Viewport meta tag enforcement
-           * 2. CSS styles to prevent zoom (16px font size is key)
-           * 3. Focus event handlers to reset zoom on input focus
-           * 4. MutationObserver to handle dynamically added inputs
-           * 5. Double-tap prevention
-           *
-           * The 16px font size is critical - iOS auto-zooms on inputs
-           * with font size less than 16px.
-           *
-           * Combined with desktop user agent, this completely prevents
-           * the iOS zoom issue that occurs when users tap payment form fields.
-           */
-          injectedJavaScript={`(function(){
+              // Android: Use domain whitelist for stricter security
+              return isAllowedDomain(url)
+            }}
+            style={styles.webView}
+            javaScriptEnabled
+            domStorageEnabled
+            startInLoadingState
+            scalesPageToFit={false}
+            bounces={false}
+            scrollEnabled
+            allowsBackForwardNavigationGestures
+            allowsInlineMediaPlayback
+            allowsFullscreenVideo={false}
+            allowFileAccess={false}
+            allowUniversalAccessFromFileURLs={false}
+            mixedContentMode="never"
+            originWhitelist={["https://*", "http://*", "about:*", "data:*", "blob:*"]}
+            sharedCookiesEnabled
+            thirdPartyCookiesEnabled
+            cacheEnabled
+            incognito={false}
+            webviewDebuggingEnabled={__DEV__}
+            automaticallyAdjustContentInsets={false}
+            contentInsetAdjustmentBehavior="never"
+            allowsLinkPreview={false}
+            injectedJavaScriptForMainFrameOnly
+            /**
+             * Custom User Agent for iOS to prevent zoom issues.
+             *
+             * CRITICAL: This desktop user agent prevents iOS WebView from:
+             * - Auto-zooming when users tap input fields
+             * - Showing mobile-specific layouts that break
+             * - Triggering viewport zoom on focus
+             *
+             * Without this, iOS WebView zooms in when users tap the
+             * payment form fields, creating a poor user experience.
+             *
+             * Android doesn't need this workaround.
+             */
+            userAgent={
+              Platform.OS === "ios"
+                ? "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+                : undefined
+            }
+            dataDetectorTypes={["none"]}
+            /**
+             * Pre-content JavaScript injection for early zoom prevention.
+             *
+             * Executes BEFORE the page content loads to:
+             * - Force viewport meta tag with no zoom
+             * - Set touch-action CSS to prevent pinch zoom
+             * - Run on multiple events to catch dynamic content
+             *
+             * This is the first line of defense against iOS zoom issues.
+             */
+            injectedJavaScriptBeforeContentLoaded={`(function(){const forceViewport=()=>{const content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no';document.querySelectorAll('meta[name="viewport"]').forEach(m=>m.remove());const meta=document.createElement('meta');meta.name='viewport';meta.content=content;if(document.head){document.head.insertBefore(meta,document.head.firstChild)}else{document.documentElement.appendChild(meta)}};forceViewport();document.addEventListener('DOMContentLoaded',forceViewport);window.addEventListener('load',forceViewport);if(document.documentElement){document.documentElement.style.touchAction='pan-x pan-y'}true})();`}
+            /**
+             * Post-content JavaScript injection for comprehensive zoom prevention.
+             *
+             * This aggressive approach handles:
+             * 1. Viewport meta tag enforcement
+             * 2. CSS styles to prevent zoom (16px font size is key)
+             * 3. Focus event handlers to reset zoom on input focus
+             * 4. MutationObserver to handle dynamically added inputs
+             * 5. Double-tap prevention
+             *
+             * The 16px font size is critical - iOS auto-zooms on inputs
+             * with font size less than 16px.
+             *
+             * Combined with desktop user agent, this completely prevents
+             * the iOS zoom issue that occurs when users tap payment form fields.
+             */
+            injectedJavaScript={`(function(){
             // Zoom prevention code only
             document.querySelectorAll('meta[name="viewport"]').forEach(m=>m.remove());
             const meta=document.createElement('meta');
@@ -340,7 +358,8 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
 
             true
           })();`}
-        />
+          />
+        )}
       </View>
     </Screen>
   )

--- a/app/screens/topup-cashout-flow/CardPayment.tsx
+++ b/app/screens/topup-cashout-flow/CardPayment.tsx
@@ -27,6 +27,10 @@ import { useIsAuthed } from "@app/graphql/is-authed-context"
 
 type Props = StackScreenProps<RootStackParamList, "CardPayment">
 
+// Fygaro hosted payment-button path. Shared between the payment URL and the
+// navigation-state guard below so the two can never drift apart.
+const FYGARO_PAYMENT_BUTTON_PATH = "/pb/bd4a34c1-3d24-4315-a2b8-627518f70916"
+
 const CardPayment: React.FC<Props> = ({ navigation, route }) => {
   const isAuthed = useIsAuthed()
   const styles = useStyles()
@@ -37,7 +41,11 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
   const [error, setError] = useState(false)
 
   // Get authenticated user data to extract username for webhook processing
-  const { data, loading: usernameLoading } = useHomeAuthedQuery({
+  const {
+    data,
+    loading: usernameLoading,
+    refetch,
+  } = useHomeAuthedQuery({
     skip: !isAuthed,
     fetchPolicy: "cache-first",
   })
@@ -50,7 +58,8 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
    * - custom_reference: Flash username (CRITICAL: ties the payment to a Flash
    *   account — Fygaro's checkout reads `custom_reference`; the previously used
    *   `client_reference` is silently ignored and left every payment unattributed)
-   * - client_note: target wallet (always USD — card top-ups are USD-only)
+   * - client_note: target wallet, recorded on the Fygaro payment for ops/audit
+   *   (informational only — the backend credits the USD cash wallet regardless)
    *
    * The URL is only built once the username is known: a payment without a real
    * username cannot be credited to anyone, so the WebView must never load with
@@ -60,7 +69,7 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
    * double entry. The email is only for Fygaro's records, not for Flash processing.
    */
   const paymentUrl = username
-    ? `https://fygaro.com/en/pb/bd4a34c1-3d24-4315-a2b8-627518f70916?amount=${amount}&custom_reference=${encodeURIComponent(
+    ? `https://fygaro.com/en${FYGARO_PAYMENT_BUTTON_PATH}?amount=${amount}&custom_reference=${encodeURIComponent(
         username,
       )}&client_note=${encodeURIComponent(`wallet:${wallet}`)}`
     : null
@@ -115,6 +124,13 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
    * This frontend handling is just for UX feedback.
    */
   const handleNavigationStateChange = ({ url }: { url: string }) => {
+    // Never pattern-match the payment-button URL itself: it embeds the
+    // user-controlled username (custom_reference), so a username containing
+    // "success"/"failed"/"error"/"cancelled" would otherwise fake a payment
+    // outcome the moment the page loads.
+    if (url.includes(FYGARO_PAYMENT_BUTTON_PATH)) {
+      return
+    }
     if (url.includes("success") || url.includes("payment_success")) {
       // Payment succeeded - navigate to success screen
       // The webhook will handle the actual wallet credit
@@ -164,6 +180,13 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
   const handleRetry = () => {
     setError(false)
     setIsLoading(true)
+    if (!paymentUrl) {
+      // The username never resolved, so there is no WebView to reload — and
+      // cache-first won't re-ask the server on its own. Refetch the account
+      // query; a failure lands back on the error screen.
+      refetch?.().catch(() => setError(true))
+      return
+    }
     webViewRef.current?.reload()
   }
 

--- a/app/screens/topup-cashout-flow/CardPayment.tsx
+++ b/app/screens/topup-cashout-flow/CardPayment.tsx
@@ -27,8 +27,7 @@ import { useIsAuthed } from "@app/graphql/is-authed-context"
 
 type Props = StackScreenProps<RootStackParamList, "CardPayment">
 
-// Fygaro hosted payment-button path. Shared between the payment URL and the
-// navigation-state guard below so the two can never drift apart.
+// Fygaro hosted payment-button path.
 const FYGARO_PAYMENT_BUTTON_PATH = "/pb/bd4a34c1-3d24-4315-a2b8-627518f70916"
 
 const CardPayment: React.FC<Props> = ({ navigation, route }) => {
@@ -113,9 +112,14 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
   /**
    * Monitors URL changes to detect payment completion.
    *
-   * Payment providers redirect to specific URLs on success/failure:
-   * - Success: URL contains "success" or "payment_success"
-   * - Failure: URL contains "error", "failed", or "cancelled"
+   * Outcome signals, in order of authority:
+   * - `?success=1|0` query param: Fygaro's checkout returns to the
+   *   payment-button URL itself with this param after external-processor
+   *   flows (PayPal), so it must be read even on the /pb/ path.
+   * - Keywords ("success", "error", "failed", "cancelled") matched against
+   *   host+path ONLY — never the query string, which embeds the
+   *   user-controlled username (custom_reference): a username like
+   *   "success-story" must never fake a payment outcome.
    *
    * On success: Navigate to success screen (webhook will handle actual crediting)
    * On failure: Show error alert and allow retry
@@ -124,14 +128,18 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
    * This frontend handling is just for UX feedback.
    */
   const handleNavigationStateChange = ({ url }: { url: string }) => {
-    // Never pattern-match the payment-button URL itself: it embeds the
-    // user-controlled username (custom_reference), so a username containing
-    // "success"/"failed"/"error"/"cancelled" would otherwise fake a payment
-    // outcome the moment the page loads.
-    if (url.includes(FYGARO_PAYMENT_BUTTON_PATH)) {
+    let parsed: URL
+    try {
+      parsed = new URL(url)
+    } catch {
+      // about:/blob:/data: and other non-hierarchical URLs carry no outcome
       return
     }
-    if (url.includes("success") || url.includes("payment_success")) {
+
+    const successParam = parsed.searchParams.get("success")
+    const hostAndPath = `${parsed.host}${parsed.pathname}`
+
+    if (successParam === "1" || hostAndPath.includes("success")) {
       // Payment succeeded - navigate to success screen
       // The webhook will handle the actual wallet credit
       navigation.navigate("paymentSuccess", {
@@ -140,9 +148,10 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
         transactionId: `txn_${Date.now()}`, // Temporary ID for UI
       })
     } else if (
-      url.includes("error") ||
-      url.includes("failed") ||
-      url.includes("cancelled")
+      successParam === "0" ||
+      hostAndPath.includes("error") ||
+      hostAndPath.includes("failed") ||
+      hostAndPath.includes("cancelled")
     ) {
       // Payment failed - show error and allow retry
       Alert.alert("Payment Failed", "Your payment was not completed. Please try again.", [

--- a/app/screens/topup-cashout-flow/TopupDetails.tsx
+++ b/app/screens/topup-cashout-flow/TopupDetails.tsx
@@ -104,10 +104,13 @@ const TopupDetails: React.FC<Props> = ({ navigation, route }) => {
           paymentType: route.params.paymentType,
         })
       } else {
-        // Card payment flow via Fygaro WebView
+        // Card payment flow via Fygaro WebView.
+        // Card top-ups credit the USD wallet only — the BTC option is not
+        // offered for card payments, and the wallet is pinned here so the
+        // Fygaro record (client_note) can never claim otherwise.
         navigation.navigate("CardPayment", {
           amount: parseFloat(amount),
-          wallet: selectedWallet, // Will be sent to webhook via metadata
+          wallet: "USD",
         })
       }
     } catch (error) {
@@ -138,7 +141,9 @@ const TopupDetails: React.FC<Props> = ({ navigation, route }) => {
     },
   ]
 
-  if (persistentState.isAdvanceMode) {
+  // Card top-ups are USD-only: Fygaro payments are recorded and credited in
+  // USD, so the BTC wallet option is only offered for bank-transfer flows.
+  if (persistentState.isAdvanceMode && route.params.paymentType !== "card") {
     walletButtons.push({
       id: "BTC",
       text: LL.TopupDetails.btcWallet(),
@@ -170,6 +175,11 @@ const TopupDetails: React.FC<Props> = ({ navigation, route }) => {
             onPress={setSelectedWallet}
             style={styles.buttonGroup}
           />
+          {route.params.paymentType === "card" && (
+            <Text type="p3" style={styles.usdOnlyNote}>
+              {LL.TopupDetails.usdOnlyNotice()}
+            </Text>
+          )}
         </View>
 
         <View style={styles.fieldContainer}>
@@ -247,6 +257,10 @@ const useStyles = makeStyles(({ colors }) => (props: { bottom: number }) => ({
   },
   buttonGroup: {
     marginTop: 8,
+  },
+  usdOnlyNote: {
+    marginTop: 8,
+    color: colors.grey2,
   },
   primaryButton: {
     marginHorizontal: 20,

--- a/app/screens/topup-cashout-flow/__tests__/CardPayment.test.tsx
+++ b/app/screens/topup-cashout-flow/__tests__/CardPayment.test.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { Alert } from "react-native"
 import { fireEvent, render, waitFor } from "@testing-library/react-native"
 import { ThemeProvider } from "@rneui/themed"
 import theme from "@app/rne-theme/theme"
@@ -163,6 +164,39 @@ describe("CardPayment navigation callbacks", () => {
 
     expect(navigate).not.toHaveBeenCalled()
     expect(goBack).not.toHaveBeenCalled()
+  })
+
+  it("fires success when Fygaro returns to the payment-button URL with ?success=1 (real PayPal return shape)", async () => {
+    const { navigate } = renderCardPayment({ amount: 10, wallet: "USD" })
+
+    lastWebViewProps().onNavigationStateChange({
+      url: "https://www.fygaro.com/en/pb/bd4a34c1-3d24-4315-a2b8-627518f70916/?success=1&custom_reference=alice",
+    })
+
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith("paymentSuccess", {
+        amount: 10,
+        wallet: "USD",
+        transactionId: expect.stringMatching(/^txn_/),
+      }),
+    )
+  })
+
+  it("fires the failure alert when Fygaro returns with ?success=0", () => {
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => undefined)
+    const { navigate } = renderCardPayment()
+
+    lastWebViewProps().onNavigationStateChange({
+      url: "https://www.fygaro.com/en/pb/bd4a34c1-3d24-4315-a2b8-627518f70916/?success=0&custom_reference=alice",
+    })
+
+    expect(navigate).not.toHaveBeenCalled()
+    expect(alertSpy).toHaveBeenCalledWith(
+      "Payment Failed",
+      expect.any(String),
+      expect.anything(),
+    )
+    alertSpy.mockRestore()
   })
 
   it("navigates to paymentSuccess with the original amount and wallet on a success URL", async () => {

--- a/app/screens/topup-cashout-flow/__tests__/CardPayment.test.tsx
+++ b/app/screens/topup-cashout-flow/__tests__/CardPayment.test.tsx
@@ -1,0 +1,147 @@
+import React from "react"
+import { render, waitFor } from "@testing-library/react-native"
+import { ThemeProvider } from "@rneui/themed"
+import theme from "@app/rne-theme/theme"
+import { i18nObject } from "../../../i18n/i18n-util"
+import { loadAllLocales } from "../../../i18n/i18n-util.sync"
+import CardPayment from "../CardPayment"
+
+// Without this, i18nObject("en") resolves every key to "" and text queries
+// match arbitrary empty text nodes.
+loadAllLocales()
+
+// Deterministic, synchronous i18n (the real TypesafeI18n loads its dictionary
+// asynchronously, leaving LL-derived labels empty on first render).
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({ LL: i18nObject("en") }),
+}))
+
+jest.mock("@app/graphql/is-authed-context", () => ({
+  useIsAuthed: () => true,
+}))
+
+const mockUseHomeAuthedQuery = jest.fn()
+jest.mock("@app/graphql/generated", () => ({
+  useHomeAuthedQuery: (...args: unknown[]) => mockUseHomeAuthedQuery(...args),
+}))
+
+// Capture WebView props so tests can assert on the payment URL and drive the
+// navigation-state callback without a real WebView native module.
+const mockWebView: jest.Mock = jest.fn(() => null)
+jest.mock("react-native-webview", () => ({
+  WebView: (props: unknown) => mockWebView(props),
+}))
+
+const en = i18nObject("en")
+
+const renderCardPayment = ({
+  amount = 25,
+  wallet = "USD",
+  navigate = jest.fn(),
+  goBack = jest.fn(),
+} = {}) => {
+  const navigation = { navigate, goBack } as never
+  const route = {
+    key: "CardPayment",
+    name: "CardPayment",
+    params: { amount, wallet },
+  } as never
+  const utils = render(
+    <ThemeProvider theme={theme}>
+      <CardPayment navigation={navigation} route={route} />
+    </ThemeProvider>,
+  )
+  return { ...utils, navigate, goBack }
+}
+
+// The test renderer occasionally issues a stray zero-arg invocation of the
+// component function; only calls that actually carried props are meaningful.
+const lastWebViewProps = () => {
+  const calls = mockWebView.mock.calls.filter((call) => call[0])
+  return calls[calls.length - 1][0] as {
+    source: { uri: string }
+    onNavigationStateChange: (event: { url: string }) => void
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockUseHomeAuthedQuery.mockReturnValue({
+    data: { me: { username: "alice" } },
+    loading: false,
+  })
+})
+
+describe("CardPayment payment URL", () => {
+  it("passes the username as custom_reference (the parameter Fygaro's checkout reads)", () => {
+    renderCardPayment()
+
+    const { uri } = lastWebViewProps().source
+    expect(uri).toContain("custom_reference=alice")
+    expect(uri).toContain("amount=25")
+    // The old parameter name is silently ignored by Fygaro and left payments
+    // unattributed — it must never come back.
+    expect(uri).not.toContain("client_reference")
+  })
+
+  it("records the target wallet in client_note", () => {
+    renderCardPayment({ wallet: "USD" })
+
+    expect(lastWebViewProps().source.uri).toContain(
+      `client_note=${encodeURIComponent("wallet:USD")}`,
+    )
+  })
+
+  it("URL-encodes usernames that contain reserved characters", () => {
+    mockUseHomeAuthedQuery.mockReturnValue({
+      data: { me: { username: "álice+test" } },
+      loading: false,
+    })
+
+    renderCardPayment()
+
+    const { uri } = lastWebViewProps().source
+    expect(uri).toContain(`custom_reference=${encodeURIComponent("álice+test")}`)
+  })
+})
+
+describe("CardPayment username gating", () => {
+  it("does not mount the WebView while the username is still loading", () => {
+    mockUseHomeAuthedQuery.mockReturnValue({ data: undefined, loading: true })
+
+    const { getAllByText } = renderCardPayment()
+
+    expect(mockWebView).not.toHaveBeenCalled()
+    expect(getAllByText(en.FygaroWebViewScreen.loading()).length).toBeGreaterThan(0)
+  })
+
+  it("shows the error screen instead of an unattributable payment when no username exists", () => {
+    mockUseHomeAuthedQuery.mockReturnValue({
+      data: { me: { username: null } },
+      loading: false,
+    })
+
+    const { getAllByText } = renderCardPayment()
+
+    expect(mockWebView).not.toHaveBeenCalled()
+    expect(getAllByText(en.FygaroWebViewScreen.error()).length).toBeGreaterThan(0)
+  })
+})
+
+describe("CardPayment navigation callbacks", () => {
+  it("navigates to paymentSuccess with the original amount and wallet on a success URL", async () => {
+    const { navigate } = renderCardPayment({ amount: 10, wallet: "USD" })
+
+    lastWebViewProps().onNavigationStateChange({
+      url: "https://www.fygaro.com/en/checkout/payment_success",
+    })
+
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith("paymentSuccess", {
+        amount: 10,
+        wallet: "USD",
+        transactionId: expect.stringMatching(/^txn_/),
+      }),
+    )
+  })
+})

--- a/app/screens/topup-cashout-flow/__tests__/CardPayment.test.tsx
+++ b/app/screens/topup-cashout-flow/__tests__/CardPayment.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, waitFor } from "@testing-library/react-native"
+import { fireEvent, render, waitFor } from "@testing-library/react-native"
 import { ThemeProvider } from "@rneui/themed"
 import theme from "@app/rne-theme/theme"
 import { i18nObject } from "../../../i18n/i18n-util"
@@ -69,6 +69,7 @@ beforeEach(() => {
   mockUseHomeAuthedQuery.mockReturnValue({
     data: { me: { username: "alice" } },
     loading: false,
+    refetch: jest.fn(() => Promise.resolve()),
   })
 })
 
@@ -107,7 +108,11 @@ describe("CardPayment payment URL", () => {
 
 describe("CardPayment username gating", () => {
   it("does not mount the WebView while the username is still loading", () => {
-    mockUseHomeAuthedQuery.mockReturnValue({ data: undefined, loading: true })
+    mockUseHomeAuthedQuery.mockReturnValue({
+      data: undefined,
+      loading: true,
+      refetch: jest.fn(() => Promise.resolve()),
+    })
 
     const { getAllByText } = renderCardPayment()
 
@@ -119,6 +124,7 @@ describe("CardPayment username gating", () => {
     mockUseHomeAuthedQuery.mockReturnValue({
       data: { me: { username: null } },
       loading: false,
+      refetch: jest.fn(() => Promise.resolve()),
     })
 
     const { getAllByText } = renderCardPayment()
@@ -126,9 +132,39 @@ describe("CardPayment username gating", () => {
     expect(mockWebView).not.toHaveBeenCalled()
     expect(getAllByText(en.FygaroWebViewScreen.error()).length).toBeGreaterThan(0)
   })
+
+  it("Retry refetches the account query when the username never resolved", () => {
+    const refetch = jest.fn(() => Promise.resolve())
+    mockUseHomeAuthedQuery.mockReturnValue({
+      data: { me: { username: null } },
+      loading: false,
+      refetch,
+    })
+
+    const { getAllByText } = renderCardPayment()
+    fireEvent.press(getAllByText(en.FygaroWebViewScreen.retry())[0])
+
+    expect(refetch).toHaveBeenCalled()
+  })
 })
 
 describe("CardPayment navigation callbacks", () => {
+  it("ignores navigation events for the payment-button URL itself, even when the username contains a trigger word", () => {
+    mockUseHomeAuthedQuery.mockReturnValue({
+      data: { me: { username: "success-story" } },
+      loading: false,
+      refetch: jest.fn(() => Promise.resolve()),
+    })
+    const { navigate, goBack } = renderCardPayment()
+
+    const props = lastWebViewProps()
+    expect(props.source.uri).toContain("success")
+    props.onNavigationStateChange({ url: props.source.uri })
+
+    expect(navigate).not.toHaveBeenCalled()
+    expect(goBack).not.toHaveBeenCalled()
+  })
+
   it("navigates to paymentSuccess with the original amount and wallet on a success URL", async () => {
     const { navigate } = renderCardPayment({ amount: 10, wallet: "USD" })
 

--- a/app/screens/topup-cashout-flow/__tests__/TopupDetails.test.tsx
+++ b/app/screens/topup-cashout-flow/__tests__/TopupDetails.test.tsx
@@ -1,0 +1,92 @@
+import React from "react"
+import { render, fireEvent } from "@testing-library/react-native"
+import { ThemeProvider } from "@rneui/themed"
+import theme from "@app/rne-theme/theme"
+import { i18nObject } from "../../../i18n/i18n-util"
+import { loadAllLocales } from "../../../i18n/i18n-util.sync"
+import TopupDetails from "../TopupDetails"
+
+// Without this, i18nObject("en") resolves every key to "" and text queries
+// match arbitrary empty text nodes.
+loadAllLocales()
+
+// Deterministic, synchronous i18n (the real TypesafeI18n loads its dictionary
+// asynchronously, leaving LL-derived labels empty on first render).
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({ LL: i18nObject("en") }),
+}))
+
+const mockPersistentState = { isAdvanceMode: true }
+jest.mock("@app/store/persistent-state", () => ({
+  usePersistentStateContext: () => ({ persistentState: mockPersistentState }),
+}))
+
+jest.mock("react-native-safe-area-context", () => {
+  const actual = jest.requireActual("react-native-safe-area-context")
+  return {
+    ...actual,
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  }
+})
+
+const en = i18nObject("en")
+
+const renderTopupDetails = ({
+  paymentType = "card" as "card" | "bankTransfer" | "bridge",
+  navigate = jest.fn(),
+} = {}) => {
+  const navigation = { navigate } as never
+  const route = {
+    key: "TopupDetails",
+    name: "TopupDetails",
+    params: { paymentType },
+  } as never
+  const utils = render(
+    <ThemeProvider theme={theme}>
+      <TopupDetails navigation={navigation} route={route} />
+    </ThemeProvider>,
+  )
+  return { ...utils, navigate }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockPersistentState.isAdvanceMode = true
+})
+
+describe("TopupDetails wallet options", () => {
+  it("offers only the USD wallet for card payments, even in advance mode", () => {
+    const { queryAllByText, getAllByText } = renderTopupDetails({
+      paymentType: "card",
+    })
+
+    expect(getAllByText(en.TopupDetails.usdWallet()).length).toBeGreaterThan(0)
+    expect(queryAllByText(en.TopupDetails.btcWallet())).toHaveLength(0)
+    expect(getAllByText(en.TopupDetails.usdOnlyNotice()).length).toBeGreaterThan(0)
+  })
+
+  it("still offers the BTC wallet for bridge transfers in advance mode", () => {
+    const { queryAllByText, getAllByText } = renderTopupDetails({
+      paymentType: "bridge",
+    })
+
+    expect(getAllByText(en.TopupDetails.btcWallet()).length).toBeGreaterThan(0)
+    expect(queryAllByText(en.TopupDetails.usdOnlyNotice())).toHaveLength(0)
+  })
+})
+
+describe("TopupDetails card continue", () => {
+  it("always navigates to CardPayment with the USD wallet", () => {
+    const { getByPlaceholderText, getAllByText, navigate } = renderTopupDetails({
+      paymentType: "card",
+    })
+
+    fireEvent.changeText(getByPlaceholderText(en.TopupDetails.amountPlaceholder()), "10")
+    fireEvent.press(getAllByText(en.TopupDetails.continue())[0])
+
+    expect(navigate).toHaveBeenCalledWith("CardPayment", {
+      amount: 10,
+      wallet: "USD",
+    })
+  })
+})


### PR DESCRIPTION
## Why

Fygaro's checkout **ignores the `client_reference` query parameter** — verified against Fygaro's production JS bundles, which read only `custom_reference`, `external_reference`, and `amount` from the URL (their helpdesk doc advertising `client_reference` is stale). Every card top-up made through the app has therefore arrived with a **blank reference in Fygaro's dashboard**, forcing manual PayPal-email archaeology to figure out who to credit (most recently a $10 top-up on Aug 7 that had to be traced through Kratos/Mongo by buyer email).

## What

- Rename `client_reference` → `custom_reference` in the Fygaro payment URL and URL-encode the username (`CardPayment.tsx`)
- Build the payment URL **only after the username resolves**; drop the `|| "user"` fallback that could produce an unattributable charge. If the account query settles with no username, show the error screen instead of loading the WebView
- Record the target wallet in `client_note` (`wallet:USD`) — recorded on the Fygaro payment for ops/audit (informational; the backend, lnflash/flash#472, credits the USD cash wallet regardless)
- **Restrict card top-ups to the USD wallet**: the BTC option is no longer offered for card payments (still offered for bridge transfers in advance mode), with a notice shown; `TopupDetails` pins `wallet: "USD"` on the CardPayment navigation
- New i18n string `TopupDetails.usdOnlyNotice` (translations regenerated)

## Tests

New unit specs (this flow previously had zero coverage):

- `CardPayment.test.tsx` — URL uses `custom_reference` (and never `client_reference`), username URL-encoding, `client_note` wallet, WebView withheld while the username loads, error screen when no username exists, success-URL navigation carries amount + wallet
- `TopupDetails.test.tsx` — USD-only for card even in advance mode (BTC still offered for bridge), continue always navigates with `wallet: "USD"`

`yarn tsc:check` clean, `yarn test` full suite green, eslint clean on touched files (remaining repo lint errors are pre-existing in files this PR doesn't touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcEjF6SS3Ci5D4CzZqdPjb
