### PR TITLE
fix(amounts): floor percentage quick-buttons to the spendable balance

### DIFF
--- a/__tests__/utils/percentage-of-balance.spec.ts
+++ b/__tests__/utils/percentage-of-balance.spec.ts
@@ -1,0 +1,76 @@
+import {
+  percentageOfBalance,
+  toSpendableBalance,
+  toUsdMoneyAmount,
+} from "@app/types/amounts"
+
+// The API can report USD cash-wallet balances in fractional cents, e.g.
+// 109.9346 = $1.099346 held at IBEX (flash#480). The percentage quick-buttons
+// (conversion 25/50/75 + top chip, cashout 50/100) previously Math.round-ed
+// the raw balance, so 100% of 109.9346 filled 110¢ — more than is spendable
+// (#696). Every quick-set amount must be a whole minor unit <= the spendable
+// balance: floor the balance first, then floor the percentage result.
+describe("percentageOfBalance", () => {
+  it("fills the floored spendable balance at 100%, not the rounded-up raw one", () => {
+    // Math.round(109.9346) = 110 was the bug: 110¢ > 109.9346¢ held
+    expect(percentageOfBalance(109.9346, 100)).toEqual(109)
+  })
+
+  it("floors partial percentages instead of rounding", () => {
+    // Math.round(109.9346 * 0.5) = 55; 50% of the 109¢ spendable is 54
+    expect(percentageOfBalance(109.9346, 50)).toEqual(54)
+    expect(percentageOfBalance(109.9346, 75)).toEqual(81)
+    expect(percentageOfBalance(109.9346, 25)).toEqual(27)
+  })
+
+  it("computes from the spendable balance so small balances cannot overshoot", () => {
+    // The conversion top chip passes 99 for USD: Math.round(1.9 * 0.99) = 2
+    // overshot both the 1¢ spendable and the 1.9¢ raw balance
+    expect(percentageOfBalance(1.9, 99)).toEqual(0)
+  })
+
+  it("passes integer balances through unchanged at 100%", () => {
+    expect(percentageOfBalance(88413, 100)).toEqual(88413)
+    expect(percentageOfBalance(158, 100)).toEqual(158)
+  })
+
+  it("computes exact partials of integer balances", () => {
+    expect(percentageOfBalance(200, 25)).toEqual(50)
+    expect(percentageOfBalance(200, 50)).toEqual(100)
+    expect(percentageOfBalance(158, 90)).toEqual(142)
+  })
+
+  it("returns zero for a zero balance at any percentage", () => {
+    expect(percentageOfBalance(0, 25)).toEqual(0)
+    expect(percentageOfBalance(0, 100)).toEqual(0)
+  })
+
+  it("returns zero for sub-cent residue (e.g. after a MAX drain)", () => {
+    expect(percentageOfBalance(0.9346, 100)).toEqual(0)
+  })
+
+  it("propagates NaN so missing balances keep the existing invalid-amount handling", () => {
+    expect(percentageOfBalance(NaN, 100)).toBeNaN()
+    expect(percentageOfBalance(NaN, 50)).toBeNaN()
+  })
+
+  it("matches toSpendableBalance exactly at 100%", () => {
+    for (const balance of [109.9346, 0.9346, 88413, 12.5]) {
+      expect(percentageOfBalance(balance, 100)).toEqual(
+        toSpendableBalance(toUsdMoneyAmount(balance)).amount,
+      )
+    }
+  })
+
+  it("never exceeds the spendable balance for any button percentage", () => {
+    const balances = [109.9346, 0.9346, 1.9, 12.5, 55, 88413]
+    const percentages = [25, 50, 75, 90, 99, 100]
+    for (const balance of balances) {
+      for (const percentage of percentages) {
+        expect(percentageOfBalance(balance, percentage)).toBeLessThanOrEqual(
+          Math.floor(balance),
+        )
+      }
+    }
+  })
+})

