### PR TITLE
feat(app-update): mount the version-gate UI on the home screen

### DIFF
--- a/__mocks__/react-native-device-info.js
+++ b/__mocks__/react-native-device-info.js
@@ -1,4 +1,8 @@
 export default {
   getReadableVersion: jest.fn(() => "1.0.0"),
   getBuildNumber: jest.fn(() => "1234"),
+  // AppUpdate scopes the version gate to this bundle — see GATED_BUNDLE_ID in
+  // app/components/app-update/app-update.tsx. Leaving it undefined would
+  // silently disable the gate in every screen test that mounts the provider.
+  getBundleId: jest.fn(() => "com.lnflash"),
 }

--- a/__tests__/components/app-update-android.spec.tsx
+++ b/__tests__/components/app-update-android.spec.tsx
@@ -7,7 +7,7 @@ import { Linking } from "react-native"
 import { createTheme, ThemeProvider } from "@rneui/themed"
 import { render, fireEvent, act } from "@testing-library/react-native"
 
-import { PLAY_STORE_LINK } from "@app/config"
+import { CONTACT_EMAIL_ADDRESS, PLAY_STORE_LINK } from "@app/config"
 import { i18nObject } from "../../app/i18n/i18n-util"
 import { loadLocale } from "../../app/i18n/i18n-util.sync"
 
@@ -168,21 +168,30 @@ describe("app update on Android", () => {
     expect(mockToastShow).not.toHaveBeenCalled()
   })
 
-  it("tells support the blocked device is on Android", () => {
+  it("tells support the blocked device is on Android", async () => {
     mockMobileVersions = versions(95, 96)
+    // Own spy, own act: reading the module-level mock instead would inherit
+    // whatever the preceding test installed, so inserting a test above this one
+    // could silently swap the composer's success path for its failure path.
+    const openURL = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined)
 
-    const { getByText } = renderWithTheme(<AppUpdateGate />)
+    const { getByText, queryByText } = renderWithTheme(<AppUpdateGate />)
 
-    fireEvent.press(getByText(LL.AppUpdate.contactSupport()))
+    await act(async () => {
+      fireEvent.press(getByText(LL.AppUpdate.contactSupport()))
+    })
 
     // The Android branch is the one that can lose the store link entirely (no
     // Play Store on the device), so support has to be told which platform it is
     // dealing with.
-    const mailto = (Linking.openURL as jest.Mock).mock.calls
-      .map(String)
-      .find((url) => url.startsWith("mailto:"))
+    const mailto = openURL.mock.calls.map(String).find((url) => url.startsWith("mailto:"))
     expect(mailto).toBeDefined()
     expect(decodeURIComponent(mailto as string)).toContain("Android")
+    // The composer opened, so the last-resort address must stay hidden — this
+    // is what pins the case to the success path.
+    expect(
+      queryByText(LL.AppUpdate.couldNotOpenSupport({ email: CONTACT_EMAIL_ADDRESS })),
+    ).toBeNull()
   })
 
   it("sends the home banner to the installed store app", async () => {

--- a/__tests__/components/app-update-android.spec.tsx
+++ b/__tests__/components/app-update-android.spec.tsx
@@ -1,0 +1,146 @@
+// Android store-link coverage. `isIos` is captured at module load
+// (app/utils/helper.ts), so the Android branch of the store link can only be
+// exercised from a separate module registry — hence a sibling spec rather than
+// another case in app-update-render.spec.tsx.
+import * as React from "react"
+import { Linking } from "react-native"
+import { createTheme, ThemeProvider } from "@rneui/themed"
+import { render, fireEvent } from "@testing-library/react-native"
+
+import { PLAY_STORE_LINK } from "@app/config"
+import { i18nObject } from "../../app/i18n/i18n-util"
+import { loadLocale } from "../../app/i18n/i18n-util.sync"
+
+jest.mock("@app/utils/helper", () => ({
+  ...jest.requireActual("@app/utils/helper"),
+  isIos: false,
+}))
+
+// Driven per-test: what the mobileVersions query returns.
+let mockMobileVersions: unknown
+
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useMobileUpdateQuery: () => ({
+    data: { mobileVersions: mockMobileVersions },
+    refetch: jest.fn().mockResolvedValue({}),
+  }),
+}))
+
+jest.mock("react-native-device-info", () => ({
+  getBuildNumber: () => "89",
+  getReadableVersion: () => "0.6.6.89",
+  // The gate only governs this bundle — see GATED_BUNDLE_ID.
+  getBundleId: () => "com.lnflash",
+}))
+
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({ LL: i18nObject("en") }),
+}))
+
+jest.mock("@app/components/contact-modal", () => ({}))
+
+jest.mock("@app/components/version", () => ({
+  VersionComponent: () => null,
+}))
+
+jest.mock("../../app/utils/toast", () => ({
+  toastShow: jest.fn(),
+}))
+
+jest.mock("react-native-modal", () => {
+  const ReactActual = jest.requireActual("react")
+  const { View } = jest.requireActual("react-native")
+  return {
+    __esModule: true,
+    default: ({
+      isVisible,
+      children,
+    }: {
+      isVisible: boolean
+      children: React.ReactNode
+    }) => (isVisible ? ReactActual.createElement(View, null, children) : null),
+  }
+})
+
+import {
+  AppUpdate,
+  AppUpdateGate,
+  AppUpdateProvider,
+} from "../../app/components/app-update/app-update"
+
+loadLocale("en")
+const LL = i18nObject("en")
+
+// Platform.OS stays "ios" under jest, so both entries carry the same numbers —
+// what this spec pins is the store link chosen by `isIos`, not the lookup.
+const versions = (minSupported: number, currentSupported: number) => [
+  {
+    __typename: "MobileVersions",
+    platform: "android",
+    currentSupported,
+    minSupported,
+  },
+  {
+    __typename: "MobileVersions",
+    platform: "ios",
+    currentSupported,
+    minSupported,
+  },
+]
+
+const renderWithTheme = (component: React.ReactElement) =>
+  render(
+    <ThemeProvider theme={createTheme({})}>
+      <AppUpdateProvider>{component}</AppUpdateProvider>
+    </ThemeProvider>,
+  )
+
+describe("app update on Android", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("sends the blocking modal's update button to the Play Store", () => {
+    mockMobileVersions = versions(95, 96)
+    const openURL = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined)
+
+    const { getByText } = renderWithTheme(<AppUpdateGate />)
+
+    fireEvent.press(getByText(LL.AppUpdate.tapHereUpdate()))
+
+    // The modal cannot be dismissed: an Android user sent to the App Store has
+    // no way out of the gate at all.
+    expect(openURL).toHaveBeenCalledTimes(1)
+    expect(openURL).toHaveBeenCalledWith(PLAY_STORE_LINK)
+  })
+
+  it("tells support the blocked device is on Android", () => {
+    mockMobileVersions = versions(95, 96)
+
+    const { getByText } = renderWithTheme(<AppUpdateGate />)
+
+    fireEvent.press(getByText(LL.AppUpdate.contactSupport()))
+
+    // The Android branch is the one that can lose the store link entirely (no
+    // Play Store on the device), so support has to be told which platform it is
+    // dealing with.
+    const mailto = (Linking.openURL as jest.Mock).mock.calls
+      .map(String)
+      .find((url) => url.startsWith("mailto:"))
+    expect(mailto).toBeDefined()
+    expect(decodeURIComponent(mailto as string)).toContain("Android")
+  })
+
+  it("sends the home banner to the Play Store", () => {
+    mockMobileVersions = versions(1, 95)
+    const openURL = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined)
+
+    const { getByText } = renderWithTheme(<AppUpdate />)
+
+    fireEvent.press(getByText(LL.HomeScreen.updateAvailable()))
+
+    expect(openURL).toHaveBeenCalledTimes(1)
+    expect(openURL).toHaveBeenCalledWith(PLAY_STORE_LINK)
+  })
+})

--- a/__tests__/components/app-update-android.spec.tsx
+++ b/__tests__/components/app-update-android.spec.tsx
@@ -5,7 +5,7 @@
 import * as React from "react"
 import { Linking } from "react-native"
 import { createTheme, ThemeProvider } from "@rneui/themed"
-import { render, fireEvent } from "@testing-library/react-native"
+import { render, fireEvent, act } from "@testing-library/react-native"
 
 import { PLAY_STORE_LINK } from "@app/config"
 import { i18nObject } from "../../app/i18n/i18n-util"
@@ -38,14 +38,13 @@ jest.mock("@app/i18n/i18n-react", () => ({
   useI18nContext: () => ({ LL: i18nObject("en") }),
 }))
 
-jest.mock("@app/components/contact-modal", () => ({}))
-
 jest.mock("@app/components/version", () => ({
   VersionComponent: () => null,
 }))
 
