### PR TITLE
fix(topup): persistent header Done exit on the card-payment WebView

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,9 @@ android/app/src/main/assets
 
 # Temporary files created by Metro to check the health of the file watcher
 .metro-health-check*
+
+# Cookie files created by watchman while the file watcher is running
+.watchman-cookie-*
 .bundle/
 vendor/
 

--- a/app/screens/topup-cashout-flow/CardPayment.tsx
+++ b/app/screens/topup-cashout-flow/CardPayment.tsx
@@ -13,8 +13,8 @@
  * - Desktop user agent spoofing on iOS to prevent mobile-specific issues
  */
 
-import React, { useState, useRef } from "react"
-import { View, ActivityIndicator, Alert, Platform } from "react-native"
+import React, { useState, useRef, useLayoutEffect } from "react"
+import { View, ActivityIndicator, Alert, Platform, TouchableOpacity } from "react-native"
 import { StackScreenProps } from "@react-navigation/stack"
 import { Text, makeStyles, useTheme } from "@rneui/themed"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
@@ -50,6 +50,31 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
   })
   const { amount, wallet } = route.params
   const username = data?.me?.username
+
+  /**
+   * Persistent header exit. The payment can complete entirely inside
+   * Fygaro's page (SPA state change, PayPal modal) with no URL change for
+   * onNavigationStateChange to detect — leaving the user stranded in the
+   * WebView with only back-navigation through the whole top-up stack. The
+   * header Done button guarantees a one-tap path straight home; leaving
+   * early is safe because crediting is webhook-driven on the backend, not
+   * dependent on this screen.
+   */
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerTitle: LL.FygaroWebViewScreen.title(),
+      headerRight: () => (
+        <TouchableOpacity
+          style={styles.headerDone}
+          onPress={() => navigation.navigate("Primary")}
+        >
+          <Text type="p1" color={colors.primary}>
+            {LL.PaymentSuccessScreen.done()}
+          </Text>
+        </TouchableOpacity>
+      ),
+    })
+  }, [navigation, LL, colors.primary, styles.headerDone])
 
   /**
    * Build Fygaro payment URL with critical parameters:
@@ -417,6 +442,7 @@ const useStyles = makeStyles(() => ({
     zIndex: 1,
   },
   loadingText: { marginTop: 16, textAlign: "center" },
+  headerDone: { paddingHorizontal: 16, paddingVertical: 8 },
   errorText: { textAlign: "center", marginBottom: 24 },
   retryButton: { marginTop: 16 },
   webView: { flex: 1 },

--- a/app/screens/topup-cashout-flow/CardPayment.tsx
+++ b/app/screens/topup-cashout-flow/CardPayment.tsx
@@ -30,6 +30,12 @@ type Props = StackScreenProps<RootStackParamList, "CardPayment">
 // Fygaro hosted payment-button path.
 const FYGARO_PAYMENT_BUTTON_PATH = "/pb/bd4a34c1-3d24-4315-a2b8-627518f70916"
 
+// Static style for the header Done button. Kept at module scope (not in
+// makeStyles) so the header useLayoutEffect can depend on stable values only —
+// makeStyles returns a fresh styles object every render, which would re-run
+// the effect and rebuild the header on each render.
+const headerDoneStyle = { paddingHorizontal: 16, paddingVertical: 8 }
+
 const CardPayment: React.FC<Props> = ({ navigation, route }) => {
   const isAuthed = useIsAuthed()
   const styles = useStyles()
@@ -65,7 +71,7 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
       headerTitle: LL.FygaroWebViewScreen.title(),
       headerRight: () => (
         <TouchableOpacity
-          style={styles.headerDone}
+          style={headerDoneStyle}
           onPress={() => navigation.navigate("Primary")}
         >
           <Text type="p1" color={colors.primary}>
@@ -74,7 +80,7 @@ const CardPayment: React.FC<Props> = ({ navigation, route }) => {
         </TouchableOpacity>
       ),
     })
-  }, [navigation, LL, colors.primary, styles.headerDone])
+  }, [navigation, LL, colors.primary])
 
   /**
    * Build Fygaro payment URL with critical parameters:
@@ -442,7 +448,6 @@ const useStyles = makeStyles(() => ({
     zIndex: 1,
   },
   loadingText: { marginTop: 16, textAlign: "center" },
-  headerDone: { paddingHorizontal: 16, paddingVertical: 8 },
   errorText: { textAlign: "center", marginBottom: 24 },
   retryButton: { marginTop: 16 },
   webView: { flex: 1 },

--- a/app/screens/topup-cashout-flow/__tests__/CardPayment.test.tsx
+++ b/app/screens/topup-cashout-flow/__tests__/CardPayment.test.tsx
@@ -40,8 +40,9 @@ const renderCardPayment = ({
   wallet = "USD",
   navigate = jest.fn(),
   goBack = jest.fn(),
+  setOptions = jest.fn(),
 } = {}) => {
-  const navigation = { navigate, goBack } as never
+  const navigation = { navigate, goBack, setOptions } as never
   const route = {
     key: "CardPayment",
     name: "CardPayment",
@@ -52,7 +53,7 @@ const renderCardPayment = ({
       <CardPayment navigation={navigation} route={route} />
     </ThemeProvider>,
   )
-  return { ...utils, navigate, goBack }
+  return { ...utils, navigate, goBack, setOptions }
 }
 
 // The test renderer occasionally issues a stray zero-arg invocation of the
@@ -146,6 +147,33 @@ describe("CardPayment username gating", () => {
     fireEvent.press(getAllByText(en.FygaroWebViewScreen.retry())[0])
 
     expect(refetch).toHaveBeenCalled()
+  })
+})
+
+describe("CardPayment header exit", () => {
+  it("provides a persistent header Done button that navigates straight home", () => {
+    const { navigate, setOptions } = renderCardPayment()
+
+    const options = (setOptions as jest.Mock).mock.calls.at(-1)?.[0]
+    expect(options?.headerRight).toBeDefined()
+
+    const { getAllByText } = render(
+      <ThemeProvider theme={theme}>{options.headerRight()}</ThemeProvider>,
+    )
+    fireEvent.press(getAllByText(en.PaymentSuccessScreen.done())[0])
+
+    expect(navigate).toHaveBeenCalledWith("Primary")
+  })
+
+  it("keeps the header exit available while the username is still loading", () => {
+    mockUseHomeAuthedQuery.mockReturnValue({
+      data: undefined,
+      loading: true,
+      refetch: jest.fn(() => Promise.resolve()),
+    })
+    const { setOptions } = renderCardPayment()
+
+    expect((setOptions as jest.Mock).mock.calls.at(-1)?.[0]?.headerRight).toBeDefined()
   })
 })
 

--- a/app/screens/topup-cashout-flow/__tests__/CardPayment.test.tsx
+++ b/app/screens/topup-cashout-flow/__tests__/CardPayment.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Alert } from "react-native"
-import { fireEvent, render, waitFor } from "@testing-library/react-native"
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native"
 import { ThemeProvider } from "@rneui/themed"
 import theme from "@app/rne-theme/theme"
 import { i18nObject } from "../../../i18n/i18n-util"
@@ -12,10 +12,18 @@ import CardPayment from "../CardPayment"
 loadAllLocales()
 
 // Deterministic, synchronous i18n (the real TypesafeI18n loads its dictionary
-// asynchronously, leaving LL-derived labels empty on first render).
-jest.mock("@app/i18n/i18n-react", () => ({
-  useI18nContext: () => ({ LL: i18nObject("en") }),
-}))
+// asynchronously, leaving LL-derived labels empty on first render). LL is
+// cached so it stays referentially stable across renders, matching the real
+// context — the header-effect memoization test below depends on that.
+jest.mock("@app/i18n/i18n-react", () => {
+  let cachedLL: ReturnType<typeof i18nObject> | undefined
+  return {
+    useI18nContext: () => {
+      cachedLL = cachedLL ?? i18nObject("en")
+      return { LL: cachedLL }
+    },
+  }
+})
 
 jest.mock("@app/graphql/is-authed-context", () => ({
   useIsAuthed: () => true,
@@ -63,6 +71,7 @@ const lastWebViewProps = () => {
   return calls[calls.length - 1][0] as {
     source: { uri: string }
     onNavigationStateChange: (event: { url: string }) => void
+    onLoadEnd: () => void
   }
 }
 
@@ -174,6 +183,22 @@ describe("CardPayment header exit", () => {
     const { setOptions } = renderCardPayment()
 
     expect((setOptions as jest.Mock).mock.calls.at(-1)?.[0]?.headerRight).toBeDefined()
+  })
+
+  it("does not re-run the header effect on unrelated re-renders", () => {
+    const { setOptions } = renderCardPayment()
+    expect(setOptions).toHaveBeenCalledTimes(1)
+
+    // A WebView load completing flips isLoading and re-renders the screen.
+    // The header effect's deps are all referentially stable, so setOptions
+    // must not fire again. (A makeStyles-derived dep breaks this: makeStyles
+    // returns a fresh styles object every render, re-running the effect and
+    // rebuilding the header on each render.)
+    act(() => {
+      lastWebViewProps().onLoadEnd()
+    })
+
+    expect(setOptions).toHaveBeenCalledTimes(1)
   })
 })
 


### PR DESCRIPTION
## Why

After completing a card top-up, users can be left stranded on the Fygaro WebView with no forward path — backing out through TopupDetails → TopupCashout → home by hand. Root cause: Fygaro can complete the payment entirely in-page (SPA state change / PayPal modal) with **no URL change**, so `onNavigationStateChange` never detects success and the `paymentSuccess` screen (which does have Done/View buttons) never shows.

## What

- `CardPayment` now sets a **persistent header `Done` button** (`navigation.setOptions` / `headerRight`) that navigates straight to `Primary`, available from the moment the screen opens — before, during, and after payment. Also sets the proper header title (`FygaroWebViewScreen.title`).
- Leaving early is safe by design: crediting is webhook-driven on the backend (lnflash/flash#472) and does not depend on this screen.
- Reuses existing i18n keys (`PaymentSuccessScreen.done`) — no locale-file churn.

## Tests

- header Done button renders and navigates to `Primary` on press
- header exit stays available while the username query is still loading (the screen's most stranded state)
- existing 13 CardPayment/TopupDetails tests updated for the `setOptions` mock and passing (15 total)

`yarn tsc:check` clean, eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcEjF6SS3Ci5D4CzZqdPjb