--- a/app/screens/conversion-flow/conversion-details-screen.tsx
+++ b/app/screens/conversion-flow/conversion-details-screen.tsx
@@ -26,6 +26,7 @@ import { useI18nContext } from "@app/i18n/i18n-react"
 import {
   DisplayCurrency,
   MoneyAmount,
+  percentageOfBalance,
   toBtcMoneyAmount,
   toSpendableBalance,
   toUsdMoneyAmount,
@@ -107,7 +108,9 @@ export const ConversionDetailsScreen: React.FC<Props> = ({ navigation }) => {
 
     setMoneyAmount(
       toWalletAmount({
-        amount: Math.round((fromBalance * percentage) / 100),
+        // Floor to the spendable balance — the raw balance can hold fractional
+        // cents, and rounding it up filled an amount the swap can't fill (#696).
+        amount: percentageOfBalance(fromBalance, percentage),
         currency: fromWalletCurrency,
       }),
     )

--- a/app/screens/topup-cashout-flow/CashoutDetails.tsx
+++ b/app/screens/topup-cashout-flow/CashoutDetails.tsx
@@ -25,6 +25,7 @@ import { useActivityIndicator, useDisplayCurrency, usePriceConversion } from "@a
 // utils
 import {
   MoneyAmount,
+  percentageOfBalance,
   toUsdMoneyAmount,
   toWalletAmount,
   WalletOrDisplayCurrency,
@@ -206,7 +207,9 @@ const CashoutDetails = ({ navigation, route }: Props) => {
   const setAmountToBalancePercentage = (percentage: number) => {
     setMoneyAmount(
       toWalletAmount({
-        amount: Math.round((usdBalance.amount * percentage) / 100),
+        // Floor to the spendable balance — the raw balance can hold fractional
+        // cents, and rounding it up filled an unsendable amount (#696).
+        amount: percentageOfBalance(usdBalance.amount, percentage),
         currency: WalletCurrency.Usd,
       }),
     )

--- a/app/types/amounts.ts
+++ b/app/types/amounts.ts
@@ -112,7 +112,9 @@ export const toWalletAmount = <T extends WalletCurrency>({
  * the invariant `displayed <= actual` even for negative amounts. `NaN`
  * passes through unchanged so missing balances keep their existing rendering.
  *
- * Display-only: never use this for validation or to build send amounts.
+ * Use for display and for pre-filling amounts (MAX chip #689, percentage
+ * quick-buttons via `percentageOfBalance` #696) — never for validation,
+ * which compares against the raw balance.
  */
 export const toSpendableBalance = <T extends WalletCurrency>(
   balance: WalletAmount<T>,
@@ -121,6 +123,23 @@ export const toSpendableBalance = <T extends WalletCurrency>(
     ...balance,
     amount: Math.floor(balance.amount),
   }
+}
+
+/**
+ * Computes a percentage quick-button amount from a raw wallet balance.
+ *
+ * Every quick-set amount must be spendable: the balance is floored to whole
+ * minor units first (raw balances can carry fractional cents, see
+ * `toSpendableBalance` above), then the percentage result is floored again,
+ * so the returned amount is always a whole minor unit that is <= the
+ * spendable balance (#696). At 100% this returns exactly the spendable
+ * balance, matching the MAX chip (#689) and the displayed balances (#695).
+ *
+ * `NaN` propagates so a missing balance keeps the existing invalid-amount
+ * handling at the call sites.
+ */
+export const percentageOfBalance = (balance: number, percentage: number): number => {
+  return Math.floor((Math.floor(balance) * percentage) / 100)
 }
 
 export const toDisplayAmount = ({


### PR DESCRIPTION
## The rule

Every percentage quick-set amount must be **≤ the spendable balance**. The API serves USD cash-wallet balances in fractional cents (flash#480), and the quick-buttons `Math.round`-ed the raw balance — rounding *up* past what is spendable.

New helper `percentageOfBalance(balance, percentage)` in `app/types/amounts.ts`, next to `toSpendableBalance` (#695): floor the balance to whole minor units first, then floor the percentage result. Every quick-set lands on a whole, sendable minor unit, and 100% returns exactly the spendable balance — the same rule as the MAX chip (#689) and the balance displays (#695).

## Both flows fixed

| Site | Before | After |
|---|---|---|
| `app/screens/topup-cashout-flow/CashoutDetails.tsx` (`setAmountToBalancePercentage`, 50%/100% buttons) | `Math.round((usdBalance.amount * percentage) / 100)` | `percentageOfBalance(usdBalance.amount, percentage)` |
| `app/screens/conversion-flow/conversion-details-screen.tsx` (`setAmountToBalancePercentage`, 25/50/75 + top chip) | `Math.round((fromBalance * percentage) / 100)` | `percentageOfBalance(fromBalance, percentage)` |

Exact numbers on the issue's wallet, 109.9346 cents held:

| Tap | Before | After |
|---|---|---|
| Cashout **100%** | 110¢ — unsendable, max-amount error | **109¢** = spendable balance |
| Cashout **50%** | 55¢ (rounded up past half the spendable 109¢) | **54¢** |
| Conversion **75%** | 82¢ | **81¢** |
| Conversion **25%** | 27¢ | 27¢ (unchanged, was already ≤) |

Small-balance overshoot in conversion is also fixed: on 1.9¢ held, the top chip (passes 99 for USD) previously set `Math.round(1.9 × 0.99) = 2¢` — more than both the spendable **and** the raw balance; now 0¢.

Also corrected the stale `toSpendableBalance` docblock line ("never use to build send amounts") — the MAX chip has used it for fills since #689; the real rule is *never for validation*, which this PR does not touch (validation still compares against the raw balance).

## Deliberately untouched

- `PercentageAmount.tsx:51` — the conversion top chip passes `90` (BTC, labeled 90%) / `99` (USD, labeled 100%). These values predate fractional balances (Sept 2024, breez-liquid migration) and look like deliberate swap-fee headroom; raising 99 → 100 is a product decision out of scope here. With this fix the chip can no longer overshoot regardless.
- `max-send-amount.ts`, `amount-input-screen.tsx` MAX paths — already floor correctly (#689).
- `quick-zap-modal.tsx` presets — fixed sat amounts, not balance-derived.
- `utils/breez-sdk/migration.ts` — integer-sat math, not a user-facing button.

## Tests

New `__tests__/utils/percentage-of-balance.spec.ts` (10 tests, house style of `to-spendable-balance.spec.ts`): the exact issue numbers (109.9346 @ 100% → 109, @ 50% → 54 not 55), small-balance overshoot (1.9 @ 99 → 0), integer passthrough, zero, sub-cent residue, NaN propagation, 100% ≡ `toSpendableBalance`, and a sweep asserting no button percentage ever exceeds the spendable balance.

- `yarn test`: 64 suites / 430 tests passed
- `yarn tsc:check`: clean
- eslint on changed files: clean (two pre-existing findings on untouched lines of `conversion-details-screen.tsx` left alone)

Fixes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fAxSGEsL2LsMx1uCjAzHH