+const mockToastShow = jest.fn()
 jest.mock("../../app/utils/toast", () => ({
-  toastShow: jest.fn(),
+  toastShow: (...args: unknown[]) => mockToastShow(...args),
 }))
 
 jest.mock("react-native-modal", () => {
@@ -67,6 +66,7 @@ import {
   AppUpdate,
   AppUpdateGate,
   AppUpdateProvider,
+  GATED_BUNDLE_ID,
 } from "../../app/components/app-update/app-update"
 
 loadLocale("en")
@@ -101,18 +101,71 @@ describe("app update on Android", () => {
     jest.clearAllMocks()
   })
 
-  it("sends the blocking modal's update button to the Play Store", () => {
+  it("sends the blocking modal's update button to the installed store app", async () => {
     mockMobileVersions = versions(95, 96)
     const openURL = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined)
 
+    const { getByText, queryByText } = renderWithTheme(<AppUpdateGate />)
+
+    await act(async () => {
+      fireEvent.press(getByText(LL.AppUpdate.tapHereUpdate()))
+    })
+
+    // market:// is claimed only by an installed store app, so it lands the user
+    // where they can actually install the update. The modal cannot be
+    // dismissed: an Android user sent anywhere else has no way out of the gate.
+    expect(openURL).toHaveBeenCalledTimes(1)
+    expect(openURL).toHaveBeenCalledWith(`market://details?id=${GATED_BUNDLE_ID}`)
+    expect(queryByText(LL.AppUpdate.couldNotOpenStore())).toBeNull()
+  })
+
+  it("falls back to the web listing when no store app handles market://", async () => {
+    mockMobileVersions = versions(95, 96)
+    const openURL = jest
+      .spyOn(Linking, "openURL")
+      .mockImplementation(async (url: string) => {
+        if (url.startsWith("market://")) {
+          throw new Error("no activity found to handle intent")
+        }
+      })
+    jest.spyOn(console, "warn").mockImplementation(() => {})
+
+    const { getByText, queryByText } = renderWithTheme(<AppUpdateGate />)
+
+    await act(async () => {
+      fireEvent.press(getByText(LL.AppUpdate.tapHereUpdate()))
+    })
+
+    // A device with a browser but no store app still gets the listing — a web
+    // page is a worse landing spot than the store app, but it is not a failure.
+    expect(openURL.mock.calls.map(String)).toEqual([
+      `market://details?id=${GATED_BUNDLE_ID}`,
+      PLAY_STORE_LINK,
+    ])
+    expect(queryByText(LL.AppUpdate.couldNotOpenStore())).toBeNull()
+  })
+
+  it("surfaces the failure when nothing on the device will take the link", async () => {
+    mockMobileVersions = versions(95, 96)
+    // A de-Googled device with no store app and no browser that claims the
+    // https listing. Going straight to PLAY_STORE_LINK made this path
+    // unreachable — any browser resolves an https URL — so a hard-blocked user
+    // got no hint at all that Contact Support was the way out.
+    jest
+      .spyOn(Linking, "openURL")
+      .mockRejectedValue(new Error("no activity found to handle intent"))
+    jest.spyOn(console, "warn").mockImplementation(() => {})
+    jest.spyOn(console, "error").mockImplementation(() => {})
+
     const { getByText } = renderWithTheme(<AppUpdateGate />)
 
-    fireEvent.press(getByText(LL.AppUpdate.tapHereUpdate()))
+    await act(async () => {
+      fireEvent.press(getByText(LL.AppUpdate.tapHereUpdate()))
+    })
 
-    // The modal cannot be dismissed: an Android user sent to the App Store has
-    // no way out of the gate at all.
-    expect(openURL).toHaveBeenCalledTimes(1)
-    expect(openURL).toHaveBeenCalledWith(PLAY_STORE_LINK)
+    expect(getByText(LL.AppUpdate.couldNotOpenStore())).toBeTruthy()
+    // A toast would be swallowed behind the modal (FIXME in utils/toast).
+    expect(mockToastShow).not.toHaveBeenCalled()
   })
 
   it("tells support the blocked device is on Android", () => {
@@ -132,15 +185,46 @@ describe("app update on Android", () => {
     expect(decodeURIComponent(mailto as string)).toContain("Android")
   })
 
-  it("sends the home banner to the Play Store", () => {
+  it("sends the home banner to the installed store app", async () => {
     mockMobileVersions = versions(1, 95)
     const openURL = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined)
 
     const { getByText } = renderWithTheme(<AppUpdate />)
 
-    fireEvent.press(getByText(LL.HomeScreen.updateAvailable()))
+    await act(async () => {
+      fireEvent.press(getByText(LL.HomeScreen.updateAvailable()))
+    })
 
     expect(openURL).toHaveBeenCalledTimes(1)
-    expect(openURL).toHaveBeenCalledWith(PLAY_STORE_LINK)
+    expect(openURL).toHaveBeenCalledWith(`market://details?id=${GATED_BUNDLE_ID}`)
+    expect(mockToastShow).not.toHaveBeenCalled()
+  })
+
+  it("toasts the banner's own wording, in the user's locale, when nothing opens", async () => {
+    mockMobileVersions = versions(1, 95)
+    jest
+      .spyOn(Linking, "openURL")
+      .mockRejectedValue(new Error("no activity found to handle intent"))
+    jest.spyOn(console, "warn").mockImplementation(() => {})
+    jest.spyOn(console, "error").mockImplementation(() => {})
+
+    const { getByText } = renderWithTheme(<AppUpdate />)
+
+    await act(async () => {
+      fireEvent.press(getByText(LL.HomeScreen.updateAvailable()))
+    })
+
+    expect(mockToastShow).toHaveBeenCalledTimes(1)
+    const [{ message, currentTranslation }] = mockToastShow.mock.calls[0]
+
+    // Without currentTranslation, utils/toast falls back to i18nObject("en") —
+    // a Spanish user gets an English toast and analytics records isTranslated
+    // false for every one of them.
+    expect(currentTranslation).toBeDefined()
+    // The gate's couldNotOpenStore points at a Contact Support button that only
+    // exists inside the blocking modal. On the home screen that button is not
+    // there, so the banner needs its own line.
+    expect(message(LL)).toBe(LL.AppUpdate.couldNotOpenStoreBanner())
+    expect(message(LL)).not.toBe(LL.AppUpdate.couldNotOpenStore())
   })
 })

--- a/__tests__/components/app-update-boundary.spec.tsx
+++ b/__tests__/components/app-update-boundary.spec.tsx
@@ -1,0 +1,132 @@
+// The gate is only worth anything if it is actually mounted. These specs cover
+// the mount itself — that the blocking modal reaches the tree from the app root,
+// that it is the last sibling (paint order is load-bearing, see #545), and that
+// app.tsx still wires it up. Without them, deleting the mount leaves every other
+// suite green while the PR's entire purpose is undone.
+import fs from "fs"
+import path from "path"
+
+import * as React from "react"
+import { Text } from "react-native"
+import { createTheme, ThemeProvider } from "@rneui/themed"
+import { render } from "@testing-library/react-native"
+
+import { i18nObject } from "../../app/i18n/i18n-util"
+import { loadLocale } from "../../app/i18n/i18n-util.sync"
+
+let mockMobileVersions: unknown
+
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useMobileUpdateQuery: () => ({
+    data: { mobileVersions: mockMobileVersions },
+    refetch: jest.fn().mockResolvedValue({}),
+  }),
+}))
+
+jest.mock("react-native-device-info", () => ({
+  getBuildNumber: () => "89",
+  getReadableVersion: () => "0.6.6.89",
+  getBundleId: () => "com.lnflash",
+}))
+
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({ LL: i18nObject("en") }),
+}))
+
+jest.mock("@app/components/version", () => ({
+  VersionComponent: () => null,
+}))
+
+jest.mock("react-native-modal", () => {
+  const ReactActual = jest.requireActual("react")
+  const { View } = jest.requireActual("react-native")
+  return {
+    __esModule: true,
+    default: (props: { isVisible: boolean; children: React.ReactNode }) =>
+      props.isVisible ? ReactActual.createElement(View, null, props.children) : null,
+  }
+})
+
+import { AppUpdateBoundary } from "../../app/components/app-update/app-update-boundary"
+
+loadLocale("en")
+const LL = i18nObject("en")
+
+const versions = (minSupported: number, currentSupported: number) => [
+  { __typename: "MobileVersions", platform: "android", currentSupported, minSupported },
+  { __typename: "MobileVersions", platform: "ios", currentSupported, minSupported },
+]
+
+const renderBoundary = () =>
+  render(
+    <ThemeProvider theme={createTheme({})}>
+      <AppUpdateBoundary>
+        <Text>app content</Text>
+      </AppUpdateBoundary>
+    </ThemeProvider>,
+  )
+
+describe("AppUpdateBoundary", () => {
+  it("renders its children when the build is supported and shows no gate", () => {
+    mockMobileVersions = versions(1, 89)
+
+    const { getByText, queryByText } = renderBoundary()
+
+    expect(getByText("app content")).toBeTruthy()
+    expect(queryByText(LL.AppUpdate.versionNotSupported())).toBeNull()
+  })
+
+  it("blocks from the app root when the build is below minSupported", () => {
+    // This is the mount the whole PR exists for: without it the modal is
+    // unreachable no matter how correct the component is.
+    mockMobileVersions = versions(95, 96)
+
+    const { getByText } = renderBoundary()
+
+    expect(getByText(LL.AppUpdate.versionNotSupported())).toBeTruthy()
+    expect(getByText(LL.AppUpdate.updateMandatory())).toBeTruthy()
+  })
+
+  it("keeps the gate as the last sibling so nothing paints over the block", () => {
+    // coverScreen={false} makes the modal render inline (#545), so paint order
+    // follows sibling order. A child mounted after the gate would draw on top of
+    // a modal that has no dismiss.
+    mockMobileVersions = versions(95, 96)
+
+    const element = AppUpdateBoundary({ children: <Text>app content</Text> })
+    const children = React.Children.toArray(
+      (element as React.ReactElement).props.children,
+    )
+
+    const last = children[children.length - 1] as React.ReactElement
+    expect(last.type).toBe(
+      jest.requireActual("../../app/components/app-update/app-update").AppUpdateGate,
+    )
+  })
+})
+
+describe("app.tsx wiring", () => {
+  // app.tsx cannot be rendered under jest — it pulls Firebase, reanimated and a
+  // pile of native modules in at import time — so the mount is asserted against
+  // the source. Deleting the boundary from the root tree has to fail something.
+  const source = fs.readFileSync(path.join(__dirname, "../../app/app.tsx"), "utf8")
+
+  it("mounts the boundary in the root component tree", () => {
+    expect(source).toContain(
+      'import { AppUpdateBoundary } from "./components/app-update/app-update-boundary"',
+    )
+    expect(source).toContain("<AppUpdateBoundary>")
+    expect(source).toContain("</AppUpdateBoundary>")
+  })
+
+  it("wraps the navigator, so deep-link cold starts cannot bypass the gate", () => {
+    const opened = source.indexOf("<AppUpdateBoundary>")
+    const rootStack = source.indexOf("<RootStack />")
+    const closed = source.indexOf("</AppUpdateBoundary>")
+
+    expect(opened).toBeGreaterThan(-1)
+    expect(rootStack).toBeGreaterThan(opened)
+    expect(closed).toBeGreaterThan(rootStack)
+  })
+})

--- a/__tests__/components/app-update-boundary.spec.tsx
+++ b/__tests__/components/app-update-boundary.spec.tsx
@@ -110,20 +110,30 @@ describe("app.tsx wiring", () => {
   // app.tsx cannot be rendered under jest — it pulls Firebase, reanimated and a
   // pile of native modules in at import time — so the mount is asserted against
   // the source. Deleting the boundary from the root tree has to fail something.
+  //
+  // Every pattern below is deliberately formatting-tolerant: prettier is free to
+  // wrap an opening tag across lines, and either tag may grow a prop. A spec
+  // that failed on a reformat while the mount was perfectly intact would be a
+  // false alarm, and false alarms get tests deleted.
   const source = fs.readFileSync(path.join(__dirname, "../../app/app.tsx"), "utf8")
 
+  // `<AppUpdateBoundary>`, `<AppUpdateBoundary\n  key={…}>`, `<AppUpdateBoundary `…
+  const OPENING_TAG = /<AppUpdateBoundary[\s>]/
+  const CLOSING_TAG = /<\/AppUpdateBoundary\s*>/
+  const ROOT_STACK = /<RootStack[\s/>]/
+
   it("mounts the boundary in the root component tree", () => {
-    expect(source).toContain(
-      'import { AppUpdateBoundary } from "./components/app-update/app-update-boundary"',
+    expect(source).toMatch(
+      /import\s*\{[^}]*\bAppUpdateBoundary\b[^}]*\}\s*from\s*["'][^"']*app-update-boundary["']/,
     )
-    expect(source).toContain("<AppUpdateBoundary>")
-    expect(source).toContain("</AppUpdateBoundary>")
+    expect(source).toMatch(OPENING_TAG)
+    expect(source).toMatch(CLOSING_TAG)
   })
 
   it("wraps the navigator, so deep-link cold starts cannot bypass the gate", () => {
-    const opened = source.indexOf("<AppUpdateBoundary>")
-    const rootStack = source.indexOf("<RootStack />")
-    const closed = source.indexOf("</AppUpdateBoundary>")
+    const opened = source.search(OPENING_TAG)
+    const rootStack = source.search(ROOT_STACK)
+    const closed = source.search(CLOSING_TAG)
 
     expect(opened).toBeGreaterThan(-1)
     expect(rootStack).toBeGreaterThan(opened)

--- a/__tests__/components/app-update-inline-modal.spec.tsx
+++ b/__tests__/components/app-update-inline-modal.spec.tsx
@@ -1,0 +1,114 @@
+// Every other app-update spec replaces react-native-modal with a stub, so
+// `coverScreen={false}` is only ever asserted as a prop value — nothing checks
+// that the library actually takes its inline render path, or that the gate's
+// content and both escape buttons survive it. That gap matters: the workaround
+// exists because RCTModalHostView mismeasures the flex:1 content host under
+// Fabric on Android (#545), and this modal has no dismiss, no backdrop press and
+// swallows the hardware back button. If the inline path ever stopped rendering
+// the content, every hard-blocked user would get a frozen screen.
+//
+// This runs the real library. It cannot prove Fabric layout — jest has no
+// layout engine — so the device check stays a release gate (see the PR note),
+// but it does pin: no native modal host in the tree, content rendered, both
+// buttons wired.
+import * as React from "react"
+import { Linking, Modal } from "react-native"
+import { createTheme, ThemeProvider } from "@rneui/themed"
+import { render, fireEvent, act } from "@testing-library/react-native"
+
+import { i18nObject } from "../../app/i18n/i18n-util"
+import { loadLocale } from "../../app/i18n/i18n-util.sync"
+
+let mockMobileVersions: unknown
+
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useMobileUpdateQuery: () => ({
+    data: { mobileVersions: mockMobileVersions },
+    refetch: jest.fn().mockResolvedValue({}),
+  }),
+}))
+
+jest.mock("react-native-device-info", () => ({
+  getBuildNumber: () => "89",
+  getReadableVersion: () => "0.6.6.89",
+  getBundleId: () => "com.lnflash",
+}))
+
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({ LL: i18nObject("en") }),
+}))
+
+jest.mock("@app/components/version", () => ({
+  VersionComponent: () => null,
+}))
+
+// NOTE: react-native-modal is deliberately NOT mocked here. That is the point.
+
+import {
+  AppUpdateGate,
+  AppUpdateProvider,
+} from "../../app/components/app-update/app-update"
+
+loadLocale("en")
+const LL = i18nObject("en")
+
+const versions = (minSupported: number, currentSupported: number) => [
+  { __typename: "MobileVersions", platform: "android", currentSupported, minSupported },
+  { __typename: "MobileVersions", platform: "ios", currentSupported, minSupported },
+]
+
+const renderGate = () =>
+  render(
+    <ThemeProvider theme={createTheme({})}>
+      <AppUpdateProvider>
+        <AppUpdateGate />
+      </AppUpdateProvider>
+    </ThemeProvider>,
+  )
+
+describe("AppUpdateGate through the real react-native-modal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockMobileVersions = versions(95, 96)
+  })
+
+  it("renders the block inline, not through the native modal host", () => {
+    const view = renderGate()
+    const { getByText } = view
+
+    // RCTModalHostView is what #545 breaks. coverScreen={false} has to keep the
+    // library off it — a regression that dropped the prop would put a native
+    // host back in the tree here. Querying by component type is the only way to
+    // see the host at all; the testing library prefixes that API as UNSAFE_.
+    // eslint-disable-next-line camelcase
+    expect(view.UNSAFE_queryAllByType(Modal)).toHaveLength(0)
+    expect(getByText(LL.AppUpdate.versionNotSupported())).toBeTruthy()
+    expect(getByText(LL.AppUpdate.updateMandatory())).toBeTruthy()
+  })
+
+  it("keeps both escapes tappable on the inline path", async () => {
+    const openURL = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined)
+
+    const { getByText } = renderGate()
+
+    await act(async () => {
+      fireEvent.press(getByText(LL.AppUpdate.tapHereUpdate()))
+    })
+    expect(openURL).toHaveBeenCalled()
+
+    await act(async () => {
+      fireEvent.press(getByText(LL.AppUpdate.contactSupport()))
+    })
+    const mailto = openURL.mock.calls.map(String).find((url) => url.startsWith("mailto:"))
+    expect(mailto).toBeDefined()
+  })
+
+  it("renders nothing at all when the build is supported", () => {
+    mockMobileVersions = versions(1, 95)
+
+    const { queryByText } = renderGate()
+
+    expect(queryByText(LL.AppUpdate.versionNotSupported())).toBeNull()
+  })
+})

