### PR TITLE
ci(android): build and upload release APKs on deploy

### DIFF
--- a/.github/workflows/android-deploy.yml
+++ b/.github/workflows/android-deploy.yml
@@ -115,6 +115,21 @@ jobs:
           GOOGLE_PLAY_JSON_KEY_PATH: google-play-key.json
         run: bundle exec fastlane android ${{ steps.lane.outputs.lane }}
 
+      # The beta/release lanes build only the Play AAB; the split APKs attached
+      # to GitHub releases come from this step (signing config is already in
+      # the generated gradle.properties above).
+      - name: Build release APKs
+        if: success() && steps.lane.outputs.lane != 'promote_to_beta'
+        run: cd android && ./gradlew assembleRelease --no-daemon --stacktrace
+
+      - name: Upload release APKs
+        if: success() && steps.lane.outputs.lane != 'promote_to_beta'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-apks
+          path: android/app/build/outputs/apk/release/*.apk
+          retention-days: 30
+
       - name: Push version bump
         if: success() && steps.lane.outputs.lane != 'promote_to_beta'
         run: |


### PR DESCRIPTION
The beta/release lanes build only the Play AAB — the split APKs attached to GitHub releases (see Android v0.6.1's assets) had to be built out-of-band with a local keystore that now exists only in CI secrets. This adds two steps after the fastlane lane: `assembleRelease` (signing config is already written by the existing gradle.properties step) and an `upload-artifact` publishing the split APKs (armeabi-v7a / arm64-v8a / universal), 30-day retention. Skipped for `promote_to_beta`, which builds nothing.

**Must merge before cutting the v0.6.4 tags** — tag-push runs use the workflow file at the tag's commit, so the APK artifacts only exist for tags cut after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcEjF6SS3Ci5D4CzZqdPjb