--- a/__tests__/components/app-update-refetch.spec.tsx
+++ b/__tests__/components/app-update-refetch.spec.tsx
@@ -22,10 +22,6 @@ jest.mock("@app/i18n/i18n-react", () => ({
   useI18nContext: () => ({ LL: i18nObject("en") }),
 }))
 
-jest.mock("@app/components/contact-modal", () => ({
-  openWhatsAppAction: jest.fn(),
-}))
-
 jest.mock("@app/components/version", () => ({
   VersionComponent: () => null,
 }))

--- a/__tests__/components/app-update-refetch.spec.tsx
+++ b/__tests__/components/app-update-refetch.spec.tsx
@@ -1,0 +1,122 @@
+// End-to-end version of the foreground re-check: a real Apollo link with two
+// sequential responses, so what is asserted is that a changed server payload
+// actually reaches the gate — not merely that refetch() was called on a
+// hand-mocked hook.
+import * as React from "react"
+import { AppState } from "react-native"
+import { createTheme, ThemeProvider } from "@rneui/themed"
+import { MockedProvider } from "@apollo/client/testing"
+import { render, act, waitFor } from "@testing-library/react-native"
+
+import { i18nObject } from "../../app/i18n/i18n-util"
+import { loadLocale } from "../../app/i18n/i18n-util.sync"
+
+jest.mock("react-native-device-info", () => ({
+  getBuildNumber: () => "89",
+  getReadableVersion: () => "0.6.6.89",
+  // The gate only governs this bundle — see GATED_BUNDLE_ID.
+  getBundleId: () => "com.lnflash",
+}))
+
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({ LL: i18nObject("en") }),
+}))
+
+jest.mock("@app/components/contact-modal", () => ({
+  openWhatsAppAction: jest.fn(),
+}))
+
+jest.mock("@app/components/version", () => ({
+  VersionComponent: () => null,
+}))
+
+jest.mock("../../app/utils/toast", () => ({
+  toastShow: jest.fn(),
+}))
+
+jest.mock("react-native-modal", () => {
+  const ReactActual = jest.requireActual("react")
+  const { View } = jest.requireActual("react-native")
+  return {
+    __esModule: true,
+    default: ({
+      isVisible,
+      children,
+    }: {
+      isVisible: boolean
+      children: React.ReactNode
+    }) => (isVisible ? ReactActual.createElement(View, null, children) : null),
+  }
+})
+
+import { MobileUpdateDocument } from "../../app/graphql/generated"
+import {
+  AppUpdate,
+  AppUpdateGate,
+  AppUpdateProvider,
+} from "../../app/components/app-update/app-update"
+
+loadLocale("en")
+const LL = i18nObject("en")
+
+// The device under test runs build 89 (jest defaults Platform.OS to ios).
+const mobileVersionsResponse = (minSupported: number, currentSupported: number) => ({
+  request: { query: MobileUpdateDocument },
+  result: {
+    data: {
+      mobileVersions: [
+        { platform: "android", currentSupported, minSupported },
+        { platform: "ios", currentSupported, minSupported },
+      ],
+    },
+  },
+})
+
+describe("app update against a real Apollo link", () => {
+  it("blocks the user when the foreground re-fetch raises minSupported past this build", async () => {
+    const addEventListener = jest.spyOn(AppState, "addEventListener")
+
+    const { queryByText } = render(
+      <MockedProvider
+        addTypename={false}
+        mocks={[
+          // first load: an update exists but is optional
+          mobileVersionsResponse(1, 95),
+          // re-fetch after the app is foregrounded: the floor was raised
+          mobileVersionsResponse(95, 96),
+        ]}
+      >
+        <ThemeProvider theme={createTheme({})}>
+          <AppUpdateProvider>
+            <AppUpdateGate />
+            <AppUpdate />
+          </AppUpdateProvider>
+        </ThemeProvider>
+      </MockedProvider>,
+    )
+
+    // The first payload landed: soft banner, no block.
+    await waitFor(() => expect(queryByText(LL.HomeScreen.updateAvailable())).toBeTruthy())
+    expect(queryByText(LL.AppUpdate.versionNotSupported())).toBeNull()
+
+    const changeCalls = addEventListener.mock.calls.filter(
+      ([event]) => event === "change",
+    )
+    // Both components are served by one provider, so there is exactly one
+    // subscription and one AppState listener for the whole tree.
+    expect(changeCalls).toHaveLength(1)
+    const handler = changeCalls[0][1] as (state: string) => void
+
+    await act(async () => {
+      handler("active")
+    })
+
+    // The second payload has to reach `required`, otherwise the re-check is
+    // decorative and a raised floor never lands on a resident app.
+    await waitFor(() =>
+      expect(queryByText(LL.AppUpdate.versionNotSupported())).toBeTruthy(),
+    )
+    expect(queryByText(LL.AppUpdate.updateMandatory())).toBeTruthy()
+    expect(queryByText(LL.HomeScreen.updateAvailable())).toBeNull()
+  })
+})

--- a/__tests__/components/app-update-render.spec.tsx
+++ b/__tests__/components/app-update-render.spec.tsx
@@ -1,0 +1,449 @@
+import * as React from "react"
+import { AppState, Linking } from "react-native"
+import DeviceInfo from "react-native-device-info"
+import { createTheme, ThemeProvider } from "@rneui/themed"
+import { render, fireEvent, act } from "@testing-library/react-native"
+
+import { i18nObject } from "../../app/i18n/i18n-util"
+import { loadLocale } from "../../app/i18n/i18n-util.sync"
+
+// Driven per-test: what the mobileVersions query returns.
+let mockMobileVersions: unknown
+const mockRefetch = jest.fn().mockResolvedValue({})
+
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useMobileUpdateQuery: () => ({
+    data: { mobileVersions: mockMobileVersions },
+    refetch: mockRefetch,
+  }),
+}))
+
+// Driven per-test: which of the two iOS apps this binary is. The served
+// mobileVersions payload has one "ios" entry but two App Store records back it
+// (com.lnflash and com.flashapp.alt), so the gate is scoped to one bundle.
+let mockBundleId = "com.lnflash"
+
+// The device under test runs build 89 (jest defaults Platform.OS to ios).
+jest.mock("react-native-device-info", () => ({
+  getBuildNumber: () => "89",
+  getReadableVersion: () => "0.6.6.89",
+  getBundleId: () => mockBundleId,
+}))
+
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({ LL: i18nObject("en") }),
+}))
+
+// The gate's second escape hatch. Module-scope so the specs can assert on it —
+// a mock nobody asserts on lets a regression that unwires the button ship green.
+jest.mock("@app/components/contact-modal", () => ({}))
+
+jest.mock("@app/components/version", () => ({
+  VersionComponent: () => null,
+}))
+
+const mockToastShow = jest.fn()
+jest.mock("../../app/utils/toast", () => ({
+  toastShow: (...args: unknown[]) => mockToastShow(...args),
+}))
+
+// Props handed to react-native-modal, so the suite can pin the ones that are
+// load-bearing on Android (coverScreen) rather than only what renders.
+const mockModalProps: Record<string, unknown>[] = []
+
+// react-native-modal drives visibility natively; flatten it so the modal's
+// children render inline exactly when isVisible is true.
+jest.mock("react-native-modal", () => {
+  const ReactActual = jest.requireActual("react")
+  const { View } = jest.requireActual("react-native")
+  return {
+    __esModule: true,
+    default: (props: { isVisible: boolean; children: React.ReactNode }) => {
+      mockModalProps.push(props)
+      return props.isVisible
+        ? ReactActual.createElement(View, null, props.children)
+        : null
+    },
+  }
+})
+
+import {
+  AppUpdate,
+  AppUpdateGate,
+  AppUpdateProvider,
+} from "../../app/components/app-update/app-update"
+
+loadLocale("en")
+const LL = i18nObject("en")
+
+const versions = (minSupported: number, currentSupported: number) => [
+  {
+    __typename: "MobileVersions",
+    platform: "android",
+    currentSupported,
+    minSupported,
+  },
+  {
+    __typename: "MobileVersions",
+    platform: "ios",
+    currentSupported,
+    minSupported,
+  },
+]
+
+const wrap = (component: React.ReactElement) => (
+  <ThemeProvider theme={createTheme({})}>
+    <AppUpdateProvider>{component}</AppUpdateProvider>
+  </ThemeProvider>
+)
+
+const renderWithTheme = (component: React.ReactElement) => {
+  const result = render(wrap(component))
+
+  return {
+    ...result,
+    // Re-runs the (mocked) version query, so a test can change what the server
+    // returns mid-flight and assert the UI follows.
+    rerender: (next: React.ReactElement) => result.rerender(wrap(next)),
+  }
+}
+
+const foregroundHandler = (spy: jest.SpyInstance) => {
+  const changeCalls = spy.mock.calls.filter(([event]) => event === "change")
+  // One listener for the whole tree — the gate and the banner share a single
+  // AppUpdateProvider rather than each subscribing to their own copy.
+  expect(changeCalls).toHaveLength(1)
+  return changeCalls[0][1] as (state: string) => void
+}
+
+describe("AppUpdate (home banner)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockModalProps.length = 0
+    mockBundleId = "com.lnflash"
+  })
+
+  it("renders nothing when the build is current", () => {
+    mockMobileVersions = versions(1, 89)
+    const { queryByText } = renderWithTheme(<AppUpdate />)
+
+    expect(queryByText(LL.HomeScreen.updateAvailable())).toBeNull()
+  })
+
+  it("renders nothing while versions have not loaded", () => {
+    mockMobileVersions = undefined
+    const { queryByText } = renderWithTheme(<AppUpdate />)
+
+    expect(queryByText(LL.HomeScreen.updateAvailable())).toBeNull()
+  })
+
+  it("shows the update-available banner and opens the store on tap", () => {
+    mockMobileVersions = versions(1, 95)
+    const openURL = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined)
+
+    const { getByText } = renderWithTheme(<AppUpdate />)
+
+    fireEvent.press(getByText(LL.HomeScreen.updateAvailable()))
+    expect(openURL).toHaveBeenCalledTimes(1)
+    expect(openURL.mock.calls[0][0]).toContain("apple")
+  })
+
+  it("toasts when the store link cannot be opened from the banner", async () => {
+    mockMobileVersions = versions(1, 95)
+    jest
+      .spyOn(Linking, "openURL")
+      .mockRejectedValue(new Error("no activity found to handle intent"))
+    jest.spyOn(console, "error").mockImplementation(() => {})
+
+    const { getByText } = renderWithTheme(<AppUpdate />)
+
+    await act(async () => {
+      fireEvent.press(getByText(LL.HomeScreen.updateAvailable()))
+    })
+
+    // Nothing is covering the screen on this path, so a toast is reachable.
+    expect(mockToastShow).toHaveBeenCalledTimes(1)
+  })
+
+  it("hides the banner when the update is required — the gate's modal owns it", () => {
+    mockMobileVersions = versions(95, 96)
+    const { queryByText } = renderWithTheme(<AppUpdate />)
+
+    expect(queryByText(LL.HomeScreen.updateAvailable())).toBeNull()
+  })
+
+  it("shows the banner once the foreground re-check raises currentSupported", () => {
+    mockMobileVersions = versions(1, 89)
+    const addEventListener = jest.spyOn(AppState, "addEventListener")
+
+    const { queryByText, rerender } = renderWithTheme(<AppUpdate />)
+    expect(queryByText(LL.HomeScreen.updateAvailable())).toBeNull()
+
+    const handler = foregroundHandler(addEventListener)
+
+    // A release lands while the app sits in the background.
+    mockMobileVersions = versions(1, 95)
+    act(() => handler("active"))
+    expect(mockRefetch).toHaveBeenCalledTimes(1)
+
+    rerender(<AppUpdate />)
+    expect(queryByText(LL.HomeScreen.updateAvailable())).toBeTruthy()
+  })
+})
+
+describe("AppUpdateGate (blocking modal)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockModalProps.length = 0
+    mockBundleId = "com.lnflash"
+  })
+
+  it("renders nothing when the build is supported", () => {
+    mockMobileVersions = versions(1, 95)
+    const { queryByText } = renderWithTheme(<AppUpdateGate />)
+
+    expect(queryByText(LL.AppUpdate.versionNotSupported())).toBeNull()
+  })
+
+  it("shows the mandatory-update modal when the build is below minSupported", () => {
+    mockMobileVersions = versions(95, 96)
+    const { getByText } = renderWithTheme(<AppUpdateGate />)
+
+    expect(getByText(LL.AppUpdate.versionNotSupported())).toBeTruthy()
+    expect(getByText(LL.AppUpdate.updateMandatory())).toBeTruthy()
+  })
+
+  it("renders inline (coverScreen={false}) so Fabric on Android cannot strand the user", () => {
+    mockMobileVersions = versions(95, 96)
+    renderWithTheme(<AppUpdateGate />)
+
+    // RCTModalHostView wrongly measures the flex:1 content host under the New
+    // Architecture (#545). This modal has no dismiss and swallows the hardware
+    // back button, so the native host path would leave a blank, frozen screen.
+    expect(mockModalProps).not.toHaveLength(0)
+    mockModalProps.forEach((props) => expect(props.coverScreen).toBe(false))
+  })
+
+  it("opens the store from the modal's update button", () => {
+    mockMobileVersions = versions(95, 96)
+    const openURL = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined)
+
+    const { getByText, queryByText } = renderWithTheme(<AppUpdateGate />)
+
+    // The only escape from the blocking gate — a regression here strands
+    // every hard-blocked user.
+    fireEvent.press(getByText(LL.AppUpdate.tapHereUpdate()))
+
+    expect(openURL).toHaveBeenCalledTimes(1)
+    expect(openURL.mock.calls[0][0]).toContain("apple")
+    expect(queryByText(LL.AppUpdate.couldNotOpenStore())).toBeNull()
+  })
+
+  it("surfaces the failure inside the modal when the store link cannot be opened", async () => {
+    mockMobileVersions = versions(95, 96)
+    jest
+      .spyOn(Linking, "openURL")
+      .mockRejectedValue(new Error("no activity found to handle intent"))
+    jest.spyOn(console, "error").mockImplementation(() => {})
+
+    const { getByText, queryByText } = renderWithTheme(<AppUpdateGate />)
+
+    expect(queryByText(LL.AppUpdate.couldNotOpenStore())).toBeNull()
+
+    await act(async () => {
+      fireEvent.press(getByText(LL.AppUpdate.tapHereUpdate()))
+    })
+
+    // A toast is dropped while a modal is up (FIXME in utils/toast), which on
+    // this path would leave the tap a silent no-op with no way out.
+    expect(getByText(LL.AppUpdate.couldNotOpenStore())).toBeTruthy()
+    expect(mockToastShow).not.toHaveBeenCalled()
+  })
+
+  it("opens support from the modal, carrying the blocked build's version", async () => {
+    mockMobileVersions = versions(95, 96)
+    const openURL = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined)
+
+    const { getByText } = renderWithTheme(<AppUpdateGate />)
+
+    // Way out #2 of a modal with no dismiss, and the one couldNotOpenStore
+    // points users at when the store link fails. Support needs the OS and build
+    // number from a user whose app is the thing refusing to show them anything.
+    await act(async () => {
+      fireEvent.press(getByText(LL.AppUpdate.contactSupport()))
+    })
+
+    const mailto = openURL.mock.calls.map(String).find((url) => url.startsWith("mailto:"))
+    expect(mailto).toBeDefined()
+    expect(mailto).toContain("support@getflash.io")
+    // The body carries what a hard-blocked user cannot look up themselves.
+    expect(decodeURIComponent(mailto as string)).toContain(
+      DeviceInfo.getReadableVersion(),
+    )
+    expect(decodeURIComponent(mailto as string)).toContain("iOS")
+  })
+
+  it("still reaches support after the store link fails", async () => {
+    mockMobileVersions = versions(95, 96)
+    jest
+      .spyOn(Linking, "openURL")
+      .mockRejectedValue(new Error("no activity found to handle intent"))
+    jest.spyOn(console, "error").mockImplementation(() => {})
+
+    const { getByText } = renderWithTheme(<AppUpdateGate />)
+
+    await act(async () => {
+      fireEvent.press(getByText(LL.AppUpdate.tapHereUpdate()))
+    })
+
+    // couldNotOpenStore tells the user to tap Contact Support; the button it
+    // names has to still work once the inline error has rendered.
+    expect(getByText(LL.AppUpdate.couldNotOpenStore())).toBeTruthy()
+    fireEvent.press(getByText(LL.AppUpdate.contactSupport()))
+
+    const mailto = (Linking.openURL as jest.Mock).mock.calls
+      .map(String)
+      .find((url) => url.startsWith("mailto:"))
+    expect(mailto).toBeDefined()
+    expect(decodeURIComponent(mailto as string)).toContain(
+      DeviceInfo.getReadableVersion(),
+    )
+  })
+
+  it("renders the support address when the mail composer will not open", async () => {
+    mockMobileVersions = versions(95, 96)
+    jest.spyOn(Linking, "openURL").mockRejectedValue(new Error("no mail client"))
+    jest.spyOn(console, "error").mockImplementation(() => {})
+
+    const { getByText } = renderWithTheme(<AppUpdateGate />)
+
+    await act(async () => {
+      fireEvent.press(getByText(LL.AppUpdate.contactSupport()))
+    })
+
+    // Both escapes are gone at this point, so the address has to be readable
+    // straight off a modal that cannot be dismissed.
+    expect(
+      getByText(LL.AppUpdate.couldNotOpenSupport({ email: "support@getflash.io" })),
+    ).toBeTruthy()
+  })
+
+  it("re-checks versions when the app returns to the foreground", () => {
+    mockMobileVersions = versions(1, 89)
+    const addEventListener = jest.spyOn(AppState, "addEventListener")
+
+    const { unmount } = renderWithTheme(<AppUpdateGate />)
+
+    const handler = foregroundHandler(addEventListener)
+
+    act(() => handler("active"))
+    expect(mockRefetch).toHaveBeenCalledTimes(1)
+
+    // background transitions must not trigger a refetch
+    act(() => handler("background"))
+    expect(mockRefetch).toHaveBeenCalledTimes(1)
+
+    unmount()
+  })
+
+  it("blocks once the foreground re-check returns a raised minSupported", () => {
+    mockMobileVersions = versions(1, 89)
+    const addEventListener = jest.spyOn(AppState, "addEventListener")
+
+    const { queryByText, rerender } = renderWithTheme(<AppUpdateGate />)
+    expect(queryByText(LL.AppUpdate.versionNotSupported())).toBeNull()
+
+    const handler = foregroundHandler(addEventListener)
+
+    // The incident lever: the floor is raised above this build while the app
+    // sits in the background. Refetching is only useful if the new numbers
+    // actually reach `required`.
+    mockMobileVersions = versions(95, 96)
+    act(() => handler("active"))
+    expect(mockRefetch).toHaveBeenCalledTimes(1)
+
+    rerender(<AppUpdateGate />)
+    expect(queryByText(LL.AppUpdate.versionNotSupported())).toBeTruthy()
+    expect(queryByText(LL.AppUpdate.updateMandatory())).toBeTruthy()
+  })
+})
+
+describe("bundle scoping", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockModalProps.length = 0
+    mockBundleId = "com.lnflash"
+  })
+
+  // The served payload has ONE "ios" entry, but two App Store Connect records
+  // ship from this JS — com.lnflash and com.flashapp.alt — and their build
+  // numbers are independent counters (fastlane/Fastfile resolves alt's from
+  // latest_testflight_build_number(app_identifier: "com.flashapp.alt")). Using
+  // the documented incident lever on the main app would otherwise hard-block
+  // alt users whose unrelated counter happens to sit under the same floor.
+  it("does not block the alt bundle on the main app's floor", () => {
+    mockMobileVersions = versions(95, 96)
+    mockBundleId = "com.flashapp.alt"
+
+    const { queryByText } = renderWithTheme(<AppUpdateGate />)
+
+    expect(queryByText(LL.AppUpdate.versionNotSupported())).toBeNull()
+  })
+
+  it("does not nudge the alt bundle on the main app's currentSupported", () => {
+    mockMobileVersions = versions(1, 95)
+    mockBundleId = "com.flashapp.alt"
+
+    const { queryByText } = renderWithTheme(<AppUpdate />)
+
+    expect(queryByText(LL.HomeScreen.updateAvailable())).toBeNull()
+  })
+
+  it("still blocks the bundle the served number is sized for", () => {
+    mockMobileVersions = versions(95, 96)
+    mockBundleId = "com.lnflash"
+
+    const { getByText } = renderWithTheme(<AppUpdateGate />)
+
+    expect(getByText(LL.AppUpdate.versionNotSupported())).toBeTruthy()
+  })
+})
+
+describe("AppUpdateProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockModalProps.length = 0
+    mockBundleId = "com.lnflash"
+  })
+
+  it("serves the gate and the banner from a single version check", () => {
+    mockMobileVersions = versions(1, 95)
+    const addEventListener = jest.spyOn(AppState, "addEventListener")
+
+    const { getByText, queryByText } = renderWithTheme(
+      <>
+        <AppUpdateGate />
+        <AppUpdate />
+      </>,
+    )
+
+    // One subscription, one listener — two views of the same fact.
+    foregroundHandler(addEventListener)
+    expect(getByText(LL.HomeScreen.updateAvailable())).toBeTruthy()
+    expect(queryByText(LL.AppUpdate.versionNotSupported())).toBeNull()
+  })
+
+  it("throws when a consumer is mounted without the provider", () => {
+    mockMobileVersions = versions(95, 96)
+    jest.spyOn(console, "error").mockImplementation(() => {})
+
+    expect(() =>
+      render(
+        <ThemeProvider theme={createTheme({})}>
+          <AppUpdateGate />
+        </ThemeProvider>,
+      ),
+    ).toThrow(/AppUpdateProvider/)
+  })
+})

--- a/__tests__/components/app-update-render.spec.tsx
+++ b/__tests__/components/app-update-render.spec.tsx
@@ -35,10 +35,6 @@ jest.mock("@app/i18n/i18n-react", () => ({
   useI18nContext: () => ({ LL: i18nObject("en") }),
 }))
 
-// The gate's second escape hatch. Module-scope so the specs can assert on it —
-// a mock nobody asserts on lets a regression that unwires the button ship green.
-jest.mock("@app/components/contact-modal", () => ({}))
-
 jest.mock("@app/components/version", () => ({
   VersionComponent: () => null,
 }))
@@ -164,6 +160,14 @@ describe("AppUpdate (home banner)", () => {
 
     // Nothing is covering the screen on this path, so a toast is reachable.
     expect(mockToastShow).toHaveBeenCalledTimes(1)
+
+    const [{ message, currentTranslation }] = mockToastShow.mock.calls[0]
+    // utils/toast falls back to i18nObject("en") when currentTranslation is
+    // absent, so leaving it off ships an English toast to every locale.
+    expect(currentTranslation).toBeDefined()
+    // The banner has no Contact Support button, so it must not borrow the
+    // gate's copy, which tells the user to tap one.
+    expect(message(LL)).toBe(LL.AppUpdate.couldNotOpenStoreBanner())
   })
 
   it("hides the banner when the update is required — the gate's modal owns it", () => {

--- a/__tests__/components/app-update.spec.tsx
+++ b/__tests__/components/app-update.spec.tsx
@@ -77,3 +77,28 @@ describe("testing isUpdateAvailableOrRequired with android abi", () => {
     expect(result.available).toBe(false)
   })
 })
+
+describe("testing isUpdateAvailableOrRequired with missing or unknown data", () => {
+  it("reports nothing when mobileVersions has not loaded", () => {
+    for (const mobileVersions of [null, undefined]) {
+      const result = isUpdateAvailableOrRequired({
+        buildNumber: 150,
+        mobileVersions,
+        OS,
+      })
+      expect(result.required).toBe(false)
+      expect(result.available).toBe(false)
+    }
+  })
+
+  it("reports nothing for a platform missing from the response", () => {
+    const result = isUpdateAvailableOrRequired({
+      buildNumber: 150,
+      mobileVersions,
+      OS: "windows" as Platform["OS"],
+    })
+    // NaN comparisons are false on purpose — never block on bad data.
+    expect(result.required).toBe(false)
+    expect(result.available).toBe(false)
+  })
+})

--- a/__tests__/screens/helper.tsx
+++ b/__tests__/screens/helper.tsx
@@ -14,21 +14,33 @@ import TypesafeI18n from "@app/i18n/i18n-react"
 import { detectDefaultLocale } from "@app/utils/locale-detector"
 import { Provider } from "react-redux"
 import { store } from "@app/store/redux"
+import { AppUpdateProvider } from "@app/components/app-update/app-update"
 
 const Stack = createStackNavigator()
 
-export const ContextForScreen: React.FC<PropsWithChildren> = ({ children }) => (
+type Props = PropsWithChildren<{
+  // Lets a spec swap in a different GraphQL payload — e.g. mobileVersions above
+  // this device's build number, which the shared mocks deliberately are not.
+  mocks?: typeof mocks
+}>
+
+export const ContextForScreen: React.FC<Props> = ({
+  children,
+  mocks: mocksOverride = mocks,
+}) => (
   <ThemeProvider theme={theme}>
     <NavigationContainer>
       <Stack.Navigator>
         <Stack.Screen name="Home">
           {() => (
             <Provider store={store}>
-              <MockedProvider mocks={mocks} cache={createCache()}>
+              <MockedProvider mocks={mocksOverride} cache={createCache()}>
                 <StoryScreen>
                   <TypesafeI18n locale={detectDefaultLocale()}>
                     <IsAuthedContextProvider value={true}>
-                      {children}
+                      {/* app.tsx mounts this above the navigator, so every
+                          screen has the shared version check available. */}
+                      <AppUpdateProvider>{children}</AppUpdateProvider>
                     </IsAuthedContextProvider>
                   </TypesafeI18n>
                 </StoryScreen>

--- a/__tests__/screens/home-app-update.spec.tsx
+++ b/__tests__/screens/home-app-update.spec.tsx
@@ -1,0 +1,62 @@
+// The soft "update available" banner is only useful if it is mounted on the
+// home screen. app-update-render.spec.tsx renders <AppUpdate /> in isolation and
+// would pass identically if the component were mounted nowhere, so this spec
+// goes through the real HomeScreen instead: delete the <AppUpdate /> line from
+// home-screen.tsx and this fails.
+import React from "react"
+
+import { render, waitFor } from "@testing-library/react-native"
+
+import { MobileUpdateDocument } from "@app/graphql/generated"
+import sharedMocks from "@app/graphql/mocks"
+
+import { i18nObject } from "../../app/i18n/i18n-util"
+import { loadLocale } from "../../app/i18n/i18n-util.sync"
+import { HomeScreen } from "../../app/screens/home-screen"
+import { ContextForScreen } from "./helper"
+
+loadLocale("en")
+const LL = i18nObject("en")
+
+// __mocks__/react-native-device-info.js reports build 1234 for every screen
+// test, and jest defaults Platform.OS to ios.
+const DEVICE_BUILD = 1234
+
+const mobileVersionsMock = (minSupported: number, currentSupported: number) => [
+  ...sharedMocks.filter((mock) => mock.request.query !== MobileUpdateDocument),
+  {
+    request: { query: MobileUpdateDocument },
+    result: {
+      data: {
+        mobileVersions: [
+          { platform: "android", currentSupported, minSupported },
+          { platform: "ios", currentSupported, minSupported },
+        ],
+      },
+    },
+  },
+]
+
+describe("HomeScreen version banner", () => {
+  it("shows the update-available banner when the served build is newer", async () => {
+    const { getByText } = render(
+      <ContextForScreen mocks={mobileVersionsMock(DEVICE_BUILD - 1, DEVICE_BUILD + 1)}>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+
+    await waitFor(() => expect(getByText(LL.HomeScreen.updateAvailable())).toBeTruthy())
+  })
+
+  it("shows nothing when this build is already current", async () => {
+    // The negative control: without it the assertion above could pass on a
+    // banner that is always on.
+    const { queryByText } = render(
+      <ContextForScreen mocks={mobileVersionsMock(DEVICE_BUILD - 1, DEVICE_BUILD)}>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+
+    await waitFor(() => expect(queryByText(LL.HomeScreen.updateAvailable())).toBeNull())
+  })
+})

--- a/app/app.tsx
+++ b/app/app.tsx
@@ -43,6 +43,7 @@ import PolyfillCrypto from "react-native-webview-crypto"
 import { ActivityIndicatorProvider } from "./contexts/ActivityIndicatorContext"
 import { BreezProvider } from "./contexts/BreezContext"
 import { ChatContextProvider } from "./screens/chat/chatContext"
+import { AppUpdateBoundary } from "./components/app-update/app-update-boundary"
 import { NotificationsProvider } from "./components/notification"
 import { SafeAreaProvider } from "react-native-safe-area-context"
 import { FlashcardProvider } from "./contexts/Flashcard"
@@ -101,17 +102,24 @@ export const App = () => {
                             <NavigationContainerWrapper>
                               <RootSiblingParent>
                                 <NotificationsProvider>
-                                  <AppStateWrapper />
-                                  <PushNotificationComponent />
-                                  <BreezProvider>
-                                    <FlashcardProvider>
-                                      <InviteDeepLinkHandler>
-                                        <RootStack />
-                                      </InviteDeepLinkHandler>
-                                    </FlashcardProvider>
-                                  </BreezProvider>
-                                  <GaloyToast />
-                                  <NetworkErrorComponent />
+                                  {/* One version check for the whole tree — the
+                                      home-screen banner inside RootStack reads
+                                      it too — and the blocking gate, which the
+                                      boundary pins as the last sibling so paint
+                                      order cannot be broken from here. */}
+                                  <AppUpdateBoundary>
+                                    <AppStateWrapper />
+                                    <PushNotificationComponent />
+                                    <BreezProvider>
+                                      <FlashcardProvider>
+                                        <InviteDeepLinkHandler>
+                                          <RootStack />
+                                        </InviteDeepLinkHandler>
+                                      </FlashcardProvider>
+                                    </BreezProvider>
+                                    <GaloyToast />
+                                    <NetworkErrorComponent />
+                                  </AppUpdateBoundary>
                                 </NotificationsProvider>
                               </RootSiblingParent>
                             </NavigationContainerWrapper>

--- a/app/components/app-update/app-update-boundary.tsx
+++ b/app/components/app-update/app-update-boundary.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+
+import { AppUpdateGate, AppUpdateProvider } from "./app-update"
+
+/**
+ * The app-wide half of the version gate: one shared version check for the whole
+ * tree, plus the blocking modal pinned as the LAST sibling inside it.
+ *
+ * It is a component rather than three lines inlined in `app.tsx` for two
+ * reasons. First, sibling order is load-bearing: the gate's modal renders with
+ * `coverScreen={false}` (RCTModalHostView is broken under Fabric on Android, see
+ * #545), so paint order follows sibling order and anything mounted after the
+ * gate would draw over a block that has no dismiss. Keeping the gate inside this
+ * component means a later edit to `app.tsx` cannot reorder it by accident.
+ * Second, `app.tsx` cannot be rendered under jest — it pulls in Firebase,
+ * reanimated and a pile of native modules at import time — so the wiring is only
+ * testable once it lives somewhere that can be mounted on its own.
+ *
+ * The soft "update available" banner is mounted separately, on the home screen.
+ * The gate lives here so deep-link cold starts that never render Home cannot
+ * bypass it.
+ */
+export const AppUpdateBoundary: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <AppUpdateProvider>
+    {children}
+    <AppUpdateGate />
+  </AppUpdateProvider>
+)

--- a/app/components/app-update/app-update.stories.tsx
+++ b/app/components/app-update/app-update.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { AppUpdate, AppUpdateModal } from "./app-update"
+import { AppUpdate, AppUpdateModal, AppUpdateProvider } from "./app-update"
 import { StoryScreen } from "../../../.storybook/views"
 import { Meta } from "@storybook/react"
 import { MockedProvider } from "@apollo/client/testing"
@@ -82,7 +82,11 @@ export default {
 
 export const UpdateAvailable = () => (
   <MockedProvider mocks={updateAvailable} cache={createCache()}>
-    <AppUpdate />
+    {/* AppUpdate reads the shared version check; in the app the provider is
+        mounted once in app.tsx, above both the gate and the navigator. */}
+    <AppUpdateProvider>
+      <AppUpdate />
+    </AppUpdateProvider>
   </MockedProvider>
 )
 
@@ -97,6 +101,24 @@ export const UpdateRequiredModal = () => {
         <GaloyPrimaryButton onPress={openModal} title="Open Modal" />
 
         <AppUpdateModal isVisible={visible} linkUpgrade={closeModal} />
+      </View>
+    </MockedProvider>
+  )
+}
+
+// The store link can fail to open (an Android device with no Play Store). A
+// toast is swallowed behind a modal, so the gate says so inline instead.
+export const UpdateRequiredModalStoreLinkFailed = () => {
+  const [visible, setVisible] = React.useState(false)
+
+  const openModal = () => setVisible(true)
+  const closeModal = () => setVisible(false)
+  return (
+    <MockedProvider mocks={updateRequired} cache={createCache()}>
+      <View>
+        <GaloyPrimaryButton onPress={openModal} title="Open Modal" />
+
+        <AppUpdateModal isVisible={visible} linkUpgrade={closeModal} openFailed />
       </View>
     </MockedProvider>
   )

--- a/app/components/app-update/app-update.stories.tsx
+++ b/app/components/app-update/app-update.stories.tsx
@@ -90,6 +90,12 @@ export const UpdateAvailable = () => (
   </MockedProvider>
 )
 
+// Stands in for the mail composer the gate opens in the app. Contact Support is
+// one of only two escapes from this modal, so a story that renders it has to
+// wire it — a dead button here would misrepresent the thing being reviewed.
+const logContactSupport = (subject: string, body: string) =>
+  console.log("contactSupport", { subject, body })
+
 export const UpdateRequiredModal = () => {
   const [visible, setVisible] = React.useState(false)
 
@@ -100,14 +106,20 @@ export const UpdateRequiredModal = () => {
       <View>
         <GaloyPrimaryButton onPress={openModal} title="Open Modal" />
 
-        <AppUpdateModal isVisible={visible} linkUpgrade={closeModal} />
+        <AppUpdateModal
+          isVisible={visible}
+          linkUpgrade={closeModal}
+          contactSupport={logContactSupport}
+        />
       </View>
     </MockedProvider>
   )
 }
 
-// The store link can fail to open (an Android device with no Play Store). A
-// toast is swallowed behind a modal, so the gate says so inline instead.
+// The store link can fail to open (an Android device with neither a store app
+// nor a browser that takes the https listing). A toast is swallowed behind a
+// modal, so the gate says so inline instead — and the text it renders points at
+// Contact Support, which is why that button is wired here too.
 export const UpdateRequiredModalStoreLinkFailed = () => {
   const [visible, setVisible] = React.useState(false)
 
@@ -118,7 +130,12 @@ export const UpdateRequiredModalStoreLinkFailed = () => {
       <View>
         <GaloyPrimaryButton onPress={openModal} title="Open Modal" />
 
-        <AppUpdateModal isVisible={visible} linkUpgrade={closeModal} openFailed />
+        <AppUpdateModal
+          isVisible={visible}
+          linkUpgrade={closeModal}
+          contactSupport={logContactSupport}
+          openFailed
+        />
       </View>
     </MockedProvider>
   )

--- a/app/components/app-update/app-update.tsx
+++ b/app/components/app-update/app-update.tsx
@@ -82,13 +82,29 @@ const openSupportEmail = (subject: string, body: string) =>
 export const GATED_BUNDLE_ID = "com.lnflash"
 
 // Resolves true when the store page opened, false when the link could not be
-// handled (an Android device with no Play Store — see the TODO above). Callers
-// decide how to surface the failure: the soft banner can afford a toast, the
-// blocking gate cannot (toastShow is dropped when a modal is already up —
-// documented FIXME in utils/toast) and shows the message inside the modal.
+// handled. Callers decide how to surface the failure: the soft banner can afford
+// a toast, the blocking gate cannot (toastShow is dropped when a modal is
+// already up — documented FIXME in utils/toast) and shows the message inside the
+// modal.
+//
+// Android tries the `market://` scheme first. Only an installed store app claims
+// it (Play Store, and AppGallery for the listings it carries), whereas
+// PLAY_STORE_LINK is an https URL that any browser handles — so going straight
+// to the web link means the store-less device the failure text was written for
+// never reaches the catch, and a hard-blocked user lands on a page they cannot
+// install from with no hint that Contact Support is the way out. The https link
+// stays as the fallback for devices that have a browser but no store app.
 const openInStore = async (): Promise<boolean> => {
   try {
-    // TODO: differentiate between PlayStore and Huawei AppGallery
+    if (!isIos) {
+      try {
+        await Linking.openURL(`market://details?id=${DeviceInfo.getBundleId()}`)
+        return true
+      } catch (err) {
+        // Not fatal on its own — a de-Googled device may still have a browser.
+        console.warn({ err }, "no store app handled market://, trying the web link")
+      }
+    }
     await Linking.openURL(storeLink())
     return true
   } catch (err) {
@@ -171,7 +187,15 @@ export const AppUpdate: React.FC = () => {
   const linkUpgrade = () =>
     openInStore().then((opened) => {
       if (!opened) {
-        toastShow({ message: (translations) => translations.errors.generic() })
+        // Nothing is covering the screen here, so a toast is reachable — but it
+        // has to be the banner's wording, not the gate's: `couldNotOpenStore`
+        // sends the user to a Contact Support button that only exists inside the
+        // blocking modal. `currentTranslation` is what makes the toast render in
+        // the user's locale (utils/toast falls back to English without it).
+        toastShow({
+          message: (translations) => translations.AppUpdate.couldNotOpenStoreBanner(),
+          currentTranslation: LL,
+        })
       }
     })
 
@@ -237,7 +261,11 @@ export const AppUpdateModal = ({
 }: {
   linkUpgrade: () => void
   isVisible: boolean
-  contactSupport?: (subject: string, body: string) => void
+  // Required, not optional: this is one of only two escapes from a modal with no
+  // dismiss, no backdrop press and a swallowed back button. An omitted handler
+  // would compile fine and ship a dead button under text that tells the user to
+  // tap it.
+  contactSupport: (subject: string, body: string) => void
   openFailed?: boolean
   contactFailed?: boolean
 }) => {
@@ -285,7 +313,7 @@ export const AppUpdateModal = ({
         )}
         <GaloySecondaryButton
           buttonStyle={styles.button}
-          onPress={() => contactSupport?.(LL.AppUpdate.versionNotSupported(), message)}
+          onPress={() => contactSupport(LL.AppUpdate.versionNotSupported(), message)}
           title={LL.AppUpdate.contactSupport()}
         />
         {contactFailed && (

--- a/app/components/app-update/app-update.tsx
+++ b/app/components/app-update/app-update.tsx
@@ -2,16 +2,16 @@ import { gql } from "@apollo/client"
 import { useMobileUpdateQuery } from "@app/graphql/generated"
 
 import * as React from "react"
-import { Linking, Platform, Pressable, View } from "react-native"
+import { AppState, Linking, Platform, Pressable, View } from "react-native"
 import DeviceInfo from "react-native-device-info"
 
-import { openWhatsAppAction } from "@app/components/contact-modal"
 import { VersionComponent } from "@app/components/version"
-import { APP_STORE_LINK, PLAY_STORE_LINK } from "@app/config"
+import { APP_STORE_LINK, CONTACT_EMAIL_ADDRESS, PLAY_STORE_LINK } from "@app/config"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { Text, makeStyles, useTheme } from "@rneui/themed"
 import ReactNativeModal from "react-native-modal"
 import { isIos } from "../../utils/helper"
+import { toastShow } from "../../utils/toast"
 import { isUpdateAvailableOrRequired } from "./app-update.logic"
 import { GaloyPrimaryButton } from "../atomic/galoy-primary-button"
 import { GaloySecondaryButton } from "../atomic/galoy-secondary-button"
@@ -26,7 +26,7 @@ gql`
   }
 `
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles(({ colors }) => ({
   bottom: {
     alignItems: "center",
     marginVertical: 16,
@@ -38,59 +38,208 @@ const useStyles = makeStyles(() => ({
     textAlign: "center",
   },
 
+  openFailedText: {
+    color: colors.error,
+    marginBottom: 12,
+    textAlign: "center",
+  },
+
   versionComponent: { flex: 1, justifyContent: "flex-end", marginVertical: 48 },
   main: { flex: 5, justifyContent: "center" },
   button: { marginVertical: 12 },
 }))
 
-export const AppUpdate: React.FC = () => {
-  const styles = useStyles()
-  // const { LL } = useI18nContext()
+const storeLink = () => (isIos ? APP_STORE_LINK : PLAY_STORE_LINK)
 
-  const { data } = useMobileUpdateQuery({ fetchPolicy: "no-cache" })
+// Local on purpose. The gate's other escape is Contact Support, and the shared
+// contact-modal helper points at wa.flashapp.me — which, verified 2026-08-19,
+// returns 200 with zero redirects and no wa.me anywhere: a static "WhatsApp
+// support is temporarily unavailable" page that discards `?text=`. A hard-
+// blocked user needs a channel that works and keeps the build number they
+// cannot look up themselves, so this one composes mail directly rather than
+// changing behavior for every other caller of the shared helper.
+const openSupportEmail = (subject: string, body: string) =>
+  Linking.openURL(
+    `mailto:${CONTACT_EMAIL_ADDRESS}?subject=${encodeURIComponent(
+      subject,
+    )}&body=${encodeURIComponent(body)}`,
+  )
 
-  const buildNumber = Number(DeviceInfo.getBuildNumber())
-  const mobileVersions = data?.mobileVersions
+// The served payload is keyed by *platform*, but we ship two iOS apps off this
+// same JS and the same API: `com.lnflash` and `com.flashapp.alt`. Their build
+// numbers come from independent App Store Connect records — fastlane resolves
+// alt's from `latest_testflight_build_number(app_identifier: "com.flashapp.alt")`
+// and the main lanes from the default record — so one `minSupported` for "ios"
+// cannot be correct for both counters. Using the documented incident lever
+// (raise minBuildNumber to push com.lnflash users off a bad build) would
+// otherwise hard-block every alt user whose independent counter happens to sit
+// below that floor, on a modal with no dismiss.
+//
+// So the gate governs only the bundle whose counter the number is sized for.
+// Android ships a single applicationId (also com.lnflash), so this is a no-op
+// there today and stays correct if an alt flavor is ever added. If the API ever
+// serves a distinct key per bundle, select on that instead and delete this.
+export const GATED_BUNDLE_ID = "com.lnflash"
 
-  const { available, required } = isUpdateAvailableOrRequired({
-    buildNumber,
-    mobileVersions,
-    OS: Platform.OS,
-  })
+// Resolves true when the store page opened, false when the link could not be
+// handled (an Android device with no Play Store — see the TODO above). Callers
+// decide how to surface the failure: the soft banner can afford a toast, the
+// blocking gate cannot (toastShow is dropped when a modal is already up —
+// documented FIXME in utils/toast) and shows the message inside the modal.
+const openInStore = async (): Promise<boolean> => {
+  try {
+    // TODO: differentiate between PlayStore and Huawei AppGallery
+    await Linking.openURL(storeLink())
+    return true
+  } catch (err) {
+    console.error({ err }, `could not open the app store link (${storeLink()})`)
+    return false
+  }
+}
 
-  const openInStore = async () => {
-    if (isIos) {
-      Linking.openURL(APP_STORE_LINK)
-    } else {
-      // TODO: differentiate between PlayStore and Huawei AppGallery
-      Linking.openURL(PLAY_STORE_LINK)
-    }
+// The version numbers are served per-request and this component tree can stay
+// resident for days, so both the banner and the gate must re-check whenever the
+// app returns to the foreground — otherwise a raised minBuildNumber (incident
+// lever) or a bumped currentSupported (routine release) only reaches users who
+// fully restart the app.
+const useMobileUpdateWithForegroundRefetch = () => {
+  const { data, refetch } = useMobileUpdateQuery({ fetchPolicy: "no-cache" })
+
+  React.useEffect(() => {
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state === "active") {
+        refetch().catch(() => {})
+      }
+    })
+    return () => subscription.remove()
+  }, [refetch])
+
+  // After every hook, so the early return never changes the hook order.
+  // See GATED_BUNDLE_ID: a served "ios" number addresses one App Store record,
+  // and this binary may be the other app.
+  if (DeviceInfo.getBundleId() !== GATED_BUNDLE_ID) {
+    return { available: false, required: false }
   }
 
+  const buildNumber = Number(DeviceInfo.getBuildNumber())
+
+  return isUpdateAvailableOrRequired({
+    buildNumber,
+    mobileVersions: data?.mobileVersions,
+    OS: Platform.OS,
+  })
+}
+
+type AppUpdateStatus = {
+  available: boolean
+  required: boolean
+}
+
+const AppUpdateContext = React.createContext<AppUpdateStatus | undefined>(undefined)
+
+// "Am I blocked?" is one fact with one source. The gate (blocking modal) and the
+// banner (soft nudge) are two views of it, so the query subscription and the
+// AppState listener live here once instead of once per consumer — otherwise the
+// two can drift apart on a later edit.
+export const AppUpdateProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const { available, required } = useMobileUpdateWithForegroundRefetch()
+
+  const status = React.useMemo(() => ({ available, required }), [available, required])
+
+  return <AppUpdateContext.Provider value={status}>{children}</AppUpdateContext.Provider>
+}
+
+const useAppUpdateStatus = (): AppUpdateStatus => {
+  const status = React.useContext(AppUpdateContext)
+
+  if (!status) {
+    throw new Error("useAppUpdateStatus must be used within an <AppUpdateProvider>")
+  }
+
+  return status
+}
+
+// Soft "update available" banner, mounted on the home screen. The blocking
+// modal is owned by AppUpdateGate (mounted globally in app.tsx) so that
+// deep-link cold starts which never render Home can't bypass the gate.
+export const AppUpdate: React.FC = () => {
+  const styles = useStyles()
+  const { LL } = useI18nContext()
+
+  const { available, required } = useAppUpdateStatus()
+
   const linkUpgrade = () =>
-    openInStore().catch((err) => {
-      console.log({ err }, "error app link on link")
+    openInStore().then((opened) => {
+      if (!opened) {
+        toastShow({ message: (translations) => translations.errors.generic() })
+      }
     })
 
-  if (available) {
+  // required implies available (build < min <= current); the gate's modal
+  // already covers the screen, so the banner only handles the soft case.
+  if (available && !required) {
     return (
       <View style={styles.bottom}>
         <Pressable onPress={linkUpgrade}>
-          {/* <Text style={styles.lightningText}>{LL.HomeScreen.updateAvailable()}</Text> */}
+          <Text style={styles.lightningText}>{LL.HomeScreen.updateAvailable()}</Text>
         </Pressable>
       </View>
     )
   }
 
-  return <AppUpdateModal isVisible={required} linkUpgrade={linkUpgrade} />
+  return null
+}
+
+// Blocking "update mandatory" gate. Mounted once, alongside the navigation
+// container, so it covers every route — including deep-link cold starts.
+export const AppUpdateGate: React.FC = () => {
+  const { required } = useAppUpdateStatus()
+
+  // A hard-blocked user has exactly two ways out of this modal, and both are
+  // buttons here. A toast would be swallowed behind the modal, so failures are
+  // rendered inline instead of leaving the tap a silent no-op.
+  const [openFailed, setOpenFailed] = React.useState(false)
+  const [contactFailed, setContactFailed] = React.useState(false)
+
+  const linkUpgrade = React.useCallback(
+    () => openInStore().then((opened) => setOpenFailed(!opened)),
+    [],
+  )
+
+  const contactSupport = React.useCallback(
+    (subject: string, body: string) =>
+      openSupportEmail(subject, body)
+        .then(() => setContactFailed(false))
+        .catch((err) => {
+          console.error({ err }, "could not open the support email composer")
+          setContactFailed(true)
+        }),
+    [],
+  )
+
+  return (
+    <AppUpdateModal
+      isVisible={required}
+      linkUpgrade={linkUpgrade}
+      contactSupport={contactSupport}
+      openFailed={openFailed}
+      contactFailed={contactFailed}
+    />
+  )
 }
 
 export const AppUpdateModal = ({
   linkUpgrade,
   isVisible,
+  contactSupport,
+  openFailed = false,
+  contactFailed = false,
 }: {
   linkUpgrade: () => void
   isVisible: boolean
+  contactSupport?: (subject: string, body: string) => void
+  openFailed?: boolean
+  contactFailed?: boolean
 }) => {
   const {
     theme: { colors },
@@ -109,6 +258,19 @@ export const AppUpdateModal = ({
       isVisible={isVisible}
       backdropColor={colors.white}
       backdropOpacity={0.92}
+      /**
+       * Render inline instead of through the native modal host. RCTModalHostView
+       * is broken under Fabric/New Architecture on Android (see #545): it
+       * wrongly measures the flex:1 content container, so the bottom-pinned
+       * spacer below (versionComponent) pushes this content off-screen while the
+       * full-screen backdrop keeps capturing touches. This modal has no dismiss,
+       * no backdrop press and swallows the hardware back button, so a wrongly
+       * measured host would strand every hard-blocked user on a blank screen.
+       * coverScreen={false} takes react-native-modal's inline render
+       * path and measures correctly — note this makes paint order follow sibling
+       * order, which is why <AppUpdateGate /> is mounted last in app.tsx.
+       */
+      coverScreen={false}
     >
       <View style={styles.main}>
         <Text style={styles.lightningText}>{LL.AppUpdate.versionNotSupported()}</Text>
@@ -118,11 +280,21 @@ export const AppUpdateModal = ({
           onPress={linkUpgrade}
           title={LL.AppUpdate.tapHereUpdate()}
         />
+        {openFailed && (
+          <Text style={styles.openFailedText}>{LL.AppUpdate.couldNotOpenStore()}</Text>
+        )}
         <GaloySecondaryButton
           buttonStyle={styles.button}
-          onPress={() => openWhatsAppAction(message)}
+          onPress={() => contactSupport?.(LL.AppUpdate.versionNotSupported(), message)}
           title={LL.AppUpdate.contactSupport()}
         />
+        {contactFailed && (
+          // Last resort: if even the mail composer will not open, the address
+          // has to be readable off the screen — this modal has no dismiss.
+          <Text style={styles.openFailedText}>
+            {LL.AppUpdate.couldNotOpenSupport({ email: CONTACT_EMAIL_ADDRESS })}
+          </Text>
+        )}
       </View>
       <View style={styles.versionComponent}>
         <VersionComponent />

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -1699,6 +1699,8 @@ const en: BaseTranslation = {
     updateMandatory: "Update is mandatory",
     tapHereUpdate: "Tap here to update now",
     contactSupport: "Contact Support",
+    couldNotOpenStore: "Couldn't open the app store. Tap Contact Support below for help.",
+    couldNotOpenSupport: "Couldn't open your email app. Please email {email: string} directly.",
   },
   RefundFlow: {
     refundListTitle: "Unclaimed Deposits",

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -1700,6 +1700,8 @@ const en: BaseTranslation = {
     tapHereUpdate: "Tap here to update now",
     contactSupport: "Contact Support",
     couldNotOpenStore: "Couldn't open the app store. Tap Contact Support below for help.",
+    couldNotOpenStoreBanner:
+      "Couldn't open the app store. You can keep using Flash and update later.",
     couldNotOpenSupport: "Couldn't open your email app. Please email {email: string} directly.",
   },
   RefundFlow: {

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -5662,6 +5662,15 @@ type RootTranslation = {
 		 * C​o​n​t​a​c​t​ ​S​u​p​p​o​r​t
 		 */
 		contactSupport: string
+		/**
+		 * C​o​u​l​d​n​'​t​ ​o​p​e​n​ ​t​h​e​ ​a​p​p​ ​s​t​o​r​e​.​ ​T​a​p​ ​C​o​n​t​a​c​t​ ​S​u​p​p​o​r​t​ ​b​e​l​o​w​ ​f​o​r​ ​h​e​l​p​.
+		 */
+		couldNotOpenStore: string
+		/**
+		 * C​o​u​l​d​n​'​t​ ​o​p​e​n​ ​y​o​u​r​ ​e​m​a​i​l​ ​a​p​p​.​ ​P​l​e​a​s​e​ ​e​m​a​i​l​ ​{​e​m​a​i​l​}​ ​d​i​r​e​c​t​l​y​.
+		 * @param {string} email
+		 */
+		couldNotOpenSupport: RequiredParams<'email'>
 	}
 	RefundFlow: {
 		/**
@@ -11790,6 +11799,14 @@ export type TranslationFunctions = {
 		 * Contact Support
 		 */
 		contactSupport: () => LocalizedString
+		/**
+		 * Couldn't open the app store. Tap Contact Support below for help.
+		 */
+		couldNotOpenStore: () => LocalizedString
+		/**
+		 * Couldn't open your email app. Please email {email} directly.
+		 */
+		couldNotOpenSupport: (arg: { email: string }) => LocalizedString
 	}
 	RefundFlow: {
 		/**

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -5667,6 +5667,10 @@ type RootTranslation = {
 		 */
 		couldNotOpenStore: string
 		/**
+		 * C​o​u​l​d​n​'​t​ ​o​p​e​n​ ​t​h​e​ ​a​p​p​ ​s​t​o​r​e​.​ ​Y​o​u​ ​c​a​n​ ​k​e​e​p​ ​u​s​i​n​g​ ​F​l​a​s​h​ ​a​n​d​ ​u​p​d​a​t​e​ ​l​a​t​e​r​.
+		 */
+		couldNotOpenStoreBanner: string
+		/**
 		 * C​o​u​l​d​n​'​t​ ​o​p​e​n​ ​y​o​u​r​ ​e​m​a​i​l​ ​a​p​p​.​ ​P​l​e​a​s​e​ ​e​m​a​i​l​ ​{​e​m​a​i​l​}​ ​d​i​r​e​c​t​l​y​.
 		 * @param {string} email
 		 */
@@ -11803,6 +11807,10 @@ export type TranslationFunctions = {
 		 * Couldn't open the app store. Tap Contact Support below for help.
 		 */
 		couldNotOpenStore: () => LocalizedString
+		/**
+		 * Couldn't open the app store. You can keep using Flash and update later.
+		 */
+		couldNotOpenStoreBanner: () => LocalizedString
 		/**
 		 * Couldn't open your email app. Please email {email} directly.
 		 */

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -1591,7 +1591,9 @@
         "versionNotSupported": "This mobile version is no longer supported",
         "updateMandatory": "Update is mandatory",
         "tapHereUpdate": "Tap here to update now",
-        "contactSupport": "Contact Support"
+        "contactSupport": "Contact Support",
+        "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+        "couldNotOpenSupport": "Couldn't open your email app. Please email {email: string} directly."
     },
     "RefundFlow": {
         "refundListTitle": "Unclaimed Deposits",

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -1593,6 +1593,7 @@
         "tapHereUpdate": "Tap here to update now",
         "contactSupport": "Contact Support",
         "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+        "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
         "couldNotOpenSupport": "Couldn't open your email app. Please email {email: string} directly."
     },
     "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -1220,7 +1220,9 @@
     "versionNotSupported": "Die sellulêre weergawe word nie meer ondersteun nie. ",
     "updateMandatory": "Opgradering is verpligtent ",
     "tapHereUpdate": "Tik hier om op te gradeer",
-    "contactSupport": "Kontak Ondersteuning"
+    "contactSupport": "Kontak Ondersteuning",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "AccountUpgrade": {
     "accountNum": "Account Number",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -1222,6 +1222,7 @@
     "tapHereUpdate": "Tik hier om op te gradeer",
     "contactSupport": "Kontak Ondersteuning",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "AccountUpgrade": {

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -1164,6 +1164,7 @@
     "tapHereUpdate": "إضغط هنا للتحديث الان",
     "contactSupport": "اتصل بالدعم الفني",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "AccountUpgrade": {

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -1162,7 +1162,9 @@
     "versionNotSupported": "لم يعد إصدار جوالك هذا مدعومًا",
     "updateMandatory": "هذا التحديث إلزامي",
     "tapHereUpdate": "إضغط هنا للتحديث الان",
-    "contactSupport": "اتصل بالدعم الفني"
+    "contactSupport": "اتصل بالدعم الفني",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "AccountUpgrade": {
     "accountNum": "Account Number",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "Aquesta versió per a mòbils ja no s'admet",
     "updateMandatory": "L'actualització és obligatòria",
     "tapHereUpdate": "Prem aquí per actualitzar ara",
-    "contactSupport": "Contacta amb suport"
+    "contactSupport": "Contacta amb suport",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Unclaimed Deposits",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Prem aquí per actualitzar ara",
     "contactSupport": "Contacta amb suport",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "Tato mobilní verze již není podporována",
     "updateMandatory": "Aktualizace je povinná",
     "tapHereUpdate": "Klepněte zde pro aktualizaci",
-    "contactSupport": "Kontaktovat podporu"
+    "contactSupport": "Kontaktovat podporu",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Nedokládané vklady",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Klepněte zde pro aktualizaci",
     "contactSupport": "Kontaktovat podporu",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Tryk her for at opdatere nu",
     "contactSupport": "Kontakt support",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "Denne mobilversion understøttes ikke længere",
     "updateMandatory": "Opdatering er påkrævet",
     "tapHereUpdate": "Tryk her for at opdatere nu",
-    "contactSupport": "Kontakt support"
+    "contactSupport": "Kontakt support",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Unclaimed Deposits",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "Diese mobile Version wird nicht mehr unterstützt",
     "updateMandatory": "Das Update ist zwingend erforderlich",
     "tapHereUpdate": "Klicke hier, um jetzt zu updaten",
-    "contactSupport": "Support kontaktieren"
+    "contactSupport": "Support kontaktieren",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Unbekannte Einzahlungen",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Klicke hier, um jetzt zu updaten",
     "contactSupport": "Support kontaktieren",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Πατήστε εδώ για να ανανεώσετε τώρα",
     "contactSupport": "Επικοινωνήστε με την Υποστήριξη",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "Αυτή η έκδοση για κινητά δεν υποστηρίζεται πλέον",
     "updateMandatory": "Η Ενημέρωση είναι υποχρεωτική",
     "tapHereUpdate": "Πατήστε εδώ για να ανανεώσετε τώρα",
-    "contactSupport": "Επικοινωνήστε με την Υποστήριξη"
+    "contactSupport": "Επικοινωνήστε με την Υποστήριξη",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Ανεκδικημένες καταθέσεις",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "Esta versión para móviles ya no es compatible",
     "updateMandatory": "La actualización es obligatoria",
     "tapHereUpdate": "Pulse para actualizar ahora",
-    "contactSupport": "Contacte con soporte"
+    "contactSupport": "Contacte con soporte",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Los depósitos no reclamados",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Pulse para actualizar ahora",
     "contactSupport": "Contacte con soporte",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "La version mobile n’est plus supportée",
     "updateMandatory": "La mise à jour est obligatoire",
     "tapHereUpdate": "Appuyez ici pour mettre à jour maintenant",
-    "contactSupport": "Contacter l’Aide"
+    "contactSupport": "Contacter l’Aide",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Les dépôts non réclamés",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Appuyez ici pour mettre à jour maintenant",
     "contactSupport": "Contacter l’Aide",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Dodirnite ovdje za ažuriranje sada",
     "contactSupport": "Obratite se podršci",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "Ova mobilna verzija više nije podržana",
     "updateMandatory": "Ažuriranje je obavezno",
     "tapHereUpdate": "Dodirnite ovdje za ažuriranje sada",
-    "contactSupport": "Obratite se podršci"
+    "contactSupport": "Obratite se podršci",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Unclaimed Deposits",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Kattintson ide a frissítéshez",
     "contactSupport": "Vegye fel a kapcsolatot az ügyfélszolgálattal",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "Ez a mobil verzió már nem támogatott",
     "updateMandatory": "Frissítés kötelező",
     "tapHereUpdate": "Kattintson ide a frissítéshez",
-    "contactSupport": "Vegye fel a kapcsolatot az ügyfélszolgálattal"
+    "contactSupport": "Vegye fel a kapcsolatot az ügyfélszolgálattal",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Nem igényelt betétek",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Սեղմել՝ հիմա թարմացնելու համար",
     "contactSupport": "Կապ հաստատել աջակցության ծառայության հետ",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "Բջջային տարբերակն այլևս չի աջակցվում։ ",
     "updateMandatory": "Թարմացումը պարտադիր է",
     "tapHereUpdate": "Սեղմել՝ հիմա թարմացնելու համար",
-    "contactSupport": "Կապ հաստատել աջակցության ծառայության հետ"
+    "contactSupport": "Կապ հաստատել աջակցության ծառայության հետ",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Unclaimed Deposits",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "This mobile version is no longer supported",
     "updateMandatory": "Update is mandatory",
     "tapHereUpdate": "Tap here to update now",
-    "contactSupport": "Contact Support"
+    "contactSupport": "Contact Support",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "I depositi non rivendicati",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Tap here to update now",
     "contactSupport": "Contact Support",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "Telefon pintar ini tidak lagi boleh gunakan aplikasi ini",
     "updateMandatory": "Kemaskini adalah wajib",
     "tapHereUpdate": "Tekan sini untuk kemaskini sekarang",
-    "contactSupport": "Hubungi pasukan sokongan"
+    "contactSupport": "Hubungi pasukan sokongan",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Deposit Unclaimed",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Tekan sini untuk kemaskini sekarang",
     "contactSupport": "Hubungi pasukan sokongan",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "Deze mobiele versie wordt niet meer ondersteund",
     "updateMandatory": "Updaten is verplicht",
     "tapHereUpdate": "Click hier om te updaten",
-    "contactSupport": "Contact Klantenservice"
+    "contactSupport": "Contact Klantenservice",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Unclaimed Deposits",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Click hier om te updaten",
     "contactSupport": "Contact Klantenservice",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Toque aqui para atualizar agora",
     "contactSupport": "Contactar suporte",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "Esta versão não é mais compatível",
     "updateMandatory": "É obrigatório atualizar",
     "tapHereUpdate": "Toque aqui para atualizar agora",
-    "contactSupport": "Contactar suporte"
+    "contactSupport": "Contactar suporte",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Depósitos não reclamados",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "Kay warmi versiónqa kanmanmi kaypiyta munanki",
     "updateMandatory": "Yachaynin rurasqanmi hamurqan",
     "tapHereUpdate": "Chimpuykachun qhipaqa imanallaqachu",
-    "contactSupport": "Kausaynin yachaykuna"
+    "contactSupport": "Kausaynin yachaykuna",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Manan willasqa depositosqa kanchu.",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Chimpuykachun qhipaqa imanallaqachu",
     "contactSupport": "Kausaynin yachaykuna",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "Ова верзија мобилне апликације више није подржана",
     "updateMandatory": "Ажурирање је обавезно",
     "tapHereUpdate": "Додирните овде да бисте ажурирали сада",
-    "contactSupport": "Контактирајте Подршку"
+    "contactSupport": "Контактирајте Подршку",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Непожељени депозити",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Додирните овде да бисте ажурирали сада",
     "contactSupport": "Контактирајте Подршку",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -1162,7 +1162,9 @@
     "versionNotSupported": "Toleo hili la simu ya mkononi halitumiki tena",
     "updateMandatory": "Usasishaji ni wa lazima",
     "tapHereUpdate": "Guza hapa ili kusasisha sasa",
-    "contactSupport": "Wasiliana na Usaidizi"
+    "contactSupport": "Wasiliana na Usaidizi",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "AccountUpgrade": {
     "accountNum": "Account Number",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -1164,6 +1164,7 @@
     "tapHereUpdate": "Guza hapa ili kusasisha sasa",
     "contactSupport": "Wasiliana na Usaidizi",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "AccountUpgrade": {

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Tap here to update now",
     "contactSupport": "Contact Support",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "This mobile version is no longer supported",
     "updateMandatory": "Update is mandatory",
     "tapHereUpdate": "Tap here to update now",
-    "contactSupport": "Contact Support"
+    "contactSupport": "Contact Support",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "เงินฝากที่ไม่ได้รับการสรรหา",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Güncellemek için buraya tıkla",
     "contactSupport": "Desteğe danışınız",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "Bu mobil sürüm artık desteklenmiyor",
     "updateMandatory": "Güncelleme gerekli",
     "tapHereUpdate": "Güncellemek için buraya tıkla",
-    "contactSupport": "Desteğe danışınız"
+    "contactSupport": "Desteğe danışınız",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "İddia edilmeyen Para Yatırımları",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "This mobile version is no longer supported",
     "updateMandatory": "Update is mandatory",
     "tapHereUpdate": "Tap here to update now",
-    "contactSupport": "Contact Support"
+    "contactSupport": "Contact Support",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Các khoản tiền gửi không được yêu cầu",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Tap here to update now",
     "contactSupport": "Contact Support",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -1383,7 +1383,9 @@
     "versionNotSupported": "This mobile version is no longer supported",
     "updateMandatory": "Update is mandatory",
     "tapHereUpdate": "Tap here to update now",
-    "contactSupport": "Contact Support"
+    "contactSupport": "Contact Support",
+    "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {
     "refundListTitle": "Iidiphozithi ezingafunekiyo ",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -1385,6 +1385,7 @@
     "tapHereUpdate": "Tap here to update now",
     "contactSupport": "Contact Support",
     "couldNotOpenStore": "Couldn't open the app store. Tap Contact Support below for help.",
+    "couldNotOpenStoreBanner": "Couldn't open the app store. You can keep using Flash and update later.",
     "couldNotOpenSupport": "Couldn't open your email app. Please email {email} directly."
   },
   "RefundFlow": {

--- a/app/screens/home-screen/home-screen.stories.tsx
+++ b/app/screens/home-screen/home-screen.stories.tsx
@@ -6,6 +6,7 @@ import { MockedProvider } from "@apollo/client/testing"
 import { createCache } from "../../graphql/cache"
 import { IsAuthedContextProvider } from "../../graphql/is-authed-context"
 import mocks from "../../graphql/mocks"
+import { AppUpdateProvider } from "../../components/app-update/app-update"
 
 export default {
   title: "Home Screen",
@@ -13,7 +14,11 @@ export default {
   decorators: [
     (Story) => (
       <MockedProvider mocks={mocks} cache={createCache()}>
-        <StoryScreen>{Story()}</StoryScreen>
+        {/* app.tsx mounts this above the navigator; the home screen's update
+            banner reads it. */}
+        <AppUpdateProvider>
+          <StoryScreen>{Story()}</StoryScreen>
+        </AppUpdateProvider>
       </MockedProvider>
     ),
   ],

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -3,6 +3,7 @@ import { RefreshControl, ScrollView } from "react-native"
 import { useTheme } from "@rneui/themed"
 
 // components
+import { AppUpdate } from "@app/components/app-update/app-update"
 import WalletOverview from "@app/components/wallet-overview/wallet-overview"
 import { SetDefaultAccountModal } from "@app/components/set-default-account-modal"
 import { UnVerifiedSeedModal } from "@app/components/unverified-seed-modal"
@@ -147,6 +148,7 @@ export const HomeScreen: React.FC = () => {
           setDefaultAccountModalVisible={setDefaultAccountModalVisible}
         />
         <QuickStart />
+        <AppUpdate />
         <Transactions
           refreshTriggered={refreshTriggered}
           loadingAuthed={loadingAuthed}


### PR DESCRIPTION
## Why

There is no way to get users onto a new build today. The `AppUpdate` component — a soft "update available" banner and a blocking "update mandatory" modal, both driven by the public `mobileVersions` query — has existed since the galoy fork but **was never mounted anywhere**, and its banner text was commented out. Case in point: a user on an old build hit the Fygaro over-cap charge bug that newer code already fixes, and we had no in-app lever to move them.

## What

- **home-screen**: render the soft banner
- **app.tsx**: mount the blocking gate via `AppUpdateBoundary`, which shares one version check with the banner and pins the modal as the last sibling (it renders with `coverScreen={false}` for the Fabric modal-host bug, so paint order follows sibling order). Mounted app-wide rather than on Home so deep-link cold starts can't bypass it.
- **app-update**:
  - restore the banner text (the i18n string already existed)
  - **bug fix**: check `required` before `available`. `required` implies `available` (build < min ≤ current), so the blocking modal was unreachable behind the soft banner — a render test caught this.
  - re-check on foreground, so a raised `minBuildNumber` reaches apps resident in memory for days
  - surface store / mail-composer failures inline instead of leaving the tap a silent no-op
  - the gate's Contact Support button composes mail directly. The shared contact-modal helper points at `wa.flashapp.me`, which as of 2026-08-19 returns 200 with **zero redirects** and no `wa.me` anywhere — a static "temporarily unavailable" page that discards `?text=`. Kept local so no other caller's behavior changes.

## Behavior

| server says | user sees |
|---|---|
| build ≥ currentSupported | nothing |
| minSupported ≤ build < currentSupported | tappable "An update is available" banner → store |
| build < minSupported | blocking modal (update / contact support) |
| query not loaded / unknown platform | nothing (never block on bad data) |

## Tests

**549 pass**, `tsc:check` clean. New coverage: banner/gate split, the store link on both platforms, the mandatory modal's buttons (the only escape from a modal with no dismiss), failure paths for both, foreground re-check, and the app-wide mount.

## ⚠️ Deploy order

Two gates, both **before** a release containing this ships:

1. **lnflash/deployments#166.** Prod `mobileVersions` currently serves the schema defaults (`min = last = 362`), which would hard-block every real build. Apply it first.
2. **Fabric device check on Android — still outstanding.** New Architecture is on for both platforms (`android/gradle.properties:35`, `ios/Podfile:1`) and jest has no layout engine, so no test in this PR can prove the blocking modal measures correctly on a real Fabric build. The modal renders with `coverScreen={false}` specifically to dodge the broken `RCTModalHostView` measurement (#545); if that inline path is wrong on device the failure mode is a hard-blocked user staring at a blank frozen screen with no dismiss, no back button and no in-app escape — exactly what this PR exists to prevent. **Check:** on an Android New-Architecture build, point the app at an API returning `minSupported` above the local build, then confirm (a) the modal renders full-screen, (b) both "Update" and "Contact Support" are tappable, (c) the hardware back button does nothing. Record the result on this PR before the release build ships.

| # | Gate | Status |
|---|---|---|
| 1 | lnflash/deployments#166 applied to prod | ☐ |
| 2 | Android Fabric device check (modal renders, buttons tappable, back button inert) | ☐ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016MsAGwtS4sNodzWu2VMTKR
