### PR TITLE
fix(send): price LNURL sends instead of guessing a fee reserve

### DIFF
--- a/__tests__/components/amount-input-screen-max-chip.spec.tsx
+++ b/__tests__/components/amount-input-screen-max-chip.spec.tsx
@@ -280,6 +280,64 @@ describe("AmountInputScreen MAX chip", () => {
     expect(getByTestId("Max Amount Note").props.children).toBe("Test fee note")
   })
 
+  describe("explained-but-empty results (an unpriceable destination)", () => {
+    // compute() can resolve a note with NO amount: the destination could not
+    // be priced, so nothing is proposed and the user is told why. The pad is
+    // untouched, so the chip must stay outlined — a solid chip over an
+    // unchanged $0 pad claims a max was applied when none was, and VoiceOver
+    // reads it as selected.
+    const noteOnly = () => ({
+      compute: jest.fn(async () => ({ note: "Couldn't estimate the network fee" })),
+    })
+
+    it("shows the note without going solid", async () => {
+      const { getByTestId } = renderScreen(noteOnly())
+
+      fireEvent.press(getByTestId("Max Amount Chip"))
+
+      await waitFor(() => {
+        expect(getByTestId("Max Amount Note").props.children).toBe(
+          "Couldn't estimate the network fee",
+        )
+      })
+      expect(getByTestId("Max Amount Chip").props.accessibilityState).toEqual(
+        expect.objectContaining({ selected: false, disabled: false, busy: false }),
+      )
+    })
+
+    it("leaves the amount alone", async () => {
+      const { getByTestId, getByText, queryByText } = renderScreen(noteOnly())
+
+      fireEvent.press(getByTestId("Max Amount Chip"))
+
+      await waitFor(() => {
+        expect(getByTestId("Max Amount Note")).toBeTruthy()
+      })
+      // Still the empty pad it started on: 1,000 sats would have rendered
+      // "$20.00" (as the fill test above asserts) — nothing was filled in.
+      expect(getByText("$0")).toBeTruthy()
+      expect(queryByText("$20.00")).toBeNull()
+    })
+
+    it("clears the note once the user starts entering an amount", async () => {
+      const { getByTestId, queryByTestId } = renderScreen(noteOnly())
+
+      fireEvent.press(getByTestId("Max Amount Chip"))
+      await waitFor(() => {
+        expect(getByTestId("Max Amount Note")).toBeTruthy()
+      })
+
+      fireEvent.press(getByTestId("key-1"))
+
+      await waitFor(() => {
+        expect(queryByTestId("Max Amount Note")).toBeNull()
+      })
+      expect(getByTestId("Max Amount Chip").props.accessibilityState).toEqual(
+        expect.objectContaining({ selected: false }),
+      )
+    })
+  })
+
   it("returns to outlined and hides the note the moment the user edits the amount", async () => {
     const { getByTestId, queryByTestId } = renderScreen({
       compute: jest.fn(async () => ({ amount: maxSats, note: "Test fee note" })),

--- a/__tests__/utils/lnurl-fee-probe.spec.ts
+++ b/__tests__/utils/lnurl-fee-probe.spec.ts
@@ -1,6 +1,8 @@
 import {
   LNURL_PROBE_TIMEOUT_MS,
   LnurlProbeDetail,
+  makeLnurlFeeProbe,
+  makeLnurlProbeCache,
   priceLnurlSend,
 } from "../../app/screens/send-bitcoin-screen/lnurl-fee-probe"
 
@@ -216,6 +218,48 @@ describe("priceLnurlSend", () => {
     expect(getIbexFee).not.toHaveBeenCalled()
   })
 
+  it("resolves null when the IBEX leg outlives the probe budget", async () => {
+    // The budget bounds the WHOLE price check, not just the mint. An LN route
+    // probe takes seconds of its own, so timing only the mint left a slow
+    // destination running until the chip's own 10s race cut it off — the
+    // failover margin this timeout exists to guarantee never applied.
+    const fee = await priceLnurlSend({
+      detail: makeLnurlDetail(makeCalls()),
+      probeAmount: 442,
+      balanceMoneyAmount: usdBalance,
+      requestInvoice: mintInvoice,
+      // mint answers instantly; the route probe never does
+      getIbexFee: jest.fn(() => new Promise<undefined>(() => {})),
+      timeoutMs: 10,
+    })
+
+    expect(fee).toBeNull()
+    expect(mintInvoice).toHaveBeenCalled()
+  })
+
+  it("bounds mint plus fee probe together, not each separately", async () => {
+    // Two legs at 60% of the budget each: each is fine alone, the pair is
+    // not. A per-leg timer lets this through with a real fee; only one timer
+    // around the whole check returns null.
+    const budget = 50
+    const after = (ms: number, value: unknown) =>
+      new Promise((resolve) => {
+        setTimeout(() => resolve(value), ms)
+      })
+
+    const fee = await priceLnurlSend({
+      detail: makeLnurlDetail(makeCalls()),
+      probeAmount: 442,
+      balanceMoneyAmount: usdBalance,
+      requestInvoice: () =>
+        after(budget * 0.6, { invoice: "lnbc-221" }) as Promise<{ invoice: string }>,
+      getIbexFee: () => after(budget * 0.6, { amount: 7 }) as Promise<{ amount: number }>,
+      timeoutMs: budget,
+    })
+
+    expect(fee).toBeNull()
+  })
+
   it("resolves null when IBEX cannot price the minted invoice", async () => {
     const fee = await priceLnurlSend({
       detail: makeLnurlDetail(makeCalls()),
@@ -299,5 +343,133 @@ describe("priceLnurlSend", () => {
     // A probe allowed to run the full chip budget would hold the tap instead
     // of degrading to "couldn't estimate".
     expect(LNURL_PROBE_TIMEOUT_MS).toBeLessThan(10_000)
+  })
+})
+
+describe("makeLnurlFeeProbe", () => {
+  // The memo the send screen hands to buildMaxAmountButton. Every probe that
+  // reaches the receiver mints a REAL invoice, so what this remembers — and
+  // for how long — is the difference between one invoice per destination and
+  // one per tap against a rate-limited service.
+  const probeFor = (
+    overrides: {
+      requestInvoice?: (args: {
+        params: TestPayParams
+        sats: number
+      }) => Promise<{ invoice: string }>
+      getIbexFee?: (
+        getFee: TestGetFee | undefined,
+      ) => Promise<{ amount: number } | undefined>
+      cache?: ReturnType<typeof makeLnurlProbeCache>
+      destination?: string
+      timeoutMs?: number
+    } = {},
+  ) =>
+    makeLnurlFeeProbe({
+      detail: makeLnurlDetail(makeCalls()),
+      destination: overrides.destination ?? "sats@flashapp.me",
+      walletCurrency: "USD",
+      balanceMoneyAmount: usdBalance,
+      requestInvoice: overrides.requestInvoice ?? mintInvoice,
+      getIbexFee: overrides.getIbexFee ?? getIbexFee,
+      cache: overrides.cache ?? makeLnurlProbeCache(),
+      timeoutMs: overrides.timeoutMs,
+    })
+
+  it("serves a repeat tap from cache without touching the receiver", async () => {
+    const probe = probeFor()
+
+    expect(await probe(442)).toBe(7)
+    expect(await probe(442)).toBe(7)
+    expect(mintInvoice).toHaveBeenCalledTimes(1)
+    expect(getIbexFee).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps the probe amount in the key so a smaller probe is priced afresh", async () => {
+    // A fee priced for a full-balance probe reused for a cap-clamped one
+    // would under-reserve — the max would exceed what the send can pay.
+    const probe = probeFor()
+
+    expect(await probe(442)).toBe(7)
+    expect(await probe(10_000)).toBe(130)
+    expect(mintInvoice).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not cache a failure — the note invites another tap", async () => {
+    // Inverting the guard to cache nulls would brand a destination
+    // unpriceable for the life of the screen on one transient blip.
+    const getFeeOnce = jest
+      .fn<Promise<{ amount: number } | undefined>, [TestGetFee | undefined]>()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValue({ amount: 7 })
+    const probe = probeFor({ getIbexFee: getFeeOnce })
+
+    expect(await probe(442)).toBeNull()
+    expect(await probe(442)).toBe(7)
+  })
+
+  it("does not leak prices across destinations", async () => {
+    const cache = makeLnurlProbeCache()
+
+    expect(await probeFor({ cache, destination: "alice@flashapp.me" })(442)).toBe(7)
+    await probeFor({ cache, destination: "bob@flashapp.me" })(442)
+
+    expect(mintInvoice).toHaveBeenCalledTimes(2)
+  })
+
+  it("shares an in-flight mint instead of asking for a second invoice", async () => {
+    // The failure this exists for: any receiver slower than the 7s budget.
+    // Promise.race abandons the wait but cannot cancel the request, so the
+    // receiver mints anyway. Nothing is ever cached, so the retry the note
+    // asks for mints another — one orphaned invoice per tap, forever.
+    let settle: (value: { invoice: string }) => void = () => {}
+    const slowMint = jest.fn(
+      () =>
+        new Promise<{ invoice: string }>((resolve) => {
+          settle = resolve
+        }),
+    )
+    const cache = makeLnurlProbeCache()
+    const probe = probeFor({ cache, requestInvoice: slowMint, timeoutMs: 10 })
+
+    // Tap one gives up on the receiver, which is still minting.
+    expect(await probe(442)).toBeNull()
+
+    // Tap two must await that same mint, not start a new one.
+    const secondTap = probe(442)
+    settle({ invoice: "lnbc-221" })
+
+    expect(await secondTap).toBe(7)
+    expect(slowMint).toHaveBeenCalledTimes(1)
+  })
+
+  it("forgets a mint that rejected", async () => {
+    const failThenSucceed = jest
+      .fn<Promise<{ invoice: string }>, [{ params: TestPayParams; sats: number }]>()
+      .mockRejectedValueOnce(new Error("receiver unreachable"))
+      .mockResolvedValue({ invoice: "lnbc-221" })
+    const cache = makeLnurlProbeCache()
+    const probe = probeFor({ cache, requestInvoice: failThenSucceed })
+
+    expect(await probe(442)).toBeNull()
+    // A cached rejection would make every later tap fail on the dead promise.
+    expect(await probe(442)).toBe(7)
+    expect(failThenSucceed).toHaveBeenCalledTimes(2)
+  })
+
+  it("forgets an answered invoice the fee probe could not price", async () => {
+    // The invoice exists but pricing it failed, and these expire in 60s.
+    // Holding it forever would re-price the same dead invoice on every retry
+    // — caching the null by another route.
+    const getFeeOnce = jest
+      .fn<Promise<{ amount: number } | undefined>, [TestGetFee | undefined]>()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValue({ amount: 7 })
+    const cache = makeLnurlProbeCache()
+    const probe = probeFor({ cache, getIbexFee: getFeeOnce })
+
+    expect(await probe(442)).toBeNull()
+    expect(await probe(442)).toBe(7)
+    expect(mintInvoice).toHaveBeenCalledTimes(2)
   })
 })

--- a/__tests__/utils/lnurl-fee-probe.spec.ts
+++ b/__tests__/utils/lnurl-fee-probe.spec.ts
@@ -1,0 +1,303 @@
+import {
+  LNURL_PROBE_TIMEOUT_MS,
+  LnurlProbeDetail,
+  priceLnurlSend,
+} from "../../app/screens/send-bitcoin-screen/lnurl-fee-probe"
+
+type TestMoneyAmount = { amount: number; currency: string; currencyCode: string }
+type TestBtcAmount = { amount: number; currency: "BTC"; currencyCode: "SAT" }
+// Sentinel getFee handle: whatever the priced detail exposes must reach
+// getIbexFee untouched, so the fee that comes back is the fee for THIS invoice.
+type TestGetFee = { invoice: string; sats: number }
+type TestPayParams = { callback: string; tag: "payRequest" }
+
+type Detail = LnurlProbeDetail<TestMoneyAmount, TestBtcAmount, TestGetFee, TestPayParams>
+
+// 1 sat = 2 cents, so cent amounts halve into sats and odd cents land on a
+// half-sat — the case that must never reach the receiver as a fractional mint.
+const CENTS_PER_SAT = 2
+
+const usdBalance: TestMoneyAmount = {
+  amount: 10_000,
+  currency: "USD",
+  currencyCode: "USD",
+}
+
+const lnurlParams: TestPayParams = {
+  callback: "https://lnurl.example/cb",
+  tag: "payRequest",
+}
+
+const convertMoneyAmount = (
+  moneyAmount: TestMoneyAmount,
+  toCurrency: "BTC",
+): TestBtcAmount => ({
+  amount:
+    moneyAmount.currency === "BTC"
+      ? moneyAmount.amount
+      : moneyAmount.amount / CENTS_PER_SAT,
+  currency: toCurrency,
+  currencyCode: "SAT",
+})
+
+type ProbeCalls = {
+  setAmount: TestMoneyAmount[]
+  setInvoice: { paymentRequest: string; paymentRequestAmount: TestBtcAmount }[]
+}
+
+const makeCalls = (): ProbeCalls => ({ setAmount: [], setInvoice: [] })
+
+/**
+ * A payment detail shaped like the LNURL arm of PaymentDetail: setAmount
+ * returns a NEW detail whose unitOfAccountAmount is the probe amount, and only
+ * that detail can attach an invoice.
+ */
+const makeLnurlDetail = (calls: ProbeCalls, overrides: Partial<Detail> = {}): Detail => {
+  const base: Detail = {
+    paymentType: "lnurl",
+    // Deliberately not the probe amount: the probe must price what setAmount
+    // produced, not whatever the screen's detail happened to be holding.
+    unitOfAccountAmount: { ...usdBalance, amount: 0 },
+    convertMoneyAmount,
+    lnurlParams,
+    setAmount: (unitOfAccountAmount) => {
+      calls.setAmount.push(unitOfAccountAmount)
+      return {
+        ...base,
+        unitOfAccountAmount,
+        setInvoice: (params) => {
+          calls.setInvoice.push(params)
+          return {
+            getFee: {
+              invoice: params.paymentRequest,
+              sats: params.paymentRequestAmount.amount,
+            },
+          }
+        },
+      }
+    },
+    ...overrides,
+  }
+  return base
+}
+
+// Fee table keyed by the minted invoice: proves the returned fee belongs to the
+// invoice this probe minted rather than to some other amount.
+const feeForInvoice: Record<string, number> = {
+  "lnbc-221": 7,
+  "lnbc-5000": 130,
+}
+
+const mintInvoice = jest.fn(
+  async ({ sats }: { params: TestPayParams; sats: number }) => ({
+    invoice: `lnbc-${sats}`,
+  }),
+)
+
+const getIbexFee = jest.fn(async (getFee: TestGetFee | undefined) =>
+  getFee && feeForInvoice[getFee.invoice] !== undefined
+    ? { amount: feeForInvoice[getFee.invoice] }
+    : undefined,
+)
+
+beforeEach(() => {
+  mintInvoice.mockClear()
+  getIbexFee.mockClear()
+})
+
+describe("priceLnurlSend", () => {
+  it("prices the destination through a throwaway invoice at the probe amount", async () => {
+    const calls = makeCalls()
+
+    const fee = await priceLnurlSend({
+      detail: makeLnurlDetail(calls),
+      probeAmount: 442,
+      balanceMoneyAmount: usdBalance,
+      requestInvoice: mintInvoice,
+      getIbexFee,
+    })
+
+    // 442 cents / 2 = 221 sats; the fee table answers for lnbc-221 only.
+    expect(fee).toBe(7)
+    expect(calls.setAmount).toEqual([{ ...usdBalance, amount: 442 }])
+  })
+
+  it("mints the invoice for the whole-sat conversion of the probe amount", async () => {
+    await priceLnurlSend({
+      detail: makeLnurlDetail(makeCalls()),
+      probeAmount: 442,
+      balanceMoneyAmount: usdBalance,
+      requestInvoice: mintInvoice,
+      getIbexFee,
+    })
+
+    expect(mintInvoice).toHaveBeenCalledWith({ params: lnurlParams, sats: 221 })
+  })
+
+  it("converts the PROBE amount, not the detail's pre-probe amount", async () => {
+    // The detail starts at 0; a probe that priced unitOfAccountAmount of the
+    // original detail (or any other field) would mint lnbc-0 and price null.
+    await priceLnurlSend({
+      detail: makeLnurlDetail(makeCalls()),
+      probeAmount: 10_000,
+      balanceMoneyAmount: usdBalance,
+      requestInvoice: mintInvoice,
+      getIbexFee,
+    })
+
+    expect(mintInvoice).toHaveBeenCalledWith({ params: lnurlParams, sats: 5_000 })
+  })
+
+  it("hands the receiver's already-resolved params to the mint (one round-trip)", async () => {
+    // Re-resolving the pay service by address costs a second network leg
+    // inside the probe budget; a slow-but-fine receiver would then read as
+    // unpriceable. The params are already on the detail — use them.
+    await priceLnurlSend({
+      detail: makeLnurlDetail(makeCalls()),
+      probeAmount: 442,
+      balanceMoneyAmount: usdBalance,
+      requestInvoice: mintInvoice,
+      getIbexFee,
+    })
+
+    expect(mintInvoice.mock.calls[0][0].params).toBe(lnurlParams)
+  })
+
+  it("prices the invoice it minted, at the sats it minted it for", async () => {
+    const calls = makeCalls()
+
+    await priceLnurlSend({
+      detail: makeLnurlDetail(calls),
+      probeAmount: 441,
+      balanceMoneyAmount: usdBalance,
+      requestInvoice: mintInvoice,
+      getIbexFee,
+    })
+
+    // 441 cents = 220.5 sats — rounded once, and the SAME whole number must
+    // reach both the mint and setInvoice. A mismatch prices a different send.
+    expect(mintInvoice).toHaveBeenCalledWith({ params: lnurlParams, sats: 221 })
+    expect(calls.setInvoice).toEqual([
+      {
+        paymentRequest: "lnbc-221",
+        paymentRequestAmount: { amount: 221, currency: "BTC", currencyCode: "SAT" },
+      },
+    ])
+    expect(getIbexFee).toHaveBeenCalledWith({ invoice: "lnbc-221", sats: 221 })
+  })
+
+  it("resolves null when the invoice mint rejects", async () => {
+    const fee = await priceLnurlSend({
+      detail: makeLnurlDetail(makeCalls()),
+      probeAmount: 442,
+      balanceMoneyAmount: usdBalance,
+      requestInvoice: jest.fn(async () => {
+        throw new Error("receiver unreachable")
+      }),
+      getIbexFee,
+    })
+
+    expect(fee).toBeNull()
+    expect(getIbexFee).not.toHaveBeenCalled()
+  })
+
+  it("resolves null when the invoice mint outlives the probe budget", async () => {
+    const fee = await priceLnurlSend({
+      detail: makeLnurlDetail(makeCalls()),
+      probeAmount: 442,
+      balanceMoneyAmount: usdBalance,
+      // never resolves
+      requestInvoice: () => new Promise(() => {}),
+      getIbexFee,
+      timeoutMs: 10,
+    })
+
+    expect(fee).toBeNull()
+    expect(getIbexFee).not.toHaveBeenCalled()
+  })
+
+  it("resolves null when IBEX cannot price the minted invoice", async () => {
+    const fee = await priceLnurlSend({
+      detail: makeLnurlDetail(makeCalls()),
+      probeAmount: 442,
+      balanceMoneyAmount: usdBalance,
+      requestInvoice: mintInvoice,
+      getIbexFee: jest.fn(async () => undefined),
+    })
+
+    expect(fee).toBeNull()
+  })
+
+  it("resolves null when the IBEX probe throws", async () => {
+    const fee = await priceLnurlSend({
+      detail: makeLnurlDetail(makeCalls()),
+      probeAmount: 442,
+      balanceMoneyAmount: usdBalance,
+      requestInvoice: mintInvoice,
+      getIbexFee: jest.fn(async () => {
+        throw new Error("fee probe failed")
+      }),
+    })
+
+    expect(fee).toBeNull()
+  })
+
+  it("mints nothing for a non-LNURL detail", async () => {
+    const fee = await priceLnurlSend({
+      detail: makeLnurlDetail(makeCalls(), { paymentType: "lightning" }),
+      probeAmount: 442,
+      balanceMoneyAmount: usdBalance,
+      requestInvoice: mintInvoice,
+      getIbexFee,
+    })
+
+    expect(fee).toBeNull()
+    expect(mintInvoice).not.toHaveBeenCalled()
+  })
+
+  it("mints nothing when the detail carries no resolved pay params", async () => {
+    const fee = await priceLnurlSend({
+      detail: makeLnurlDetail(makeCalls(), { lnurlParams: undefined }),
+      probeAmount: 442,
+      balanceMoneyAmount: usdBalance,
+      requestInvoice: mintInvoice,
+      getIbexFee,
+    })
+
+    expect(fee).toBeNull()
+    expect(mintInvoice).not.toHaveBeenCalled()
+  })
+
+  it("mints nothing when the amount cannot be set", async () => {
+    const fee = await priceLnurlSend({
+      detail: makeLnurlDetail(makeCalls(), { setAmount: undefined }),
+      probeAmount: 442,
+      balanceMoneyAmount: usdBalance,
+      requestInvoice: mintInvoice,
+      getIbexFee,
+    })
+
+    expect(fee).toBeNull()
+    expect(mintInvoice).not.toHaveBeenCalled()
+  })
+
+  it("mints nothing when the probe amount is worth less than a sat", async () => {
+    // A dust probe would otherwise ask the receiver for a 0-sat invoice.
+    const fee = await priceLnurlSend({
+      detail: makeLnurlDetail(makeCalls()),
+      probeAmount: 0.4,
+      balanceMoneyAmount: usdBalance,
+      requestInvoice: mintInvoice,
+      getIbexFee,
+    })
+
+    expect(fee).toBeNull()
+    expect(mintInvoice).not.toHaveBeenCalled()
+  })
+
+  it("keeps its budget under the MAX chip's own 10s fee budget", () => {
+    // A probe allowed to run the full chip budget would hold the tap instead
+    // of degrading to "couldn't estimate".
+    expect(LNURL_PROBE_TIMEOUT_MS).toBeLessThan(10_000)
+  })
+})

--- a/__tests__/utils/lnurl-fee-probe.spec.ts
+++ b/__tests__/utils/lnurl-fee-probe.spec.ts
@@ -1,10 +1,30 @@
+// The adapter under test is the one line that talks to the real lnurl-pay
+// API, so the library is replaced wholesale. `toSats` stays a passthrough —
+// the real one is a bare cast, and the point of the test is the number that
+// reaches the receiver.
+jest.mock("lnurl-pay", () => ({
+  __esModule: true,
+  requestInvoiceWithServiceParams: jest.fn(),
+  requestInvoice: jest.fn(),
+  utils: { toSats: (value: number) => value },
+}))
+
+import { requestInvoice, requestInvoiceWithServiceParams } from "lnurl-pay"
+import type { LnUrlPayServiceResponse } from "lnurl-pay/dist/types/types"
+
+import { FEE_ESTIMATE_TIMEOUT_MS } from "../../app/screens/send-bitcoin-screen/max-send-amount"
 import {
   LNURL_PROBE_TIMEOUT_MS,
   LnurlProbeDetail,
   makeLnurlFeeProbe,
   makeLnurlProbeCache,
+  MINT_REUSE_TTL_MS,
+  mintProbeInvoice,
   priceLnurlSend,
 } from "../../app/screens/send-bitcoin-screen/lnurl-fee-probe"
+
+const mockedMintCall = requestInvoiceWithServiceParams as unknown as jest.Mock
+const mockedAddressMintCall = requestInvoice as unknown as jest.Mock
 
 type TestMoneyAmount = { amount: number; currency: string; currencyCode: string }
 type TestBtcAmount = { amount: number; currency: "BTC"; currencyCode: "SAT" }
@@ -339,10 +359,55 @@ describe("priceLnurlSend", () => {
     expect(mintInvoice).not.toHaveBeenCalled()
   })
 
-  it("keeps its budget under the MAX chip's own 10s fee budget", () => {
+  it("keeps its budget under the MAX chip's own fee budget", () => {
     // A probe allowed to run the full chip budget would hold the tap instead
-    // of degrading to "couldn't estimate".
-    expect(LNURL_PROBE_TIMEOUT_MS).toBeLessThan(10_000)
+    // of degrading to "couldn't estimate". Asserted against the chip's real
+    // constant, not a copy of today's value: a copy keeps passing after the
+    // chip's budget drops below the probe's, which is the moment the
+    // invariant is actually broken.
+    expect(LNURL_PROBE_TIMEOUT_MS).toBeLessThan(FEE_ESTIMATE_TIMEOUT_MS)
+  })
+})
+
+describe("mintProbeInvoice", () => {
+  // Minimal stand-in: the adapter passes the params straight through, so only
+  // identity matters here.
+  const params = {
+    callback: "https://lnurl.example/cb",
+  } as unknown as LnUrlPayServiceResponse
+
+  beforeEach(() => {
+    mockedMintCall.mockReset()
+    mockedAddressMintCall.mockReset()
+    mockedMintCall.mockResolvedValue({ invoice: "lnbc-real" })
+  })
+
+  it("mints through the params-taking call at the exact whole-sat count", async () => {
+    const minted = await mintProbeInvoice({ params, sats: 221 })
+
+    expect(mockedMintCall).toHaveBeenCalledWith({ params, tokens: 221 })
+    expect(minted.invoice).toBe("lnbc-real")
+  })
+
+  it("does not use the address-taking variant", async () => {
+    // `requestInvoice` re-resolves the receiver's pay service before it can
+    // reach their callback — a second network leg inside a 7s budget, on a
+    // detail that already carries the resolved params.
+    await mintProbeInvoice({ params, sats: 221 })
+
+    expect(mockedAddressMintCall).not.toHaveBeenCalled()
+  })
+
+  it("refuses a fractional amount instead of casting it to Satoshis", async () => {
+    // utils.toSats performs no validation — it brands 220.5 as Satoshis and
+    // the receiver is asked for half a sat.
+    await expect(mintProbeInvoice({ params, sats: 220.5 })).rejects.toThrow(/220\.5 sats/)
+    expect(mockedMintCall).not.toHaveBeenCalled()
+  })
+
+  it("refuses to ask the receiver for a zero-sat invoice", async () => {
+    await expect(mintProbeInvoice({ params, sats: 0 })).rejects.toThrow()
+    expect(mockedMintCall).not.toHaveBeenCalled()
   })
 })
 
@@ -457,10 +522,14 @@ describe("makeLnurlFeeProbe", () => {
     expect(failThenSucceed).toHaveBeenCalledTimes(2)
   })
 
-  it("forgets an answered invoice the fee probe could not price", async () => {
-    // The invoice exists but pricing it failed, and these expire in 60s.
-    // Holding it forever would re-price the same dead invoice on every retry
-    // — caching the null by another route.
+  it("keeps a fresh answered invoice when only the fee leg failed", async () => {
+    // The invoice is FINE — the second leg is what failed. Discarding it on a
+    // failed price throws away a live invoice whenever the route probe is the
+    // slow half: mint answers at 2s, getIbexFee hangs, the 7s budget fires,
+    // and an invoice good for another 53s is dropped. The note then tells the
+    // user to tap MAX again, so the retry mints ANOTHER at the receiver — one
+    // orphaned invoice per tap against a rate-limited service, which is the
+    // exact failure this memo exists to prevent.
     const getFeeOnce = jest
       .fn<Promise<{ amount: number } | undefined>, [TestGetFee | undefined]>()
       .mockResolvedValueOnce(undefined)
@@ -470,6 +539,41 @@ describe("makeLnurlFeeProbe", () => {
 
     expect(await probe(442)).toBeNull()
     expect(await probe(442)).toBe(7)
-    expect(mintInvoice).toHaveBeenCalledTimes(2)
+    expect(mintInvoice).toHaveBeenCalledTimes(1)
+  })
+
+  it("reuses one mint for probe amounts that round to the same sats", async () => {
+    // 441¢ and 442¢ are both 221 sats at 2¢/sat. Same invoice, two prices —
+    // the fee key differs, the mint key does not.
+    const cache = makeLnurlProbeCache()
+
+    expect(await probeFor({ cache })(442)).toBe(7)
+    expect(await probeFor({ cache })(441)).toBe(7)
+    expect(mintInvoice).toHaveBeenCalledTimes(1)
+  })
+
+  it("re-mints once the held invoice has aged out", async () => {
+    // The other side of sharing by sat count: an invoice minted minutes ago
+    // expires (60s from issue), and pricing an expired invoice is a fee IBEX
+    // will refuse at send time. Age retires a mint — nothing else does.
+    const cache = makeLnurlProbeCache()
+    const start = 1_700_000_000_000
+    const clock = jest.spyOn(Date, "now").mockReturnValue(start)
+    try {
+      expect(await probeFor({ cache })(442)).toBe(7)
+
+      clock.mockReturnValue(start + MINT_REUSE_TTL_MS + 1)
+      expect(await probeFor({ cache })(441)).toBe(7)
+
+      expect(mintInvoice).toHaveBeenCalledTimes(2)
+    } finally {
+      clock.mockRestore()
+    }
+  })
+
+  it("keeps the invoice reuse window inside the 60s invoice lifetime", () => {
+    // Reusing an invoice for longer than the receiver keeps it alive hands
+    // IBEX something already dead.
+    expect(MINT_REUSE_TTL_MS).toBeLessThan(60_000)
   })
 })

--- a/__tests__/utils/max-amount-button-strings.spec.ts
+++ b/__tests__/utils/max-amount-button-strings.spec.ts
@@ -1,0 +1,57 @@
+import type { TranslationFunctions } from "@app/i18n/i18n-types"
+import { maxAmountButtonStrings } from "@app/screens/send-bitcoin-screen/max-amount-button-strings"
+import { breezFeeErrorMessage } from "@app/utils/breez-sdk/fee-error-message"
+
+const LL = {
+  AmountInputScreen: {
+    maxNoteIntraledger: jest.fn(() => "No fee between Flash accounts."),
+    maxNoteFeeReserved: jest.fn(
+      ({ fee }: { fee: string }) => `~${fee} reserved for the network fee.`,
+    ),
+    maxNoteRecipientCap: jest.fn(
+      ({ max }: { max: string }) => `Recipient can receive at most ${max}.`,
+    ),
+    maxNoteFeeUnknown: jest.fn(() => "Couldn't estimate the fee."),
+    maxNoteFeeTooLarge: jest.fn(() => "The fee is larger than your balance."),
+  },
+  SendBitcoinScreen: {
+    minReceiveAmountError: jest.fn(
+      ({ amount }: { amount: string }) =>
+        `The minimum this recipient can receive is ${amount}`,
+    ),
+  },
+} as unknown as TranslationFunctions
+
+// Stands in for useFormatSats: display currency plus a separated sat count.
+const formatSats = (sats: number) =>
+  `$${((sats * 65) / 100_000).toFixed(2)} (${sats.toLocaleString("en-US")} sats)`
+
+describe("maxAmountButtonStrings", () => {
+  it("formats the receiver's minimum through formatSats", () => {
+    // A hand-rolled `${minSats} sats` gives "1000 sats": unlocalized, no
+    // thousands separator, no display-currency half.
+    expect(maxAmountButtonStrings(LL, formatSats).recipientMin(1_000)).toBe(
+      "The minimum this recipient can receive is $0.65 (1,000 sats)",
+    )
+  })
+
+  // The chip note and the validation banner are one sentence about one limit,
+  // and on the BTC LNURL path both can be on screen at once — the chip note
+  // under the pad, breezFeeErrorMessage's banner two rows down. Two renderings
+  // of the same number read as two different limits.
+  it("renders the same sentence as the fee-error banner for the same limit", () => {
+    expect(maxAmountButtonStrings(LL, formatSats).recipientMin(1_000)).toBe(
+      breezFeeErrorMessage({ kind: "amount-below-min", minSats: 1_000 }, LL, formatSats),
+    )
+  })
+
+  it("passes the remaining notes through to their own keys", () => {
+    const strings = maxAmountButtonStrings(LL, formatSats)
+
+    expect(strings.intraledger()).toBe("No fee between Flash accounts.")
+    expect(strings.feeReserved("$0.30")).toBe("~$0.30 reserved for the network fee.")
+    expect(strings.recipientCap("$40.00")).toBe("Recipient can receive at most $40.00.")
+    expect(strings.feeUnknown()).toBe("Couldn't estimate the fee.")
+    expect(strings.feeTooLarge()).toBe("The fee is larger than your balance.")
+  })
+})

--- a/__tests__/utils/max-amount-button.spec.ts
+++ b/__tests__/utils/max-amount-button.spec.ts
@@ -47,6 +47,9 @@ const makeArgs = (overrides: Partial<TestArgs> = {}): TestArgs => ({
     getFee: { probeAmount: amount.amount },
   })),
   getIbexFee: jest.fn(async () => ({ amount: 0 })),
+  // Required, like fetchBreezFee and getIbexFee — a caller that forgets it
+  // must not compile. Defaults to unpriceable; LNURL cases override it.
+  probeLnurlFee: jest.fn(async () => null),
   formatDisplayAmount: (moneyAmount: TestMoneyAmount) =>
     `$${(moneyAmount.amount / 100).toFixed(2)}`,
   strings,
@@ -169,7 +172,8 @@ describe("buildMaxAmountButton", () => {
         selectedFeeType: undefined,
         knownPayRequest: undefined,
       })
-      expect(result?.amount).toEqual({ ...btcBalance, amount: 99_750 })
+      // 100_000 − 250 fee − 1 unit of slack for the confirm-time re-price.
+      expect(result?.amount).toEqual({ ...btcBalance, amount: 99_749 })
     })
 
     it("prefers the flash user address over the raw destination", async () => {
@@ -262,7 +266,7 @@ describe("buildMaxAmountButton", () => {
       const result = await button?.compute()
 
       expect(fetchBreezFee).toHaveBeenCalled()
-      expect(result?.amount).toEqual({ ...btcBalance, amount: 99_700 })
+      expect(result?.amount).toEqual({ ...btcBalance, amount: 99_699 })
       expect(result?.note).toBe("fee note: $3.00")
     })
 
@@ -298,7 +302,7 @@ describe("buildMaxAmountButton", () => {
       // The probe detail is the balance with the probe amount swapped in.
       expect(setAmount).toHaveBeenCalledWith({ ...usdBalance, amount: 10_000 })
       expect(getIbexFee).toHaveBeenCalledWith({ probeAmount: 10_000 })
-      expect(result?.amount).toEqual({ ...usdBalance, amount: 9_970 })
+      expect(result?.amount).toEqual({ ...usdBalance, amount: 9_969 })
       expect(result?.note).toBe("fee note: $0.30")
     })
 
@@ -376,7 +380,9 @@ describe("buildMaxAmountButton", () => {
 
       const result = await button?.compute()
 
-      expect(result?.amount).toEqual(usdBalance)
+      // Still a unit below the balance: a zero estimate is not a promise that
+      // the invoice the send mints will also be free.
+      expect(result?.amount).toEqual({ ...usdBalance, amount: 9_999 })
       expect(result?.note).toBeUndefined()
     })
 
@@ -390,7 +396,7 @@ describe("buildMaxAmountButton", () => {
 
       const result = await button?.compute()
 
-      expect(result?.amount).toEqual({ ...usdBalance, amount: 9_875 })
+      expect(result?.amount).toEqual({ ...usdBalance, amount: 9_874 })
       expect(result?.note).toBeUndefined()
     })
 
@@ -429,7 +435,7 @@ describe("LNURL destinations are priced, not guessed (ENG-554)", () => {
     // The invoice-less IBEX probe must not be consulted for LNURL — it is
     // the path that silently returned nothing and started all this.
     expect(getIbexFee).not.toHaveBeenCalled()
-    expect(result?.amount).toEqual({ ...usdBalance, amount: 10_000 - 37 })
+    expect(result?.amount).toEqual({ ...usdBalance, amount: 10_000 - 37 - 1 })
     expect(result?.note).toEqual("fee note: $0.37")
   })
 
@@ -437,15 +443,6 @@ describe("LNURL destinations are priced, not guessed (ENG-554)", () => {
     const button = buildMaxAmountButton(
       makeArgs({ paymentType: "lnurl", probeLnurlFee: jest.fn(async () => null) }),
     )
-
-    const result = await button?.compute()
-
-    expect(result?.amount).toBeUndefined()
-    expect(result?.note).toEqual("fee unknown note")
-  })
-
-  it("declines when no LNURL probe is wired at all", async () => {
-    const button = buildMaxAmountButton(makeArgs({ paymentType: "lnurl" }))
 
     const result = await button?.compute()
 
@@ -463,6 +460,6 @@ describe("LNURL destinations are priced, not guessed (ENG-554)", () => {
     const result = await button?.compute()
 
     expect(probeLnurlFee).not.toHaveBeenCalled()
-    expect(result?.amount).toEqual({ ...usdBalance, amount: 10_000 - 12 })
+    expect(result?.amount).toEqual({ ...usdBalance, amount: 10_000 - 12 - 1 })
   })
 })

--- a/__tests__/utils/max-amount-button.spec.ts
+++ b/__tests__/utils/max-amount-button.spec.ts
@@ -26,6 +26,7 @@ const strings = {
   feeReserved: (fee: string) => `fee note: ${fee}`,
   recipientCap: (max: string) => `cap note: ${max}`,
   feeUnknown: () => "fee unknown note",
+  recipientMin: (minSats: number) => `min note: ${minSats} sats`,
   feeTooLarge: () => "fee too large note",
 }
 
@@ -541,5 +542,47 @@ describe("a fee bigger than the balance is explained, not swallowed", () => {
 
     expect(result?.amount).toBeUndefined()
     expect(result?.note).toBe("fee too large note")
+  })
+})
+
+describe("a typed Breez bounds error keeps its message", () => {
+  // Before this PR a null fee still filled the balance, so committing it
+  // surfaced the receiver's minimum. Now that nothing is proposed, the MAX
+  // note is the only place that reason can still reach the user — telling
+  // them "couldn't estimate the fee" when the real answer is "this recipient
+  // won't accept less than 1,000 sats" sends them nowhere.
+  it("reports the receiver's minimum rather than a generic estimate failure", async () => {
+    const button = buildMaxAmountButton(
+      makeArgs({
+        walletCurrency: "BTC",
+        balanceMoneyAmount: btcBalance,
+        fetchBreezFee: jest.fn(async () => ({
+          fee: null,
+          err: { kind: "amount-below-min", minSats: 1_000 },
+        })),
+      }),
+    )
+
+    const result = await button?.compute()
+
+    expect(result?.amount).toBeUndefined()
+    expect(result?.note).toBe("min note: 1000 sats")
+  })
+
+  it("falls back to the generic note for an untyped failure", async () => {
+    const button = buildMaxAmountButton(
+      makeArgs({
+        walletCurrency: "BTC",
+        balanceMoneyAmount: btcBalance,
+        fetchBreezFee: jest.fn(async () => ({
+          fee: null,
+          err: { kind: "network", message: "offline" },
+        })),
+      }),
+    )
+
+    const result = await button?.compute()
+
+    expect(result?.note).toBe("fee unknown note")
   })
 })

--- a/__tests__/utils/max-amount-button.spec.ts
+++ b/__tests__/utils/max-amount-button.spec.ts
@@ -26,6 +26,7 @@ const strings = {
   feeReserved: (fee: string) => `fee note: ${fee}`,
   recipientCap: (max: string) => `cap note: ${max}`,
   feeUnknown: () => "fee unknown note",
+  feeTooLarge: () => "fee too large note",
 }
 
 type TestArgs = BuildMaxAmountButtonArgs<TestMoneyAmount, TestGetFee, TestPayRequest>
@@ -125,9 +126,11 @@ describe("buildMaxAmountButton", () => {
       await expect(button?.compute()).resolves.toBeNull()
     })
 
-    it("resolves null when the fee estimate meets or exceeds the balance", async () => {
-      // { amount: 0, reason: "fee-reserved" } — not "zero-balance" — must
-      // also leave the pad untouched (BTC wallet with 20 sats, fee 26).
+    it("fills nothing but says why when the fee meets or exceeds the balance", async () => {
+      // { amount: 0, reason: "fee-exceeds-balance" } — not "zero-balance" —
+      // must leave the pad untouched (BTC wallet with 20 sats, fee 26). It
+      // used to resolve null, which the amount screen drops on the floor: the
+      // chip spun and then said nothing at all.
       const button = buildMaxAmountButton(
         makeArgs({
           walletCurrency: "BTC",
@@ -136,15 +139,39 @@ describe("buildMaxAmountButton", () => {
         }),
       )
 
-      await expect(button?.compute()).resolves.toBeNull()
+      const result = await button?.compute()
+
+      expect(result?.amount).toBeUndefined()
+      expect(result?.note).toBe("fee too large note")
     })
 
-    it("resolves null when the receiver advertises a zero maxSendable cap", async () => {
+    it("says why when the receiver advertises a zero maxSendable cap", async () => {
+      // The third silent-zero route: a receiver that can accept nothing. The
+      // cap note is the honest explanation — it names the limit that bound.
       const button = buildMaxAmountButton(
         makeArgs({
           walletCurrency: "BTC",
           balanceMoneyAmount: btcBalance,
           receiverMaxSats: 0,
+        }),
+      )
+
+      const result = await button?.compute()
+
+      expect(result?.amount).toBeUndefined()
+      expect(result?.note).toBe("cap note: $0.00")
+    })
+
+    it("resolves null when a zero max has nothing worth saying", async () => {
+      // No display rate, so the cap note cannot be formatted. A result of
+      // `{ note: undefined }` would set chip state for no visible reason;
+      // null keeps the tap inert instead.
+      const button = buildMaxAmountButton(
+        makeArgs({
+          walletCurrency: "BTC",
+          balanceMoneyAmount: btcBalance,
+          receiverMaxSats: 0,
+          formatDisplayAmount: () => undefined,
         }),
       )
 
@@ -461,5 +488,58 @@ describe("LNURL destinations are priced, not guessed (ENG-554)", () => {
 
     expect(probeLnurlFee).not.toHaveBeenCalled()
     expect(result?.amount).toEqual({ ...usdBalance, amount: 10_000 - 12 - 1 })
+  })
+})
+
+describe("a fee bigger than the balance is explained, not swallowed", () => {
+  // The reported case: a BTC wallet holding 2_000 sats against a Breez
+  // channel-open fee of 2_500. MAX has nothing to offer — but the tap used to
+  // resolve null, which amount-input-screen drops without a word, so the chip
+  // spun, went back to outlined, and the user was told nothing.
+  it("returns the fee-too-large note for 2_000 sats against a 2_500-sat fee", async () => {
+    const button = buildMaxAmountButton(
+      makeArgs({
+        walletCurrency: "BTC",
+        balanceMoneyAmount: { ...btcBalance, amount: 2_000 },
+        fetchBreezFee: jest.fn(async () => ({ fee: 2_500, err: null })),
+      }),
+    )
+
+    const result = await button?.compute()
+
+    expect(result).not.toBeNull()
+    expect(result?.amount).toBeUndefined()
+    expect(result?.note).toBe("fee too large note")
+  })
+
+  it("distinguishes an unaffordable fee from an unpriceable destination", async () => {
+    // Same empty pad, different next move: top up versus tap MAX again.
+    const unpriceable = buildMaxAmountButton(
+      makeArgs({
+        walletCurrency: "BTC",
+        balanceMoneyAmount: { ...btcBalance, amount: 2_000 },
+        fetchBreezFee: jest.fn(async () => ({ fee: null, err: "probe failed" })),
+      }),
+    )
+
+    expect((await unpriceable?.compute())?.note).toBe("fee unknown note")
+  })
+
+  it("explains the boundary the confirm-time slack pushed to zero", async () => {
+    // balance 2_500 with a 2_499-sat fee: one sat on the old arithmetic, zero
+    // once a unit of slack is reserved. Zero with no note would be a silent
+    // regression against the previous release, so it must speak.
+    const button = buildMaxAmountButton(
+      makeArgs({
+        walletCurrency: "BTC",
+        balanceMoneyAmount: { ...btcBalance, amount: 2_500 },
+        fetchBreezFee: jest.fn(async () => ({ fee: 2_499, err: null })),
+      }),
+    )
+
+    const result = await button?.compute()
+
+    expect(result?.amount).toBeUndefined()
+    expect(result?.note).toBe("fee too large note")
   })
 })

--- a/__tests__/utils/max-amount-button.spec.ts
+++ b/__tests__/utils/max-amount-button.spec.ts
@@ -555,6 +555,101 @@ describe("LNURL destinations are priced, not guessed (ENG-554)", () => {
     expect(probeLnurlFee).toHaveBeenCalledWith(442)
   })
 
+  // The probe guard checks the amount going IN; the fee is subtracted after
+  // it. Every balance in [min, min + fee + slack) therefore clears the probe
+  // and still leaves the chip proposing less than the receiver will accept —
+  // the cap is applied to the result, so the floor has to be too.
+  it("proposes nothing when the fee drops a cleared balance back under the minimum", async () => {
+    // BTC wallet, 3_000 sats, LNURL receiver with minSendable 1_000, Breez
+    // channel-open fee 2_500. The probe at 3_000 clears the floor, the
+    // computation returns 3_000 − 2_500 − 1 = 499, and the chip used to fill
+    // 499 sats under "~2,500 sats reserved for the network fee" — with "the
+    // minimum this recipient can receive is 1,000 sats" painted directly
+    // beneath it by DetailAmountNote.
+    const button = buildMaxAmountButton(
+      makeArgs({
+        walletCurrency: "BTC",
+        paymentType: "lnurl",
+        balanceMoneyAmount: { ...btcBalance, amount: 3_000 },
+        receiverMinSats: 1_000,
+        fetchBreezFee: jest.fn(async () => ({ fee: 2_500, err: null })),
+      }),
+    )
+
+    const result = await button?.compute()
+
+    expect(result?.amount).toBeUndefined()
+    expect(result?.note).toBe("min note: 1000 sats")
+  })
+
+  it("proposes nothing on the USD path when the fee drops the amount under the minimum", async () => {
+    // USD wallet at 2¢/sat holding 2_010¢ (1_005 sats) against the same
+    // 1_000-sat floor: the probe guard passes (2_000 ≤ 2_010), the 20¢ fee
+    // leaves 1_989¢ = 994 sats, and nothing downstream catches it — the USD
+    // path has no working local min check, so Next asks the LNURL mint for an
+    // impossible invoice, lnurl-pay throws Error("Invalid amount"), and the
+    // screen blames the fetch. ENG-554's own symptom, out of the chip written
+    // to prevent it.
+    const probeLnurlFee = jest.fn(async () => 20)
+    const button = buildMaxAmountButton(
+      makeArgs({
+        paymentType: "lnurl",
+        balanceMoneyAmount: { ...usdBalance, amount: 2_010 },
+        receiverMinSats: 1_000,
+        convertSatsToWallet: (sats: number) => sats * 2,
+        probeLnurlFee,
+      }),
+    )
+
+    const result = await button?.compute()
+
+    expect(probeLnurlFee).toHaveBeenCalledWith(2_010)
+    expect(result?.amount).toBeUndefined()
+    expect(result?.note).toBe("min note: 1000 sats")
+  })
+
+  it("still proposes an amount that lands exactly on the receiver's minimum", async () => {
+    // The floor is inclusive: 2_020¢ (1_010 sats) less a 19¢ fee and 1¢ of
+    // slack is 2_000¢ — exactly 1_000 sats. Rejecting this would make the
+    // guard eat sends the receiver would have accepted.
+    const button = buildMaxAmountButton(
+      makeArgs({
+        paymentType: "lnurl",
+        balanceMoneyAmount: { ...usdBalance, amount: 2_020 },
+        receiverMinSats: 1_000,
+        convertSatsToWallet: (sats: number) => sats * 2,
+        probeLnurlFee: jest.fn(async () => 19),
+      }),
+    )
+
+    const result = await button?.compute()
+
+    expect(result?.amount).toEqual({ ...usdBalance, amount: 2_000 })
+    expect(result?.note).toBe("fee note: $0.19")
+  })
+
+  it("names the minimum, not the cap, when the cap clamps beneath the floor", async () => {
+    // A receiver advertising maxSendable 900 against minSendable 1_000 — a
+    // window nothing fits through. The cap wins the clamp and the result is
+    // 900 sats, which the floor then rejects: "recipient can receive at most
+    // 900" would be true and useless, because 900 is also unsendable.
+    const button = buildMaxAmountButton(
+      makeArgs({
+        walletCurrency: "BTC",
+        paymentType: "lnurl",
+        balanceMoneyAmount: btcBalance,
+        receiverMinSats: 1_000,
+        receiverMaxSats: 900,
+        fetchBreezFee: jest.fn(async () => ({ fee: 250, err: null })),
+      }),
+    )
+
+    const result = await button?.compute()
+
+    expect(result?.amount).toBeUndefined()
+    expect(result?.note).toBe("min note: 1000 sats")
+  })
+
   it("leaves non-LNURL USD sends on the ordinary IBEX probe", async () => {
     const probeLnurlFee = jest.fn(async () => 37)
     const getIbexFee = jest.fn(async () => ({ amount: 12 }))

--- a/__tests__/utils/max-amount-button.spec.ts
+++ b/__tests__/utils/max-amount-button.spec.ts
@@ -25,6 +25,7 @@ const strings = {
   intraledger: () => "intraledger note",
   feeReserved: (fee: string) => `fee note: ${fee}`,
   recipientCap: (max: string) => `cap note: ${max}`,
+  feeUnknown: () => "fee unknown note",
 }
 
 type TestArgs = BuildMaxAmountButtonArgs<TestMoneyAmount, TestGetFee, TestPayRequest>
@@ -241,10 +242,10 @@ describe("buildMaxAmountButton", () => {
 
       const result = await button?.compute()
 
-      // No usable estimate, so the backend's fee cap is reserved instead of
-      // offering the whole balance (which the send flow would refuse).
-      expect(result?.amount).toEqual({ ...btcBalance, amount: 99_503 })
-      expect(result?.note).toEqual("fee note: $4.97")
+      // Nothing could price it, so nothing is proposed — the note is the
+      // whole result, and the pad is left for the user to fill.
+      expect(result?.amount).toBeUndefined()
+      expect(result?.note).toEqual("fee unknown note")
     })
 
     it("routes BTC-wallet intraledger through the fee path (not the no-fee arm)", async () => {
@@ -302,13 +303,14 @@ describe("buildMaxAmountButton", () => {
     })
 
     it("probes at the cap-clamped amount when the LNURL cap binds", async () => {
-      const setAmount = jest.fn((amount: TestMoneyAmount) => ({
-        getFee: { probeAmount: amount.amount },
-      }))
+      // Probing at the raw balance trips the receiver's LUD-06 bounds check
+      // whenever the cap binds, losing the estimate exactly where the fee
+      // headroom matters most.
+      const probeLnurlFee = jest.fn(async () => 10)
       const button = buildMaxAmountButton(
         makeArgs({
           paymentType: "lnurl",
-          setAmount,
+          probeLnurlFee,
           // 2 wallet minor units per sat.
           convertSatsToWallet: (sats: number) => sats * 2,
           lnurlParamsMaxSats: 2_000,
@@ -317,21 +319,20 @@ describe("buildMaxAmountButton", () => {
 
       await button?.compute()
 
-      expect(setAmount).toHaveBeenCalledWith({ ...usdBalance, amount: 4_000 })
+      expect(probeLnurlFee).toHaveBeenCalledWith(4_000)
     })
 
-    it("reserves the fee cap when no IBEX estimate is available", async () => {
-      // The LNURL case from ENG-554: no invoice exists yet, so getIbexFee
-      // resolves undefined. Offering the full balance here is what made the
-      // send fail with a generic error.
+    it("proposes nothing when no IBEX estimate is available", async () => {
+      // Offering the full balance here is what made the send fail with a
+      // generic error (ENG-554); a guessed reserve would be no more honest.
       const button = buildMaxAmountButton(
         makeArgs({ getIbexFee: jest.fn(async () => undefined) }),
       )
 
       const result = await button?.compute()
 
-      expect(result?.amount).toEqual({ ...usdBalance, amount: 9_951 })
-      expect(result?.note).toEqual("fee note: $0.49")
+      expect(result?.amount).toBeUndefined()
+      expect(result?.note).toEqual("fee unknown note")
     })
 
     it("never calls the Breez probe for a USD wallet", async () => {
@@ -399,7 +400,7 @@ describe("buildMaxAmountButton", () => {
           paymentType: "lnurl",
           convertSatsToWallet: (sats: number) => sats * 2,
           lnurlParamsMaxSats: 2_000,
-          getIbexFee: jest.fn(async () => ({ amount: 0 })),
+          probeLnurlFee: jest.fn(async () => 0),
         }),
       )
 
@@ -408,5 +409,60 @@ describe("buildMaxAmountButton", () => {
       expect(result?.amount).toEqual({ ...usdBalance, amount: 4_000 })
       expect(result?.note).toBe("cap note: $40.00")
     })
+  })
+})
+
+describe("LNURL destinations are priced, not guessed (ENG-554)", () => {
+  // An LNURL payment detail has no getFee until an invoice is attached, so
+  // the plain IBEX probe cannot price it at all. probeLnurlFee mints a
+  // throwaway invoice purely to price the send.
+  it("prices an LNURL destination through probeLnurlFee", async () => {
+    const probeLnurlFee = jest.fn(async () => 37)
+    const getIbexFee = jest.fn(async () => ({ amount: 999 }))
+    const button = buildMaxAmountButton(
+      makeArgs({ paymentType: "lnurl", probeLnurlFee, getIbexFee }),
+    )
+
+    const result = await button?.compute()
+
+    expect(probeLnurlFee).toHaveBeenCalledWith(usdBalance.amount)
+    // The invoice-less IBEX probe must not be consulted for LNURL — it is
+    // the path that silently returned nothing and started all this.
+    expect(getIbexFee).not.toHaveBeenCalled()
+    expect(result?.amount).toEqual({ ...usdBalance, amount: 10_000 - 37 })
+    expect(result?.note).toEqual("fee note: $0.37")
+  })
+
+  it("declines to propose an amount when the LNURL probe cannot price it", async () => {
+    const button = buildMaxAmountButton(
+      makeArgs({ paymentType: "lnurl", probeLnurlFee: jest.fn(async () => null) }),
+    )
+
+    const result = await button?.compute()
+
+    expect(result?.amount).toBeUndefined()
+    expect(result?.note).toEqual("fee unknown note")
+  })
+
+  it("declines when no LNURL probe is wired at all", async () => {
+    const button = buildMaxAmountButton(makeArgs({ paymentType: "lnurl" }))
+
+    const result = await button?.compute()
+
+    expect(result?.amount).toBeUndefined()
+    expect(result?.note).toEqual("fee unknown note")
+  })
+
+  it("leaves non-LNURL USD sends on the ordinary IBEX probe", async () => {
+    const probeLnurlFee = jest.fn(async () => 37)
+    const getIbexFee = jest.fn(async () => ({ amount: 12 }))
+    const button = buildMaxAmountButton(
+      makeArgs({ paymentType: "lightning", probeLnurlFee, getIbexFee }),
+    )
+
+    const result = await button?.compute()
+
+    expect(probeLnurlFee).not.toHaveBeenCalled()
+    expect(result?.amount).toEqual({ ...usdBalance, amount: 10_000 - 12 })
   })
 })

--- a/__tests__/utils/max-amount-button.spec.ts
+++ b/__tests__/utils/max-amount-button.spec.ts
@@ -43,6 +43,7 @@ const makeArgs = (overrides: Partial<TestArgs> = {}): TestArgs => ({
   knownPayRequest: undefined,
   receiverMaxSats: null,
   lnurlParamsMaxSats: null,
+  receiverMinSats: null,
   convertSatsToWallet: (sats: number) => sats,
   fetchBreezFee: jest.fn(async () => ({ fee: 0, err: null })),
   setAmount: jest.fn((amount: TestMoneyAmount) => ({
@@ -476,6 +477,82 @@ describe("LNURL destinations are priced, not guessed (ENG-554)", () => {
 
     expect(result?.amount).toBeUndefined()
     expect(result?.note).toEqual("fee unknown note")
+  })
+
+  it("reports the receiver's minimum instead of asking for an impossible invoice", async () => {
+    // lnurl-pay bounds-checks client-side and throws a bare
+    // Error("Invalid amount") below minSendable, which the probe collapses
+    // into the same null as a network blip. The user is then told to tap MAX
+    // again — and no number of taps can make a $4.42 balance (221 sats at
+    // 2¢/sat) reach a 1_000-sat minimum. The bound is the only actionable
+    // half of the message, and on this path nothing else can surface it.
+    const probeLnurlFee = jest.fn(async () => null)
+    const button = buildMaxAmountButton(
+      makeArgs({
+        paymentType: "lnurl",
+        balanceMoneyAmount: { ...usdBalance, amount: 442 },
+        receiverMinSats: 1_000,
+        convertSatsToWallet: (sats: number) => sats * 2,
+        probeLnurlFee,
+      }),
+    )
+
+    const result = await button?.compute()
+
+    // Nothing was asked of the receiver — the answer was knowable locally.
+    expect(probeLnurlFee).not.toHaveBeenCalled()
+    expect(result?.amount).toBeUndefined()
+    expect(result?.note).toBe("min note: 1000 sats")
+  })
+
+  it("still probes when the balance clears the receiver's minimum", async () => {
+    const probeLnurlFee = jest.fn(async () => 37)
+    const button = buildMaxAmountButton(
+      makeArgs({
+        paymentType: "lnurl",
+        receiverMinSats: 1_000,
+        convertSatsToWallet: (sats: number) => sats * 2,
+        probeLnurlFee,
+      }),
+    )
+
+    const result = await button?.compute()
+
+    expect(probeLnurlFee).toHaveBeenCalledWith(10_000)
+    expect(result?.amount).toEqual({ ...usdBalance, amount: 10_000 - 37 - 1 })
+  })
+
+  it("does not borrow the minimum's message for an ordinary probe failure", async () => {
+    // A destination with a known minimum the balance clears, whose probe then
+    // fails for an unrelated reason, must not be reported as below-minimum.
+    const button = buildMaxAmountButton(
+      makeArgs({
+        paymentType: "lnurl",
+        receiverMinSats: 1_000,
+        convertSatsToWallet: (sats: number) => sats * 2,
+        probeLnurlFee: jest.fn(async () => null),
+      }),
+    )
+
+    const result = await button?.compute()
+
+    expect(result?.note).toBe("fee unknown note")
+  })
+
+  it("probes as before when the receiver advertises no minimum", async () => {
+    const probeLnurlFee = jest.fn(async () => 37)
+    const button = buildMaxAmountButton(
+      makeArgs({
+        paymentType: "lnurl",
+        balanceMoneyAmount: { ...usdBalance, amount: 442 },
+        receiverMinSats: null,
+        probeLnurlFee,
+      }),
+    )
+
+    await button?.compute()
+
+    expect(probeLnurlFee).toHaveBeenCalledWith(442)
   })
 
   it("leaves non-LNURL USD sends on the ordinary IBEX probe", async () => {

--- a/__tests__/utils/max-amount-button.spec.ts
+++ b/__tests__/utils/max-amount-button.spec.ts
@@ -241,9 +241,10 @@ describe("buildMaxAmountButton", () => {
 
       const result = await button?.compute()
 
-      // fee-unavailable falls back to the full balance — no fee subtracted.
-      expect(result?.amount).toEqual(btcBalance)
-      expect(result?.note).toBeUndefined()
+      // No usable estimate, so the backend's fee cap is reserved instead of
+      // offering the whole balance (which the send flow would refuse).
+      expect(result?.amount).toEqual({ ...btcBalance, amount: 99_503 })
+      expect(result?.note).toEqual("fee note: $4.97")
     })
 
     it("routes BTC-wallet intraledger through the fee path (not the no-fee arm)", async () => {
@@ -319,15 +320,18 @@ describe("buildMaxAmountButton", () => {
       expect(setAmount).toHaveBeenCalledWith({ ...usdBalance, amount: 4_000 })
     })
 
-    it("falls back to the full balance when no IBEX estimate is available", async () => {
+    it("reserves the fee cap when no IBEX estimate is available", async () => {
+      // The LNURL case from ENG-554: no invoice exists yet, so getIbexFee
+      // resolves undefined. Offering the full balance here is what made the
+      // send fail with a generic error.
       const button = buildMaxAmountButton(
         makeArgs({ getIbexFee: jest.fn(async () => undefined) }),
       )
 
       const result = await button?.compute()
 
-      expect(result?.amount).toEqual(usdBalance)
-      expect(result?.note).toBeUndefined()
+      expect(result?.amount).toEqual({ ...usdBalance, amount: 9_951 })
+      expect(result?.note).toEqual("fee note: $0.49")
     })
 
     it("never calls the Breez probe for a USD wallet", async () => {

--- a/__tests__/utils/max-send-amount.spec.ts
+++ b/__tests__/utils/max-send-amount.spec.ts
@@ -1,10 +1,8 @@
 import {
   computeMaxSendAmount,
   effectiveMaxPaymentType,
-  maxAmountWithinFeeCap,
   maxChipSupportsPaymentType,
   noteForResult,
-  reservedFeeCapFor,
   resolveRecipientCap,
 } from "../../app/screens/send-bitcoin-screen/max-send-amount"
 
@@ -50,25 +48,21 @@ describe("computeMaxSendAmount", () => {
     })
   })
 
-  it("reserves the backend fee cap when no fee estimate is available", async () => {
-    // The LNURL case: no invoice exists yet, so there is nothing to probe.
-    // Offering the full 100_000 would be rejected by the backend, which adds
-    // its own cap on top and checks balance >= amount + fee.
+  it("proposes nothing when no fee estimate is available", async () => {
+    // The LNURL case before #702's probe: nothing can price the send. The
+    // old behaviour offered the full 100_000, which the send then refused
+    // because the fee lands on top (ENG-554). Guessing a reserve would be no
+    // better — nothing in this app knows what IBEX charges — so it declines.
     const result = await computeMaxSendAmount({
       paymentType: "lnurl",
       balance: 100_000,
       fetchFee: async () => null,
     })
 
-    expect(result).toEqual({
-      amount: 99_503,
-      reason: "fee-unavailable",
-      feeReserved: 497,
-    })
-    expect(result.amount + reservedFeeCapFor(result.amount)).toBeLessThanOrEqual(100_000)
+    expect(result).toEqual({ amount: 0, reason: "fee-unavailable" })
   })
 
-  it("reserves the fee cap when the fee fetch throws", async () => {
+  it("proposes nothing when the fee fetch throws", async () => {
     const result = await computeMaxSendAmount({
       paymentType: "lightning",
       balance: 100_000,
@@ -77,14 +71,10 @@ describe("computeMaxSendAmount", () => {
       },
     })
 
-    expect(result).toEqual({
-      amount: 99_503,
-      reason: "fee-unavailable",
-      feeReserved: 497,
-    })
+    expect(result).toEqual({ amount: 0, reason: "fee-unavailable" })
   })
 
-  it("reserves the fee cap when the fee fetch hangs past the timeout", async () => {
+  it("proposes nothing when the fee fetch hangs past the timeout", async () => {
     const result = await computeMaxSendAmount({
       paymentType: "lightning",
       balance: 100_000,
@@ -93,11 +83,7 @@ describe("computeMaxSendAmount", () => {
       timeoutMs: 20,
     })
 
-    expect(result).toEqual({
-      amount: 99_503,
-      reason: "fee-unavailable",
-      feeReserved: 497,
-    })
+    expect(result).toEqual({ amount: 0, reason: "fee-unavailable" })
   })
 
   it("clamps to the recipient's LNURL maxSendable when it is the binding limit", async () => {
@@ -187,7 +173,9 @@ describe("computeMaxSendAmount", () => {
     expect(result).toEqual({ amount: 150_000, reason: "recipient-cap" })
   })
 
-  it("applies the cap on the fee-unavailable fallback as well", async () => {
+  it("offers nothing when unpriceable, even where a recipient cap would bind", async () => {
+    // The cap is not a safe fallback: sending exactly the cap still needs a
+    // fee on top, and that fee is the thing we could not determine.
     const result = await computeMaxSendAmount({
       paymentType: "lnurl",
       balance: 1_000_000,
@@ -195,7 +183,7 @@ describe("computeMaxSendAmount", () => {
       recipientCap: 150_000,
     })
 
-    expect(result).toEqual({ amount: 150_000, reason: "recipient-cap" })
+    expect(result).toEqual({ amount: 0, reason: "fee-unavailable" })
   })
 
   it("returns zero for a zero balance", async () => {
@@ -256,18 +244,9 @@ describe("computeMaxSendAmount", () => {
       fetchFee: async () => Number.NaN,
     })
 
-    // Both take the no-estimate path, which reserves the backend fee cap
-    // rather than offering the full balance.
-    expect(negative).toEqual({
-      amount: 99_503,
-      reason: "fee-unavailable",
-      feeReserved: 497,
-    })
-    expect(nan).toEqual({
-      amount: 99_503,
-      reason: "fee-unavailable",
-      feeReserved: 497,
-    })
+    // Both take the no-estimate path: no number is proposed at all.
+    expect(negative).toEqual({ amount: 0, reason: "fee-unavailable" })
+    expect(nan).toEqual({ amount: 0, reason: "fee-unavailable" })
   })
 
   // On-device repro (2026-08-13): USD cash balance arrives as FRACTIONAL
@@ -441,80 +420,57 @@ describe("noteForResult", () => {
     })
   })
 
-  it("fee-unavailable and zero-balance get no note", () => {
-    expect(noteForResult({ amount: 100_000, reason: "fee-unavailable" })).toEqual({
-      kind: "none",
-    })
+  it("zero-balance gets no note; fee-unavailable explains itself", () => {
     expect(noteForResult({ amount: 0, reason: "zero-balance" })).toEqual({
       kind: "none",
+    })
+    expect(noteForResult({ amount: 0, reason: "fee-unavailable" })).toEqual({
+      kind: "fee-unknown",
     })
   })
 })
 
-describe("fee-cap reserve (ENG-554)", () => {
-  // The reported failure: balance $4.42, MAX filled the full 442 cents, the
-  // backend added its cap on top and refused the send. $4.00 went through
-  // because it happened to leave enough headroom.
-  it("leaves headroom for the reported 442-cent balance", async () => {
+describe("an unpriceable destination is never guessed at (ENG-554)", () => {
+  // The bug: MAX filled the full $4.42 balance for an LNURL destination, the
+  // fee landed on top, and the send was refused. The first fix reserved a
+  // constant borrowed from flash's FEECAP_BASIS_POINTS — but that governs
+  // galoy's payment flow, and lnNoAmountUsdInvoicePaymentSend bypasses it
+  // entirely to call Ibex.payInvoice, so the number bounded nothing real.
+  it("does not offer the reported 442-cent balance when it cannot be priced", async () => {
     const result = await computeMaxSendAmount({
       paymentType: "lnurl",
       balance: 442,
       fetchFee: async () => null,
     })
 
-    expect(result.amount).toBeLessThan(442)
-    expect(result.amount + reservedFeeCapFor(result.amount)).toBeLessThanOrEqual(442)
+    expect(result).toEqual({ amount: 0, reason: "fee-unavailable" })
   })
 
-  it("never proposes an amount the backend balance check would refuse", () => {
-    // Exhaustive over the range a cash wallet actually lives in, plus the
-    // boundaries where the one-unit fee floor dominates the percentage.
-    for (let balance = 1; balance <= 5_000; balance += 1) {
-      const amount = maxAmountWithinFeeCap(balance)
-      expect(amount + reservedFeeCapFor(amount)).toBeLessThanOrEqual(balance)
-    }
-  })
-
-  it("offers the largest amount that fits — not a needlessly conservative one", () => {
-    for (let balance = 2; balance <= 5_000; balance += 1) {
-      const amount = maxAmountWithinFeeCap(balance)
-      const nextUp = amount + 1
-      expect(nextUp + reservedFeeCapFor(nextUp)).toBeGreaterThan(balance)
-    }
-  })
-
-  it("yields nothing spendable when the balance cannot cover the minimum fee", () => {
-    // One minor unit: any send needs at least a 1-unit fee on top, so there
-    // is no amount that fits. The chip greys out rather than filling a 1.
-    expect(maxAmountWithinFeeCap(1)).toBe(0)
-    expect(maxAmountWithinFeeCap(0)).toBe(0)
-    expect(maxAmountWithinFeeCap(-5)).toBe(0)
-    expect(maxAmountWithinFeeCap(NaN)).toBe(0)
-  })
-
-  it("mirrors the backend cap: 50 bps with a one-unit floor", () => {
-    expect(reservedFeeCapFor(10_000)).toBe(50)
-    expect(reservedFeeCapFor(1_000)).toBe(5)
-    // Below 200 the percentage floors to zero, so the one-unit floor applies.
-    expect(reservedFeeCapFor(100)).toBe(1)
-    expect(reservedFeeCapFor(1)).toBe(1)
-  })
-
-  it("still explains the shortfall to the user", () => {
-    // Without a note the amount screen would silently show less than the
-    // balance the user can see on the home screen.
-    expect(
-      noteForResult({ amount: 439, reason: "fee-unavailable", feeReserved: 3 }),
-    ).toEqual({ kind: "fee-reserved", feeReserved: 3 })
-  })
-
-  it("intraledger is untouched — genuinely fee-free, so MAX stays the full balance", async () => {
+  it("uses the real fee once the destination can be priced", async () => {
+    // With #702's probe the LNURL path gets a genuine IBEX estimate, so the
+    // max is balance minus that fee — no invented constant anywhere.
     const result = await computeMaxSendAmount({
-      paymentType: "intraledger",
+      paymentType: "lnurl",
       balance: 442,
-      fetchFee: async () => null,
+      fetchFee: async () => 2,
     })
 
-    expect(result).toEqual({ amount: 442, reason: "intraledger-full-balance" })
+    expect(result).toEqual({ amount: 440, reason: "fee-reserved", feeReserved: 2 })
+  })
+
+  it("probes at the amount it is about to offer, not some other one", async () => {
+    // Fees are monotone in amount, so probing above the final amount is safe
+    // and probing below is not. Pin which amount reaches the probe.
+    const fetchFee = jest.fn(async () => 5)
+
+    await computeMaxSendAmount({ paymentType: "lnurl", balance: 1_000, fetchFee })
+
+    expect(fetchFee).toHaveBeenCalledWith(1_000)
+  })
+
+  it("explains itself rather than looking like a broken tap", () => {
+    expect(noteForResult({ amount: 0, reason: "fee-unavailable" })).toEqual({
+      kind: "fee-unknown",
+    })
   })
 })

--- a/__tests__/utils/max-send-amount.spec.ts
+++ b/__tests__/utils/max-send-amount.spec.ts
@@ -232,7 +232,11 @@ describe("computeMaxSendAmount", () => {
       fetchFee: async () => 500,
     })
 
-    expect(result).toEqual({ amount: 0, reason: "fee-reserved", feeReserved: 500 })
+    expect(result).toEqual({
+      amount: 0,
+      reason: "fee-exceeds-balance",
+      feeReserved: 500,
+    })
   })
 
   it("treats a negative or non-finite fee as unavailable", async () => {
@@ -431,6 +435,23 @@ describe("noteForResult", () => {
       kind: "fee-unknown",
     })
   })
+
+  it("a fee that swallowed the balance explains itself too", () => {
+    // The other zero that a user can act on (top up, or send less from
+    // somewhere else). Silence here is what made the chip look broken.
+    expect(
+      noteForResult({ amount: 0, reason: "fee-exceeds-balance", feeReserved: 2_500 }),
+    ).toEqual({ kind: "fee-too-large" })
+  })
+
+  it("says the fee is too large even when the estimate itself was zero", () => {
+    // balance 1 with a zero fee: the slack unit is what emptied it. Falling
+    // back to { kind: "none" } (as the fee-reserved arm does for a zero fee)
+    // would put this straight back to a silent tap.
+    expect(
+      noteForResult({ amount: 0, reason: "fee-exceeds-balance", feeReserved: 0 }),
+    ).toEqual({ kind: "fee-too-large" })
+  })
 })
 
 describe("an unpriceable destination is never guessed at (ENG-554)", () => {
@@ -528,7 +549,14 @@ describe("the reserved fee leaves slack for the invoice the send actually pays",
       fetchFee: async () => 0,
     })
 
-    expect(result).toEqual({ amount: 0, reason: "fee-reserved", feeReserved: 0 })
+    // Zero, and reported as a fee that ate the balance rather than as a fee
+    // that was reserved out of it — the caller owes the user a reason, and
+    // "~0 reserved" is not one.
+    expect(result).toEqual({
+      amount: 0,
+      reason: "fee-exceeds-balance",
+      feeReserved: 0,
+    })
   })
 
   it("leaves the fee-free intraledger arm at the full balance", async () => {
@@ -540,5 +568,64 @@ describe("the reserved fee leaves slack for the invoice the send actually pays",
     })
 
     expect(result).toEqual({ amount: 100_000, reason: "intraledger-full-balance" })
+  })
+})
+
+describe("a fee bigger than the balance is an answer, not a shrug", () => {
+  // The tap has to say something. Clamping to zero under the fee-reserved
+  // banner routed straight to a `null` result in max-amount-button, which the
+  // amount screen drops on the floor: the chip spun, went back to outlined,
+  // and explained nothing.
+  it("reports the fee that swallowed the balance (2_000 sats, 2_500-sat fee)", async () => {
+    // A BTC wallet holding 2_000 sats against a Breez channel-open fee.
+    const result = await computeMaxSendAmount({
+      paymentType: "lnurl",
+      balance: 2_000,
+      fetchFee: async () => 2_500,
+    })
+
+    expect(result).toEqual({
+      amount: 0,
+      reason: "fee-exceeds-balance",
+      feeReserved: 2_500,
+    })
+  })
+
+  it("covers the boundary where the fee exactly consumes the balance", async () => {
+    // balance − ceil(fee) − 1 === 0. Nothing to offer, so it must not report
+    // itself as a reservation.
+    const result = await computeMaxSendAmount({
+      paymentType: "lnurl",
+      balance: 2_500,
+      fetchFee: async () => 2_499,
+    })
+
+    expect(result).toEqual({
+      amount: 0,
+      reason: "fee-exceeds-balance",
+      feeReserved: 2_499,
+    })
+  })
+
+  it("still reserves normally one unit above that boundary", async () => {
+    const result = await computeMaxSendAmount({
+      paymentType: "lnurl",
+      balance: 2_501,
+      fetchFee: async () => 2_499,
+    })
+
+    expect(result).toEqual({ amount: 1, reason: "fee-reserved", feeReserved: 2_499 })
+  })
+
+  it("keeps an unpriceable destination distinct from an unaffordable one", async () => {
+    // Both propose nothing, but the user's next move differs: retry versus
+    // top up. Collapsing them would hand back the wrong note.
+    const unpriceable = await computeMaxSendAmount({
+      paymentType: "lnurl",
+      balance: 2_000,
+      fetchFee: async () => null,
+    })
+
+    expect(unpriceable).toEqual({ amount: 0, reason: "fee-unavailable" })
   })
 })

--- a/__tests__/utils/max-send-amount.spec.ts
+++ b/__tests__/utils/max-send-amount.spec.ts
@@ -27,8 +27,10 @@ describe("computeMaxSendAmount", () => {
       fetchFee: async () => 320,
     })
 
+    // 100_000 − 320 fee − 1 unit of slack: the estimate was priced against
+    // the probe invoice, not the one the send will actually pay.
     expect(result).toEqual({
-      amount: 99_680,
+      amount: 99_679,
       reason: "fee-reserved",
       feeReserved: 320,
     })
@@ -42,7 +44,7 @@ describe("computeMaxSendAmount", () => {
     })
 
     expect(result).toEqual({
-      amount: 99_740,
+      amount: 99_739,
       reason: "fee-reserved",
       feeReserved: 260,
     })
@@ -127,7 +129,8 @@ describe("computeMaxSendAmount", () => {
     // would fail LUD-06 bounds validation (fee null), MAX would fill 99_900
     // with no fee headroom, and confirm-time 99_900 + 300 > 100_000 would
     // dead-end. Probing at the capped amount keeps the estimate, so MAX
-    // fills 99_700 — confirm-safe (99_700 + 300 = 100_000).
+    // fills 99_699 — confirm-safe with a unit to spare
+    // (99_699 + 300 = 99_999 < 100_000).
     const fetchFee = jest.fn(async (probeAmount: number) =>
       probeAmount > 99_900 ? null : 300,
     )
@@ -141,7 +144,7 @@ describe("computeMaxSendAmount", () => {
 
     expect(fetchFee).toHaveBeenCalledWith(99_900)
     expect(result).toEqual({
-      amount: 99_700,
+      amount: 99_699,
       reason: "fee-reserved",
       feeReserved: 300,
     })
@@ -156,7 +159,7 @@ describe("computeMaxSendAmount", () => {
     })
 
     expect(result).toEqual({
-      amount: 99_500,
+      amount: 99_499,
       reason: "fee-reserved",
       feeReserved: 500,
     })
@@ -272,7 +275,7 @@ describe("computeMaxSendAmount", () => {
         fetchFee: async () => 0,
       })
 
-      expect(result).toEqual({ amount: 109, reason: "fee-reserved", feeReserved: 0 })
+      expect(result).toEqual({ amount: 108, reason: "fee-reserved", feeReserved: 0 })
     })
 
     it("floors a fractional recipient cap before offering it", async () => {
@@ -455,7 +458,7 @@ describe("an unpriceable destination is never guessed at (ENG-554)", () => {
       fetchFee: async () => 2,
     })
 
-    expect(result).toEqual({ amount: 440, reason: "fee-reserved", feeReserved: 2 })
+    expect(result).toEqual({ amount: 439, reason: "fee-reserved", feeReserved: 2 })
   })
 
   it("probes at the amount it is about to offer, not some other one", async () => {
@@ -472,5 +475,70 @@ describe("an unpriceable destination is never guessed at (ENG-554)", () => {
     expect(noteForResult({ amount: 0, reason: "fee-unavailable" })).toEqual({
       kind: "fee-unknown",
     })
+  })
+})
+
+describe("the reserved fee leaves slack for the invoice the send actually pays", () => {
+  // The probe prices a THROWAWAY invoice minted at the probe amount; pressing
+  // Next mints a fresh invoice at balance − fee and re-prices that one.
+  // Amount-monotonicity says a smaller amount is not dearer on the same route
+  // — it says nothing about invoice-to-invoice route variance. So the max
+  // reserves ceil(fee) plus one whole minor unit.
+  it("rounds a fractional fee up rather than leaving sub-unit margin", async () => {
+    const result = await computeMaxSendAmount({
+      paymentType: "lnurl",
+      balance: 442,
+      fetchFee: async () => 0.5,
+    })
+
+    // Not 441 (442 − 0.5 floored): ceil(0.5) = 1, then a unit of slack.
+    expect(result).toEqual({ amount: 440, reason: "fee-reserved", feeReserved: 0.5 })
+  })
+
+  it("survives the confirm-time re-price that used to dead-end the send", async () => {
+    // The regression band, exactly: balance 442¢, probe fee 0.5¢. The old
+    // `floor(balance - fee)` filled 441¢; the final invoice priced at 1.5¢ and
+    // fetchSendingFee blocked with "amount exceeds balance (amount + fee)".
+    const balance = 442
+    const confirmTimeFee = 1.5
+
+    const result = await computeMaxSendAmount({
+      paymentType: "lnurl",
+      balance,
+      fetchFee: async () => 0.5,
+    })
+
+    expect(result.amount + confirmTimeFee).toBeLessThanOrEqual(balance)
+  })
+
+  it("reserves the slack for a zero fee too (the estimate is not a cap)", async () => {
+    const result = await computeMaxSendAmount({
+      paymentType: "lightning",
+      balance: 100_000,
+      fetchFee: async () => 0,
+    })
+
+    expect(result).toEqual({ amount: 99_999, reason: "fee-reserved", feeReserved: 0 })
+  })
+
+  it("still never goes negative when the slack would push below zero", async () => {
+    const result = await computeMaxSendAmount({
+      paymentType: "lightning",
+      balance: 1,
+      fetchFee: async () => 0,
+    })
+
+    expect(result).toEqual({ amount: 0, reason: "fee-reserved", feeReserved: 0 })
+  })
+
+  it("leaves the fee-free intraledger arm at the full balance", async () => {
+    // No probe, no invoice, no re-price — nothing to leave slack for.
+    const result = await computeMaxSendAmount({
+      paymentType: "intraledger",
+      balance: 100_000,
+      fetchFee: jest.fn(),
+    })
+
+    expect(result).toEqual({ amount: 100_000, reason: "intraledger-full-balance" })
   })
 })

--- a/__tests__/utils/max-send-amount.spec.ts
+++ b/__tests__/utils/max-send-amount.spec.ts
@@ -1,8 +1,10 @@
 import {
   computeMaxSendAmount,
   effectiveMaxPaymentType,
+  maxAmountWithinFeeCap,
   maxChipSupportsPaymentType,
   noteForResult,
+  reservedFeeCapFor,
   resolveRecipientCap,
 } from "../../app/screens/send-bitcoin-screen/max-send-amount"
 
@@ -48,17 +50,25 @@ describe("computeMaxSendAmount", () => {
     })
   })
 
-  it("falls back to the full balance when no fee estimate is available", async () => {
+  it("reserves the backend fee cap when no fee estimate is available", async () => {
+    // The LNURL case: no invoice exists yet, so there is nothing to probe.
+    // Offering the full 100_000 would be rejected by the backend, which adds
+    // its own cap on top and checks balance >= amount + fee.
     const result = await computeMaxSendAmount({
       paymentType: "lnurl",
       balance: 100_000,
       fetchFee: async () => null,
     })
 
-    expect(result).toEqual({ amount: 100_000, reason: "fee-unavailable" })
+    expect(result).toEqual({
+      amount: 99_503,
+      reason: "fee-unavailable",
+      feeReserved: 497,
+    })
+    expect(result.amount + reservedFeeCapFor(result.amount)).toBeLessThanOrEqual(100_000)
   })
 
-  it("falls back to the full balance when the fee fetch throws", async () => {
+  it("reserves the fee cap when the fee fetch throws", async () => {
     const result = await computeMaxSendAmount({
       paymentType: "lightning",
       balance: 100_000,
@@ -67,10 +77,14 @@ describe("computeMaxSendAmount", () => {
       },
     })
 
-    expect(result).toEqual({ amount: 100_000, reason: "fee-unavailable" })
+    expect(result).toEqual({
+      amount: 99_503,
+      reason: "fee-unavailable",
+      feeReserved: 497,
+    })
   })
 
-  it("falls back to the full balance when the fee fetch hangs past the timeout", async () => {
+  it("reserves the fee cap when the fee fetch hangs past the timeout", async () => {
     const result = await computeMaxSendAmount({
       paymentType: "lightning",
       balance: 100_000,
@@ -79,7 +93,11 @@ describe("computeMaxSendAmount", () => {
       timeoutMs: 20,
     })
 
-    expect(result).toEqual({ amount: 100_000, reason: "fee-unavailable" })
+    expect(result).toEqual({
+      amount: 99_503,
+      reason: "fee-unavailable",
+      feeReserved: 497,
+    })
   })
 
   it("clamps to the recipient's LNURL maxSendable when it is the binding limit", async () => {
@@ -238,8 +256,18 @@ describe("computeMaxSendAmount", () => {
       fetchFee: async () => Number.NaN,
     })
 
-    expect(negative).toEqual({ amount: 100_000, reason: "fee-unavailable" })
-    expect(nan).toEqual({ amount: 100_000, reason: "fee-unavailable" })
+    // Both take the no-estimate path, which reserves the backend fee cap
+    // rather than offering the full balance.
+    expect(negative).toEqual({
+      amount: 99_503,
+      reason: "fee-unavailable",
+      feeReserved: 497,
+    })
+    expect(nan).toEqual({
+      amount: 99_503,
+      reason: "fee-unavailable",
+      feeReserved: 497,
+    })
   })
 
   // On-device repro (2026-08-13): USD cash balance arrives as FRACTIONAL
@@ -420,5 +448,73 @@ describe("noteForResult", () => {
     expect(noteForResult({ amount: 0, reason: "zero-balance" })).toEqual({
       kind: "none",
     })
+  })
+})
+
+describe("fee-cap reserve (ENG-554)", () => {
+  // The reported failure: balance $4.42, MAX filled the full 442 cents, the
+  // backend added its cap on top and refused the send. $4.00 went through
+  // because it happened to leave enough headroom.
+  it("leaves headroom for the reported 442-cent balance", async () => {
+    const result = await computeMaxSendAmount({
+      paymentType: "lnurl",
+      balance: 442,
+      fetchFee: async () => null,
+    })
+
+    expect(result.amount).toBeLessThan(442)
+    expect(result.amount + reservedFeeCapFor(result.amount)).toBeLessThanOrEqual(442)
+  })
+
+  it("never proposes an amount the backend balance check would refuse", () => {
+    // Exhaustive over the range a cash wallet actually lives in, plus the
+    // boundaries where the one-unit fee floor dominates the percentage.
+    for (let balance = 1; balance <= 5_000; balance += 1) {
+      const amount = maxAmountWithinFeeCap(balance)
+      expect(amount + reservedFeeCapFor(amount)).toBeLessThanOrEqual(balance)
+    }
+  })
+
+  it("offers the largest amount that fits — not a needlessly conservative one", () => {
+    for (let balance = 2; balance <= 5_000; balance += 1) {
+      const amount = maxAmountWithinFeeCap(balance)
+      const nextUp = amount + 1
+      expect(nextUp + reservedFeeCapFor(nextUp)).toBeGreaterThan(balance)
+    }
+  })
+
+  it("yields nothing spendable when the balance cannot cover the minimum fee", () => {
+    // One minor unit: any send needs at least a 1-unit fee on top, so there
+    // is no amount that fits. The chip greys out rather than filling a 1.
+    expect(maxAmountWithinFeeCap(1)).toBe(0)
+    expect(maxAmountWithinFeeCap(0)).toBe(0)
+    expect(maxAmountWithinFeeCap(-5)).toBe(0)
+    expect(maxAmountWithinFeeCap(NaN)).toBe(0)
+  })
+
+  it("mirrors the backend cap: 50 bps with a one-unit floor", () => {
+    expect(reservedFeeCapFor(10_000)).toBe(50)
+    expect(reservedFeeCapFor(1_000)).toBe(5)
+    // Below 200 the percentage floors to zero, so the one-unit floor applies.
+    expect(reservedFeeCapFor(100)).toBe(1)
+    expect(reservedFeeCapFor(1)).toBe(1)
+  })
+
+  it("still explains the shortfall to the user", () => {
+    // Without a note the amount screen would silently show less than the
+    // balance the user can see on the home screen.
+    expect(
+      noteForResult({ amount: 439, reason: "fee-unavailable", feeReserved: 3 }),
+    ).toEqual({ kind: "fee-reserved", feeReserved: 3 })
+  })
+
+  it("intraledger is untouched — genuinely fee-free, so MAX stays the full balance", async () => {
+    const result = await computeMaxSendAmount({
+      paymentType: "intraledger",
+      balance: 442,
+      fetchFee: async () => null,
+    })
+
+    expect(result).toEqual({ amount: 442, reason: "intraledger-full-balance" })
   })
 })

--- a/app/components/amount-input-screen/amount-input-screen.tsx
+++ b/app/components/amount-input-screen/amount-input-screen.tsx
@@ -23,8 +23,12 @@ import {
 } from "./number-pad-reducer"
 
 export type MaxAmountButtonResult = {
-  /** The computed max, in the sending wallet's currency. */
-  amount: MoneyAmount<WalletOrDisplayCurrency>
+  /**
+   * The computed max, in the sending wallet's currency. Absent when the
+   * computation declined to propose one — an unpriceable destination, say —
+   * in which case `note` carries the reason and the pad is left alone.
+   */
+  amount?: MoneyAmount<WalletOrDisplayCurrency>
   /** Info-row note explaining the computation (fee reserved, no fee, cap). */
   note?: string
 }
@@ -271,12 +275,21 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
               if (!result) {
                 return
               }
+              // Explained-but-empty: nothing to fill, but the user still
+              // needs to know why the chip did nothing.
+              if (!result.amount) {
+                if (editGeneration.current === generationAtTap) {
+                  setAppliedMax({ note: result.note })
+                }
+                return
+              }
+              const resultAmount = result.amount
               // The user typed, cleared, or toggled currency while the fee
               // fetch was in flight — their edit wins; drop the stale max.
               if (editGeneration.current !== generationAtTap) {
                 return
               }
-              const converted = convertMoneyAmount(result.amount, currencyRef.current)
+              const converted = convertMoneyAmount(resultAmount, currencyRef.current)
               // The pad may hold a DIFFERENT currency than the wallet (e.g.
               // JMD display over a USD wallet). The send path converts the
               // pad amount BACK to wallet units and rounds, so a display
@@ -287,9 +300,9 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
               let fillAmount = Math.floor(converted.amount)
               const roundTripsAboveMax = (amount: number) =>
                 Math.round(
-                  convertMoneyAmount({ ...converted, amount }, result.amount.currency)
+                  convertMoneyAmount({ ...converted, amount }, resultAmount.currency)
                     .amount,
-                ) > result.amount.amount
+                ) > resultAmount.amount
               while (fillAmount > 0 && roundTripsAboveMax(fillAmount)) {
                 fillAmount -= 1
               }
@@ -301,8 +314,8 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
               // toggle does) and shows the true max, which needs no display
               // round-trip — the computation already floors it to whole
               // wallet minor units.
-              if (fillAmount === 0 && result.amount.amount > 0) {
-                setNumberPadAmount(result.amount)
+              if (fillAmount === 0 && resultAmount.amount > 0) {
+                setNumberPadAmount(resultAmount)
               } else {
                 setNumberPadAmount({
                   ...converted,

--- a/app/components/amount-input-screen/amount-input-screen.tsx
+++ b/app/components/amount-input-screen/amount-input-screen.tsx
@@ -188,10 +188,19 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
     displayAmount: convertMoneyAmount(newPrimaryAmount, DisplayCurrency),
   })
 
-  // MAX chip: solid ("active") from the moment the tap fills the amount until
+  // MAX chip: solid ("active") from the moment the tap FILLS the amount until
   // the user edits it; the currency toggle keeps the same underlying amount so
   // it does not clear the state.
-  const [appliedMax, setAppliedMax] = useState<{ note?: string } | null>(null)
+  //
+  // `applied` is deliberately separate from `note`: a tap can end with a note
+  // and no fill (an unpriceable destination explains itself without proposing
+  // an amount). That must leave the chip outlined and unselected — a solid,
+  // VoiceOver-"selected" MAX over an unchanged $0 pad claims a max was applied
+  // when none was.
+  const [appliedMax, setAppliedMax] = useState<{
+    note?: string
+    applied: boolean
+  } | null>(null)
   const [isComputingMax, setIsComputingMax] = useState(false)
   const maxComputeInFlight = useRef(false)
   // The fee fetch behind compute() can take seconds. Every user edit
@@ -276,10 +285,12 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
                 return
               }
               // Explained-but-empty: nothing to fill, but the user still
-              // needs to know why the chip did nothing.
+              // needs to know why the chip did nothing. `applied: false` keeps
+              // the chip outlined — no max was applied, so it must not claim
+              // one (visually or to VoiceOver).
               if (!result.amount) {
                 if (editGeneration.current === generationAtTap) {
-                  setAppliedMax({ note: result.note })
+                  setAppliedMax({ note: result.note, applied: false })
                 }
                 return
               }
@@ -322,7 +333,7 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
                   amount: fillAmount,
                 })
               }
-              setAppliedMax({ note: result.note })
+              setAppliedMax({ note: result.note, applied: true })
             })
             .catch(() => {
               // The computation is expected to resolve with a fallback; a
@@ -342,7 +353,7 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
     } else if (isComputingMax) {
       maxChipState = "computing"
     } else {
-      maxChipState = appliedMax ? "active" : "available"
+      maxChipState = appliedMax?.applied ? "active" : "available"
     }
   }
 

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -1763,7 +1763,7 @@ const en: BaseTranslation = {
     maxNoteFeeUnknown:
       "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
     maxNoteFeeTooLarge:
-      "The network fee is more than this balance can cover — nothing to send right now",
+      "This balance is too small to send after the network fee — nothing to send right now",
   },
   AmountInputButton: {
     tapToSetAmount: "Add an amount",

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -1761,7 +1761,7 @@ const en: BaseTranslation = {
     maxNoteRecipientCap:
       "Capped at {max: string} — the most this recipient can receive per payment",
     maxNoteFeeUnknown:
-      "Couldn't estimate the network fee for this destination — enter an amount to continue",
+      "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
   },
   AmountInputButton: {
     tapToSetAmount: "Add an amount",

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -1760,6 +1760,8 @@ const en: BaseTranslation = {
       "~{fee: string} reserved for the network fee — final fee shown on confirm",
     maxNoteRecipientCap:
       "Capped at {max: string} — the most this recipient can receive per payment",
+    maxNoteFeeUnknown:
+      "Couldn't estimate the network fee for this destination — enter an amount to continue",
   },
   AmountInputButton: {
     tapToSetAmount: "Add an amount",

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -1762,6 +1762,8 @@ const en: BaseTranslation = {
       "Capped at {max: string} — the most this recipient can receive per payment",
     maxNoteFeeUnknown:
       "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    maxNoteFeeTooLarge:
+      "The network fee is more than this balance can cover — nothing to send right now",
   },
   AmountInputButton: {
     tapToSetAmount: "Add an amount",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -5737,6 +5737,10 @@ type RootTranslation = {
 		 * C​o​u​l​d​n​'​t​ ​e​s​t​i​m​a​t​e​ ​t​h​e​ ​n​e​t​w​o​r​k​ ​f​e​e​ ​r​i​g​h​t​ ​n​o​w​ ​—​ ​t​a​p​ ​M​A​X​ ​a​g​a​i​n​ ​o​r​ ​e​n​t​e​r​ ​a​n​ ​a​m​o​u​n​t
 		 */
 		maxNoteFeeUnknown: string
+		/**
+		 * T​h​e​ ​n​e​t​w​o​r​k​ ​f​e​e​ ​i​s​ ​m​o​r​e​ ​t​h​a​n​ ​t​h​i​s​ ​b​a​l​a​n​c​e​ ​c​a​n​ ​c​o​v​e​r​ ​—​ ​n​o​t​h​i​n​g​ ​t​o​ ​s​e​n​d​ ​r​i​g​h​t​ ​n​o​w
+		 */
+		maxNoteFeeTooLarge: string
 	}
 	AmountInputButton: {
 		/**
@@ -11975,6 +11979,10 @@ export type TranslationFunctions = {
 		 * Couldn't estimate the network fee right now — tap MAX again or enter an amount
 		 */
 		maxNoteFeeUnknown: () => LocalizedString
+		/**
+		 * The network fee is more than this balance can cover — nothing to send right now
+		 */
+		maxNoteFeeTooLarge: () => LocalizedString
 	}
 	AmountInputButton: {
 		/**

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -5738,7 +5738,7 @@ type RootTranslation = {
 		 */
 		maxNoteFeeUnknown: string
 		/**
-		 * T​h​e​ ​n​e​t​w​o​r​k​ ​f​e​e​ ​i​s​ ​m​o​r​e​ ​t​h​a​n​ ​t​h​i​s​ ​b​a​l​a​n​c​e​ ​c​a​n​ ​c​o​v​e​r​ ​—​ ​n​o​t​h​i​n​g​ ​t​o​ ​s​e​n​d​ ​r​i​g​h​t​ ​n​o​w
+		 * T​h​i​s​ ​b​a​l​a​n​c​e​ ​i​s​ ​t​o​o​ ​s​m​a​l​l​ ​t​o​ ​s​e​n​d​ ​a​f​t​e​r​ ​t​h​e​ ​n​e​t​w​o​r​k​ ​f​e​e​ ​—​ ​n​o​t​h​i​n​g​ ​t​o​ ​s​e​n​d​ ​r​i​g​h​t​ ​n​o​w
 		 */
 		maxNoteFeeTooLarge: string
 	}
@@ -11980,7 +11980,7 @@ export type TranslationFunctions = {
 		 */
 		maxNoteFeeUnknown: () => LocalizedString
 		/**
-		 * The network fee is more than this balance can cover — nothing to send right now
+		 * This balance is too small to send after the network fee — nothing to send right now
 		 */
 		maxNoteFeeTooLarge: () => LocalizedString
 	}

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -5733,6 +5733,10 @@ type RootTranslation = {
 		 * @param {string} max
 		 */
 		maxNoteRecipientCap: RequiredParams<'max'>
+		/**
+		 * C​o​u​l​d​n​'​t​ ​e​s​t​i​m​a​t​e​ ​t​h​e​ ​n​e​t​w​o​r​k​ ​f​e​e​ ​f​o​r​ ​t​h​i​s​ ​d​e​s​t​i​n​a​t​i​o​n​ ​—​ ​e​n​t​e​r​ ​a​n​ ​a​m​o​u​n​t​ ​t​o​ ​c​o​n​t​i​n​u​e
+		 */
+		maxNoteFeeUnknown: string
 	}
 	AmountInputButton: {
 		/**
@@ -11967,6 +11971,10 @@ export type TranslationFunctions = {
 		 * Capped at {max} — the most this recipient can receive per payment
 		 */
 		maxNoteRecipientCap: (arg: { max: string }) => LocalizedString
+		/**
+		 * Couldn't estimate the network fee for this destination — enter an amount to continue
+		 */
+		maxNoteFeeUnknown: () => LocalizedString
 	}
 	AmountInputButton: {
 		/**

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -5734,7 +5734,7 @@ type RootTranslation = {
 		 */
 		maxNoteRecipientCap: RequiredParams<'max'>
 		/**
-		 * C​o​u​l​d​n​'​t​ ​e​s​t​i​m​a​t​e​ ​t​h​e​ ​n​e​t​w​o​r​k​ ​f​e​e​ ​f​o​r​ ​t​h​i​s​ ​d​e​s​t​i​n​a​t​i​o​n​ ​—​ ​e​n​t​e​r​ ​a​n​ ​a​m​o​u​n​t​ ​t​o​ ​c​o​n​t​i​n​u​e
+		 * C​o​u​l​d​n​'​t​ ​e​s​t​i​m​a​t​e​ ​t​h​e​ ​n​e​t​w​o​r​k​ ​f​e​e​ ​r​i​g​h​t​ ​n​o​w​ ​—​ ​t​a​p​ ​M​A​X​ ​a​g​a​i​n​ ​o​r​ ​e​n​t​e​r​ ​a​n​ ​a​m​o​u​n​t
 		 */
 		maxNoteFeeUnknown: string
 	}
@@ -11972,7 +11972,7 @@ export type TranslationFunctions = {
 		 */
 		maxNoteRecipientCap: (arg: { max: string }) => LocalizedString
 		/**
-		 * Couldn't estimate the network fee for this destination — enter an amount to continue
+		 * Couldn't estimate the network fee right now — tap MAX again or enter an amount
 		 */
 		maxNoteFeeUnknown: () => LocalizedString
 	}

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -1606,7 +1606,8 @@
         "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
         "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
         "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-        "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+        "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+        "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
     },
     "AmountInputButton": {
         "tapToSetAmount": "Add an amount",

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -1606,7 +1606,7 @@
         "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
         "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
         "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-        "maxNoteFeeUnknown": "Couldn't estimate the network fee for this destination — enter an amount to continue"
+        "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
     },
     "AmountInputButton": {
         "tapToSetAmount": "Add an amount",

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -1607,7 +1607,7 @@
         "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
         "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
         "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-        "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+        "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
     },
     "AmountInputButton": {
         "tapToSetAmount": "Add an amount",

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -663,6 +663,7 @@
         "paymentSetupFailed": "Failed to initiate payment. Please try again.",
         "changeAmount": "Change amount",
         "allowanceRemaining": "{remaining} of {limit} left today",
+        "allowanceExhausted": "You've used today's {limit} top-up limit",
         "allowanceHeld": "{held} is held by a payment link you haven't completed",
         "allowanceResets": "More becomes available at {when: string}",
         "bankTransfer": "Bank Transfer",
@@ -1604,7 +1605,8 @@
         "max": "MAX",
         "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
         "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-        "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+        "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+        "maxNoteFeeUnknown": "Couldn't estimate the network fee for this destination — enter an amount to continue"
     },
     "AmountInputButton": {
         "tapToSetAmount": "Add an amount",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -1208,7 +1208,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Tik om bedrag te stel",
@@ -1583,6 +1584,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -1210,7 +1210,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Tik om bedrag te stel",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -1209,7 +1209,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Tik om bedrag te stel",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -1151,7 +1151,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -1152,7 +1152,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -1150,7 +1150,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",
@@ -1588,6 +1589,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Toca per definir l'import",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Toca per definir l'import",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Toca per definir l'import",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Klepnutím nastavte částku",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Klepnutím nastavte částku",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Klepnutím nastavte částku",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Vælg beløb",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Vælg beløb",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Vælg beløb",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Tippen, um Betrag festzulegen.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Tippen, um Betrag festzulegen.",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Tippen, um Betrag festzulegen.",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Πατήστε για να ορίσετε ποσό",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Πατήστε για να ορίσετε ποσό",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Πατήστε για να ορίσετε ποσό",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Pulse para establecer una cantidad",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Pulse para establecer una cantidad",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Pulse para establecer una cantidad",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Toucher pour fixer le montant",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Toucher pour fixer le montant",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Toucher pour fixer le montant",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Dodirni za postavljanje iznosa",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Dodirni za postavljanje iznosa",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Dodirni za postavljanje iznosa",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Összeg beállítása",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Összeg beállítása",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Összeg beállítása",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Սեղմել՝ գումարի չափը սահմանելու համար",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Սեղմել՝ գումարի չափը սահմանելու համար",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Սեղմել՝ գումարի չափը սահմանելու համար",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Tekan untuk tetapkan amaun",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Tekan untuk tetapkan amaun",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Tekan untuk tetapkan amaun",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Tik om het bedrag in te stellen",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Tik om het bedrag in te stellen",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Tik om het bedrag in te stellen",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Toque para inserir quantidade",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Toque para inserir quantidade",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Toque para inserir quantidade",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Chimpuy ruranichu kaymi kanchu",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Chimpuy ruranichu kaymi kanchu",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Chimpuy ruranichu kaymi kanchu",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Додирните да бисте поставили износ",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Додирните да бисте поставили износ",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Додирните да бисте поставили износ",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -1151,7 +1151,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -1152,7 +1152,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -1150,7 +1150,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",
@@ -1588,6 +1589,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Tutarı ayarlamak için dokunun",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Tutarı ayarlamak için dokunun",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Tutarı ayarlamak için dokunun",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -1373,7 +1373,7 @@
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
     "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
-    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
+    "maxNoteFeeTooLarge": "This balance is too small to send after the network fee — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -1371,7 +1371,8 @@
     "max": "MAX",
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
-    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment"
+    "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -1372,7 +1372,8 @@
     "maxNoteIntraledger": "Full balance — no fee between Flash accounts",
     "maxNoteFeeReserved": "~{fee: string} reserved for the network fee — final fee shown on confirm",
     "maxNoteRecipientCap": "Capped at {max: string} — the most this recipient can receive per payment",
-    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount"
+    "maxNoteFeeUnknown": "Couldn't estimate the network fee right now — tap MAX again or enter an amount",
+    "maxNoteFeeTooLarge": "The network fee is more than this balance can cover — nothing to send right now"
   },
   "AmountInputButton": {
     "tapToSetAmount": "Add an amount",

--- a/app/screens/send-bitcoin-screen/lnurl-fee-probe.ts
+++ b/app/screens/send-bitcoin-screen/lnurl-fee-probe.ts
@@ -12,6 +12,9 @@
 // the sat conversion, the invoice mint, the timeout and the failure mapping are
 // unit-testable under plain jest (mirrors max-amount-button.ts).
 
+import { requestInvoiceWithServiceParams, utils } from "lnurl-pay"
+import type { LnUrlPayServiceResponse } from "lnurl-pay/dist/types/types"
+
 /** Structural stand-in for MoneyAmount — keeps this module RN-free. */
 type MoneyAmountShape = { amount: number }
 
@@ -72,6 +75,36 @@ export type PriceLnurlSendArgs<
   /** Runs a priced detail's getFee (the IBEX fee probe). */
   getIbexFee: (getFee: F | undefined) => Promise<MoneyAmountShape | undefined>
   timeoutMs?: number
+}
+
+/**
+ * The real invoice mint: `PriceLnurlSendArgs["requestInvoice"]` bound to
+ * lnurl-pay. Lives here rather than inline in the send screen so the two
+ * choices it encodes are testable.
+ *
+ * The params-taking `requestInvoiceWithServiceParams`, not the address-taking
+ * `requestInvoice`: the receiver's pay-service params are already resolved on
+ * the payment detail, so this is ONE round-trip to their callback instead of
+ * two, which is the difference between a slow-but-priceable destination and
+ * one that reads as unpriceable inside the probe budget.
+ *
+ * `utils.toSats` is a bare cast — it brands a number as Satoshis without
+ * checking anything — so the whole-sat contract is enforced here before the
+ * cast rather than trusted after it. A fractional or millisat value reaching
+ * the receiver mints an invoice for the wrong amount (or none at all); the
+ * throw is caught by `priceLnurlSend` and reads as "couldn't price it".
+ */
+export const mintProbeInvoice = async ({
+  params,
+  sats,
+}: {
+  params: LnUrlPayServiceResponse
+  sats: number
+}): Promise<{ invoice: string }> => {
+  if (!Number.isInteger(sats) || sats <= 0) {
+    throw new Error(`lnurl fee probe: refusing to mint an invoice for ${sats} sats`)
+  }
+  return requestInvoiceWithServiceParams({ params, tokens: utils.toSats(sats) })
 }
 
 const TIMED_OUT = Symbol("lnurl-probe-timeout")
@@ -149,8 +182,26 @@ export const priceLnurlSend = async <
   }
 }
 
-/** An in-flight or already-answered invoice mint. */
-type MintEntry = { promise: Promise<{ invoice: string }>; settled: boolean }
+/**
+ * An invoice mint — in flight, or answered and still young enough to reuse.
+ *
+ * `mintedAt` is stamped when the REQUEST goes out rather than when it answers:
+ * the receiver's own expiry clock starts no later than that, so ageing from
+ * here retires an invoice at or before the receiver does, never after.
+ */
+type MintEntry = { promise: Promise<{ invoice: string }>; mintedAt: number }
+
+/**
+ * How long a mint may be reused.
+ *
+ * These invoices expire 60s after the receiver issues them, and the mint key
+ * is destination + SATS while the fee key is destination + wallet + probe
+ * amount — 441¢ and 442¢ both round to 221 sats at 2¢/sat, so a brand-new fee
+ * key can land on an existing mint. Without an age bound that mint could be
+ * minutes old, and IBEX would refuse the expired invoice it prices. 45s leaves
+ * the route probe room to finish against an invoice that is still alive.
+ */
+export const MINT_REUSE_TTL_MS = 45_000
 
 /**
  * Per-screen memo for the LNURL price probe. Every probe that reaches the
@@ -205,10 +256,15 @@ export type MakeLnurlFeeProbeArgs<
  *   the budget — Tor-hosted, cold serverless, LNbits under load — costs a
  *   fresh invoice on every tap and never caches anything, which is the exact
  *   orphan/rate-limit failure the memo exists to prevent.
- * - A mint that REJECTED is forgotten immediately, and one that answered but
- *   could not be priced is forgotten once the probe using it gives up: reusing
- *   a settled-but-unpriceable invoice forever would brand the destination dead
- *   just as surely as caching the null.
+ * - A mint that REJECTED is forgotten immediately; a mint that ANSWERED is
+ *   kept until it ages out (MINT_REUSE_TTL_MS), whatever became of the probe
+ *   that asked for it. Dropping a live invoice because the probe failed reads
+ *   the failure as the invoice's fault, and usually it is not: mint at 2s,
+ *   route probe hangs, budget fires at 7s, and a 2s-old invoice good for
+ *   another 53s is thrown away. The note tells the user to tap MAX again, so
+ *   the next tap mints another at the receiver — the same orphan/rate-limit
+ *   failure this memo exists to prevent, moved from the first leg to the
+ *   second. Age, not the outcome of a probe, is what retires an invoice.
  */
 export const makeLnurlFeeProbe =
   <M extends MoneyAmountShape, B extends MoneyAmountShape, F, P>({
@@ -225,43 +281,35 @@ export const makeLnurlFeeProbe =
       return cachedFee
     }
 
-    let mintKey: string | undefined
-
     const fee = await priceLnurlSend({
       ...priceArgs,
       probeAmount,
       requestInvoice: ({ params, sats }) => {
-        mintKey = `${destination}:${sats}`
+        const mintKey = `${destination}:${sats}`
         const outstanding = cache.mints.get(mintKey)
-        if (outstanding) {
+        if (outstanding && Date.now() - outstanding.mintedAt < MINT_REUSE_TTL_MS) {
           return outstanding.promise
         }
         const entry: MintEntry = {
           promise: requestInvoice({ params, sats }),
-          settled: false,
+          mintedAt: Date.now(),
         }
         cache.mints.set(mintKey, entry)
-        const key = mintKey
-        entry.promise.then(
-          () => {
-            entry.settled = true
-          },
-          () => cache.mints.delete(key),
-        )
+        entry.promise.catch(() => {
+          // A refused mint is worthless to everyone; forget it so the next tap
+          // asks again rather than awaiting a dead promise forever. Only if it
+          // is still the entry under this key — a later mint has since taken
+          // over and must not be evicted by this one's failure.
+          if (cache.mints.get(mintKey) === entry) {
+            cache.mints.delete(mintKey)
+          }
+        })
         return entry.promise
       },
     })
 
     if (fee !== null) {
       cache.fees.set(feeKey, fee)
-      return fee
     }
-    // Unpriced. Keep a mint still in flight — the next tap should await that
-    // invoice rather than ask for another — but drop one that has already
-    // answered, so the retry the note invites gets a fresh invoice instead of
-    // re-pricing the same dead one.
-    if (mintKey && cache.mints.get(mintKey)?.settled) {
-      cache.mints.delete(mintKey)
-    }
-    return null
+    return fee
   }

--- a/app/screens/send-bitcoin-screen/lnurl-fee-probe.ts
+++ b/app/screens/send-bitcoin-screen/lnurl-fee-probe.ts
@@ -19,6 +19,12 @@ type MoneyAmountShape = { amount: number }
  * The MAX chip's own fee budget is 10s (max-send-amount.ts). Keep the LNURL
  * price check well under it so a slow receiver degrades to "couldn't estimate"
  * instead of holding the tap.
+ *
+ * This bounds the WHOLE price check — the invoice mint and the IBEX fee probe
+ * that follows it — not just the mint. Timing only the mint left the second
+ * leg unbounded, so a 6.9s mint plus a 5s route probe ran 11.9s and only the
+ * chip's outer 10s race stopped it: the margin this constant exists to
+ * guarantee did not apply to the slow destinations it was written for.
  */
 export const LNURL_PROBE_TIMEOUT_MS = 7000
 
@@ -115,22 +121,25 @@ export const priceLnurlSend = async <
       return null
     }
 
-    const minted = await Promise.race([
-      requestInvoice({ params, sats }),
+    // Both legs run inside ONE timer. The IBEX leg is a real route probe that
+    // takes seconds of its own, so racing only the mint bounded half the wait
+    // and let a slow destination hold the chip for its full 10s budget.
+    const setInvoice = probeDetail.setInvoice
+    const priced = await Promise.race([
+      (async () => {
+        const minted = await requestInvoice({ params, sats })
+        const pricedDetail = setInvoice({
+          paymentRequest: minted.invoice,
+          paymentRequestAmount: { ...btcProbeAmount, amount: sats },
+        })
+        const fee = await getIbexFee(pricedDetail.getFee)
+        return fee?.amount ?? null
+      })(),
       new Promise<typeof TIMED_OUT>((resolve) => {
         timer = setTimeout(() => resolve(TIMED_OUT), timeoutMs)
       }),
     ])
-    if (minted === TIMED_OUT) {
-      return null
-    }
-
-    const pricedDetail = probeDetail.setInvoice({
-      paymentRequest: minted.invoice,
-      paymentRequestAmount: { ...btcProbeAmount, amount: sats },
-    })
-    const fee = await getIbexFee(pricedDetail.getFee)
-    return fee?.amount ?? null
+    return priced === TIMED_OUT ? null : priced
   } catch {
     // Unpriceable — the computation declines to propose an amount rather than
     // guessing one the send would refuse.
@@ -139,3 +148,120 @@ export const priceLnurlSend = async <
     clearTimeout(timer)
   }
 }
+
+/** An in-flight or already-answered invoice mint. */
+type MintEntry = { promise: Promise<{ invoice: string }>; settled: boolean }
+
+/**
+ * Per-screen memo for the LNURL price probe. Every probe that reaches the
+ * receiver mints a REAL invoice, so repeated MAX taps orphan invoices at the
+ * receiver and trip rate-limited services (BTCPay, LNbits) until the
+ * destination stops answering at all.
+ *
+ * Two maps, because the two things worth remembering have different lifetimes:
+ * a finished fee is good for the session, while a mint is worth sharing only
+ * while it is the freshest invoice anyone has.
+ */
+export type LnurlProbeCache = {
+  /** Completed fee estimates, keyed by destination + wallet + probe amount. */
+  fees: Map<string, number>
+  /** Invoice mints, keyed by destination + sats. */
+  mints: Map<string, MintEntry>
+}
+
+export const makeLnurlProbeCache = (): LnurlProbeCache => ({
+  fees: new Map(),
+  mints: new Map(),
+})
+
+export type MakeLnurlFeeProbeArgs<
+  M extends MoneyAmountShape,
+  B extends MoneyAmountShape,
+  F,
+  P,
+> = Omit<PriceLnurlSendArgs<M, B, F, P>, "probeAmount"> & {
+  /** Cache-key discriminator — the screen's resolved destination string. */
+  destination: string
+  /** Cache-key discriminator — the sending wallet, whose minor unit the
+   * probe amount is denominated in. */
+  walletCurrency: string
+  cache: LnurlProbeCache
+}
+
+/**
+ * A memoized `probeLnurlFee` for `buildMaxAmountButton`.
+ *
+ * The glue that used to sit inline in the send screen, extracted so the
+ * caching rules are testable — they are the part with teeth:
+ *
+ * - A completed fee is cached; a null is NOT. A transient failure must not
+ *   brand a destination unpriceable for the life of the screen, because the
+ *   note it produces invites the user to tap MAX again.
+ * - The probe amount is part of the fee key. A fee priced for a full-balance
+ *   probe reused for a smaller cap-clamped one would under-reserve.
+ * - The in-flight MINT is shared, not just the finished fee. The 7s budget
+ *   abandons the wait but cannot cancel the request, so the receiver mints and
+ *   returns an invoice regardless. Without this, every destination slower than
+ *   the budget — Tor-hosted, cold serverless, LNbits under load — costs a
+ *   fresh invoice on every tap and never caches anything, which is the exact
+ *   orphan/rate-limit failure the memo exists to prevent.
+ * - A mint that REJECTED is forgotten immediately, and one that answered but
+ *   could not be priced is forgotten once the probe using it gives up: reusing
+ *   a settled-but-unpriceable invoice forever would brand the destination dead
+ *   just as surely as caching the null.
+ */
+export const makeLnurlFeeProbe =
+  <M extends MoneyAmountShape, B extends MoneyAmountShape, F, P>({
+    destination,
+    walletCurrency,
+    cache,
+    requestInvoice,
+    ...priceArgs
+  }: MakeLnurlFeeProbeArgs<M, B, F, P>) =>
+  async (probeAmount: number): Promise<number | null> => {
+    const feeKey = `${destination}:${walletCurrency}:${probeAmount}`
+    const cachedFee = cache.fees.get(feeKey)
+    if (cachedFee !== undefined) {
+      return cachedFee
+    }
+
+    let mintKey: string | undefined
+
+    const fee = await priceLnurlSend({
+      ...priceArgs,
+      probeAmount,
+      requestInvoice: ({ params, sats }) => {
+        mintKey = `${destination}:${sats}`
+        const outstanding = cache.mints.get(mintKey)
+        if (outstanding) {
+          return outstanding.promise
+        }
+        const entry: MintEntry = {
+          promise: requestInvoice({ params, sats }),
+          settled: false,
+        }
+        cache.mints.set(mintKey, entry)
+        const key = mintKey
+        entry.promise.then(
+          () => {
+            entry.settled = true
+          },
+          () => cache.mints.delete(key),
+        )
+        return entry.promise
+      },
+    })
+
+    if (fee !== null) {
+      cache.fees.set(feeKey, fee)
+      return fee
+    }
+    // Unpriced. Keep a mint still in flight — the next tap should await that
+    // invoice rather than ask for another — but drop one that has already
+    // answered, so the retry the note invites gets a fresh invoice instead of
+    // re-pricing the same dead one.
+    if (mintKey && cache.mints.get(mintKey)?.settled) {
+      cache.mints.delete(mintKey)
+    }
+    return null
+  }

--- a/app/screens/send-bitcoin-screen/lnurl-fee-probe.ts
+++ b/app/screens/send-bitcoin-screen/lnurl-fee-probe.ts
@@ -1,0 +1,141 @@
+// Prices an LNURL send so the MAX chip can propose a real number (ENG-554).
+//
+// An LNURL payment detail has no `getFee` until an invoice is attached
+// (payment-details/lightning.ts sets canGetFee false until then), so the plain
+// IBEX probe cannot price the destination at all — that gap is what made MAX
+// offer an amount the send then refused. This mints a throwaway invoice at the
+// probe amount purely to price it. The invoice is never paid: pressing Next
+// mints a fresh one for the actual send, which matters because these expire in
+// 60s.
+//
+// Dependency-injected and free of react-native / generated-GraphQL imports so
+// the sat conversion, the invoice mint, the timeout and the failure mapping are
+// unit-testable under plain jest (mirrors max-amount-button.ts).
+
+/** Structural stand-in for MoneyAmount — keeps this module RN-free. */
+type MoneyAmountShape = { amount: number }
+
+/**
+ * The MAX chip's own fee budget is 10s (max-send-amount.ts). Keep the LNURL
+ * price check well under it so a slow receiver degrades to "couldn't estimate"
+ * instead of holding the tap.
+ */
+export const LNURL_PROBE_TIMEOUT_MS = 7000
+
+/**
+ * The slice of PaymentDetail this probe needs, expressed structurally so the
+ * module stays out of the react-native dependency tree.
+ *
+ * `P` is the receiver's already-resolved LNURL pay-service params. Passing them
+ * to the invoice mint is what keeps this to ONE network round-trip: the
+ * address-taking `requestInvoice` re-resolves the pay service before it can hit
+ * the callback, so a receiver answering each leg in 4s would blow the budget on
+ * a destination that is perfectly priceable.
+ */
+export type LnurlProbeDetail<
+  M extends MoneyAmountShape,
+  B extends MoneyAmountShape,
+  F,
+  P,
+> = {
+  paymentType: string
+  unitOfAccountAmount: M
+  /** Invoices are denominated in sats, so `B` is the BTC-side money amount. */
+  convertMoneyAmount: (moneyAmount: M, toCurrency: "BTC") => B
+  setAmount?: (unitOfAccountAmount: M) => LnurlProbeDetail<M, B, F, P>
+  lnurlParams?: P
+  setInvoice?: (params: { paymentRequest: string; paymentRequestAmount: B }) => {
+    getFee?: F
+  }
+}
+
+export type PriceLnurlSendArgs<
+  M extends MoneyAmountShape,
+  B extends MoneyAmountShape,
+  F,
+  P,
+> = {
+  /** The screen's current payment detail. Non-LNURL details price as null. */
+  detail: LnurlProbeDetail<M, B, F, P>
+  /** Amount to price, in the sending wallet's minor units. */
+  probeAmount: number
+  /** Sending wallet balance — the currency template for the probe amount. */
+  balanceMoneyAmount: M
+  /** Mints a throwaway invoice for `sats` against the resolved pay params. */
+  requestInvoice: (args: { params: P; sats: number }) => Promise<{ invoice: string }>
+  /** Runs a priced detail's getFee (the IBEX fee probe). */
+  getIbexFee: (getFee: F | undefined) => Promise<MoneyAmountShape | undefined>
+  timeoutMs?: number
+}
+
+const TIMED_OUT = Symbol("lnurl-probe-timeout")
+
+/**
+ * The estimated fee for sending `probeAmount` to an LNURL destination, in the
+ * sending wallet's minor units, or null when it cannot be priced.
+ *
+ * Null is a real answer, not a failure to report: the max computation declines
+ * to propose an amount rather than guessing one the send would refuse.
+ */
+export const priceLnurlSend = async <
+  M extends MoneyAmountShape,
+  B extends MoneyAmountShape,
+  F,
+  P,
+>({
+  detail,
+  probeAmount,
+  balanceMoneyAmount,
+  requestInvoice,
+  getIbexFee,
+  timeoutMs = LNURL_PROBE_TIMEOUT_MS,
+}: PriceLnurlSendArgs<M, B, F, P>): Promise<number | null> => {
+  if (detail.paymentType !== "lnurl" || !detail.setAmount || !detail.lnurlParams) {
+    return null
+  }
+
+  const params = detail.lnurlParams
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    const probeDetail = detail.setAmount({ ...balanceMoneyAmount, amount: probeAmount })
+    if (probeDetail.paymentType !== "lnurl" || !probeDetail.setInvoice) {
+      return null
+    }
+
+    // Invoices are denominated in sats regardless of the sending wallet, and
+    // must be whole ones. The app's converter already rounds BTC targets; this
+    // rounds again so the module cannot mint a fractional-sat request on its
+    // own if that ever changes.
+    const btcProbeAmount = probeDetail.convertMoneyAmount(
+      probeDetail.unitOfAccountAmount,
+      "BTC",
+    )
+    const sats = Math.round(btcProbeAmount.amount)
+    if (!Number.isFinite(sats) || sats <= 0) {
+      return null
+    }
+
+    const minted = await Promise.race([
+      requestInvoice({ params, sats }),
+      new Promise<typeof TIMED_OUT>((resolve) => {
+        timer = setTimeout(() => resolve(TIMED_OUT), timeoutMs)
+      }),
+    ])
+    if (minted === TIMED_OUT) {
+      return null
+    }
+
+    const pricedDetail = probeDetail.setInvoice({
+      paymentRequest: minted.invoice,
+      paymentRequestAmount: { ...btcProbeAmount, amount: sats },
+    })
+    const fee = await getIbexFee(pricedDetail.getFee)
+    return fee?.amount ?? null
+  } catch {
+    // Unpriceable — the computation declines to propose an amount rather than
+    // guessing one the send would refuse.
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/app/screens/send-bitcoin-screen/max-amount-button-strings.ts
+++ b/app/screens/send-bitcoin-screen/max-amount-button-strings.ts
@@ -1,0 +1,33 @@
+// Localized note strings for the MAX chip.
+//
+// Split out of send-bitcoin-details-screen so the wording is unit-testable
+// without mounting the send flow (mirrors app/utils/breez-sdk/fee-error-message.ts,
+// which renders some of the same sentences for the validation banner). That
+// overlap is the point: `recipientMin` and breezFeeErrorMessage's
+// "amount-below-min" arm are one sentence about one limit, and on the BTC
+// LNURL path both can be on screen at once. Rendering the sat amount two
+// different ways there reads as two different limits, so both go through the
+// caller's `formatSats`.
+
+import type { TranslationFunctions } from "@app/i18n/i18n-types"
+
+import type { MaxAmountButtonStrings } from "./max-amount-button"
+
+/**
+ * Bind the chip's note builders to the current locale.
+ *
+ * `formatSats` converts a sat amount into the user's display format
+ * (e.g. "$0.65 (1,000 sats)") — the same function the fee-error banner uses.
+ */
+export const maxAmountButtonStrings = (
+  LL: TranslationFunctions,
+  formatSats: (sats: number) => string,
+): MaxAmountButtonStrings => ({
+  intraledger: () => LL.AmountInputScreen.maxNoteIntraledger(),
+  feeReserved: (fee) => LL.AmountInputScreen.maxNoteFeeReserved({ fee }),
+  recipientCap: (max) => LL.AmountInputScreen.maxNoteRecipientCap({ max }),
+  feeUnknown: () => LL.AmountInputScreen.maxNoteFeeUnknown(),
+  recipientMin: (minSats) =>
+    LL.SendBitcoinScreen.minReceiveAmountError({ amount: formatSats(minSats) }),
+  feeTooLarge: () => LL.AmountInputScreen.maxNoteFeeTooLarge(),
+})

--- a/app/screens/send-bitcoin-screen/max-amount-button.ts
+++ b/app/screens/send-bitcoin-screen/max-amount-button.ts
@@ -67,6 +67,10 @@ export type BuildMaxAmountButtonArgs<M extends MoneyAmountShape, F, P> = {
    * same null as a network blip and produces "couldn't estimate the fee — tap
    * MAX again" — a retry loop that cannot succeed. Checking here is what turns
    * that into the receiver's actual minimum.
+   *
+   * It bounds two things, on every wallet: the amount probed (above) and the
+   * amount proposed (in `compute`). The fee is subtracted between them, so
+   * clearing the first says nothing about clearing the second.
    */
   receiverMinSats: number | null
   /** Convert sats into the sending wallet's minor units. */
@@ -149,6 +153,16 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
 
   const withAmount = (amount: number): M => ({ ...balanceMoneyAmount, amount })
 
+  // The receiver's LUD-06 floor, carried in both units: sats for the message
+  // (the receiver advertises it in sats, and that is what their error will say)
+  // and wallet minor units for every comparison against an amount. Resolved
+  // once so the probe guard and the result guard can never drift apart —
+  // they are the two halves of one bound.
+  const recipientMin =
+    receiverMinSats !== null && Number.isFinite(receiverMinSats)
+      ? { sats: receiverMinSats, wallet: convertSatsToWallet(receiverMinSats) }
+      : null
+
   // The Breez probe returns a TYPED reason (below the receiver's minimum,
   // above their maximum, offline...). Collapsing it into the same null as a
   // network blip costs the user the only actionable half of the message: on
@@ -213,12 +227,8 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
       // minSendable. Report the bound instead — the only half of this the
       // user can act on. (The recipient cap handles the other end: it clamps
       // the probe, so a probe amount can only ever be too small here.)
-      if (
-        receiverMinSats !== null &&
-        Number.isFinite(receiverMinSats) &&
-        convertSatsToWallet(receiverMinSats) > probeAmount
-      ) {
-        lastFeeError = { kind: "amount-below-min", minSats: receiverMinSats }
+      if (recipientMin !== null && recipientMin.wallet > probeAmount) {
+        lastFeeError = { kind: "amount-below-min", minSats: recipientMin.sats }
         return null
       }
       // Clear a minimum recorded by an earlier tap: a later generic failure
@@ -254,6 +264,30 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
         fetchFee,
         recipientCap,
       })
+
+      // The receiver's floor guards the probe INPUT; this guards the number
+      // the chip actually puts in the pad — the other half of the same bound,
+      // and the half the user sees. They are not the same check: the fee is
+      // subtracted between them, so any balance in [min, min + fee + slack)
+      // clears the probe and still lands below the floor. On the BTC wallet
+      // that shows as a chip filling 499 sats under "~2,500 sats reserved for
+      // the network fee" with "the minimum this recipient can receive is
+      // 1,000 sats" painted directly beneath it; on the USD wallet, where no
+      // local check compares like units, it shows as the LNURL mint throwing
+      // Error("Invalid amount") on Next and the screen blaming the fetch —
+      // ENG-554's own symptom, reproduced by the chip meant to end it.
+      //
+      // The cap is applied to the result (max-send-amount.ts), so the floor
+      // must be too. Propose nothing and name the bound: no amount over this
+      // balance is sendable to this receiver, so the tap has no number to
+      // offer — only the reason.
+      if (
+        recipientMin !== null &&
+        result.amount > 0 &&
+        result.amount < recipientMin.wallet
+      ) {
+        return { note: strings.recipientMin(recipientMin.sats) }
+      }
 
       const note = noteFor(noteForResult(result))
 

--- a/app/screens/send-bitcoin-screen/max-amount-button.ts
+++ b/app/screens/send-bitcoin-screen/max-amount-button.ts
@@ -220,13 +220,7 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
     // nothing for the plain IBEX probe to price — mint one at the probe
     // amount and price that instead.
     if (paymentType === "lnurl") {
-      // The receiver's floor, checked before we ask them for an invoice.
-      // Below it the mint throws a bare Error("Invalid amount") that reads as
-      // "couldn't estimate the fee — tap MAX again", and no number of taps
-      // ever will: a $4.42 balance is 221 sats against a 1_000-sat
-      // minSendable. Report the bound instead — the only half of this the
-      // user can act on. (The recipient cap handles the other end: it clamps
-      // the probe, so a probe amount can only ever be too small here.)
+      // Probe-input half of the receiver's floor; see `receiverMinSats`.
       if (recipientMin !== null && recipientMin.wallet > probeAmount) {
         lastFeeError = { kind: "amount-below-min", minSats: recipientMin.sats }
         return null
@@ -265,22 +259,10 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
         recipientCap,
       })
 
-      // The receiver's floor guards the probe INPUT; this guards the number
-      // the chip actually puts in the pad — the other half of the same bound,
-      // and the half the user sees. They are not the same check: the fee is
-      // subtracted between them, so any balance in [min, min + fee + slack)
-      // clears the probe and still lands below the floor. On the BTC wallet
-      // that shows as a chip filling 499 sats under "~2,500 sats reserved for
-      // the network fee" with "the minimum this recipient can receive is
-      // 1,000 sats" painted directly beneath it; on the USD wallet, where no
-      // local check compares like units, it shows as the LNURL mint throwing
-      // Error("Invalid amount") on Next and the screen blaming the fetch —
-      // ENG-554's own symptom, reproduced by the chip meant to end it.
-      //
-      // The cap is applied to the result (max-send-amount.ts), so the floor
-      // must be too. Propose nothing and name the bound: no amount over this
-      // balance is sendable to this receiver, so the tap has no number to
-      // offer — only the reason.
+      // Result half of the same floor; see `receiverMinSats`. Distinct from
+      // the probe-input check because the fee is subtracted between them, so
+      // a balance in [min, min + fee + slack) clears the probe and still
+      // lands below the floor.
       if (
         recipientMin !== null &&
         result.amount > 0 &&

--- a/app/screens/send-bitcoin-screen/max-amount-button.ts
+++ b/app/screens/send-bitcoin-screen/max-amount-button.ts
@@ -77,8 +77,12 @@ export type BuildMaxAmountButtonArgs<M extends MoneyAmountShape, F, P> = {
    * invoice at the probe amount purely to price it; it is never paid, and the
    * send flow mints its own on Next. Resolve null when the destination cannot
    * be priced.
+   *
+   * Required, like fetchBreezFee and getIbexFee: a caller that forgets to wire
+   * it must fail to compile, not silently degrade every USD LNURL send to
+   * "couldn't estimate".
    */
-  probeLnurlFee?: (probeAmount: number) => Promise<number | null>
+  probeLnurlFee: (probeAmount: number) => Promise<number | null>
   /** moneyAmountToDisplayCurrencyString — undefined when no rate is known. */
   formatDisplayAmount: (moneyAmount: M) => string | undefined
   strings: MaxAmountButtonStrings
@@ -147,7 +151,7 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
     // nothing for the plain IBEX probe to price — mint one at the probe
     // amount and price that instead.
     if (paymentType === "lnurl") {
-      return probeLnurlFee ? probeLnurlFee(probeAmount) : null
+      return probeLnurlFee(probeAmount)
     }
     const fee = await getIbexFee(setAmount(withAmount(probeAmount)).getFee)
     return fee?.amount ?? null

--- a/app/screens/send-bitcoin-screen/max-amount-button.ts
+++ b/app/screens/send-bitcoin-screen/max-amount-button.ts
@@ -32,6 +32,8 @@ export type MaxAmountButtonStrings = {
   recipientCap: (max: string) => string
   /** maxNoteFeeUnknown — shown when the destination cannot be priced. */
   feeUnknown: () => string
+  /** minReceiveAmountError — the receiver's own lower bound, in sats. */
+  recipientMin: (minSats: number) => string
   /** maxNoteFeeTooLarge — shown when the fee swallows the whole balance. */
   feeTooLarge: () => string
 }
@@ -135,6 +137,14 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
 
   const withAmount = (amount: number): M => ({ ...balanceMoneyAmount, amount })
 
+  // The Breez probe returns a TYPED reason (below the receiver's minimum,
+  // above their maximum, offline...). Collapsing it into the same null as a
+  // network blip costs the user the only actionable half of the message: on
+  // main a null fee still filled the balance, so committing it surfaced
+  // "The minimum this recipient can receive is N sats". Now that no amount is
+  // proposed, this is the only place that reason can still reach them.
+  let lastFeeError: { kind: string; minSats?: number } | null = null
+
   // Note kind → localized string. Undefined only where there is genuinely
   // nothing worth saying: an unremarkable result, or a money note with no
   // display rate to format it against.
@@ -148,8 +158,13 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
       }
       case "fee-too-large":
         return strings.feeTooLarge()
-      case "fee-unknown":
-        return strings.feeUnknown()
+      case "fee-unknown": {
+        // Prefer the receiver's own lower bound over a generic "couldn't
+        // estimate": it is the half of the message the user can act on.
+        const minSats =
+          lastFeeError?.kind === "amount-below-min" ? lastFeeError.minSats : undefined
+        return minSats ? strings.recipientMin(minSats) : strings.feeUnknown()
+      }
       case "recipient-cap": {
         const capString = formatDisplayAmount(withAmount(decision.cap))
         return capString ? strings.recipientCap(capString) : undefined
@@ -172,6 +187,7 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
         selectedFeeType,
         knownPayRequest,
       })
+      lastFeeError = (err as { kind: string; minSats?: number } | null) ?? null
       return err ? null : fee
     }
     // USD wallet. An LNURL destination has no invoice yet, so there is

--- a/app/screens/send-bitcoin-screen/max-amount-button.ts
+++ b/app/screens/send-bitcoin-screen/max-amount-button.ts
@@ -12,6 +12,7 @@ import {
   computeMaxSendAmount,
   effectiveMaxPaymentType,
   maxChipSupportsPaymentType,
+  MaxSendNote,
   MaxSendPaymentType,
   MaxSendWalletCurrency,
   noteForResult,
@@ -31,6 +32,8 @@ export type MaxAmountButtonStrings = {
   recipientCap: (max: string) => string
   /** maxNoteFeeUnknown — shown when the destination cannot be priced. */
   feeUnknown: () => string
+  /** maxNoteFeeTooLarge — shown when the fee swallows the whole balance. */
+  feeTooLarge: () => string
 }
 
 export type BuildMaxAmountButtonArgs<M extends MoneyAmountShape, F, P> = {
@@ -132,6 +135,30 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
 
   const withAmount = (amount: number): M => ({ ...balanceMoneyAmount, amount })
 
+  // Note kind → localized string. Undefined only where there is genuinely
+  // nothing worth saying: an unremarkable result, or a money note with no
+  // display rate to format it against.
+  const noteFor = (decision: MaxSendNote): string | undefined => {
+    switch (decision.kind) {
+      case "intraledger":
+        return strings.intraledger()
+      case "fee-reserved": {
+        const feeString = formatDisplayAmount(withAmount(decision.feeReserved))
+        return feeString ? strings.feeReserved(feeString) : undefined
+      }
+      case "fee-too-large":
+        return strings.feeTooLarge()
+      case "fee-unknown":
+        return strings.feeUnknown()
+      case "recipient-cap": {
+        const capString = formatDisplayAmount(withAmount(decision.cap))
+        return capString ? strings.recipientCap(capString) : undefined
+      }
+      default:
+        return undefined
+    }
+  }
+
   // probeAmount is the balance clamped to the recipient cap (computed by
   // computeMaxSendAmount). Probing at the raw balance would trip the LUD-06
   // bounds validation inside fetchBreezFee whenever the cap binds, losing
@@ -182,30 +209,22 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
         recipientCap,
       })
 
-      const noteDecision = noteForResult(result)
+      const note = noteFor(noteForResult(result))
 
       // Nothing spendable: leave the pad untouched rather than filling an
       // empty amount under a solid MAX chip. A zero max arrives on several
-      // routes, not just "zero-balance" — a fee estimate that meets or
-      // exceeds the balance yields { amount: 0, reason: "fee-reserved" },
-      // and a receiver advertising maxSendable 0 yields a zero cap — so
-      // gate on the amount itself.
+      // routes, not just "zero-balance" — a fee that swallows the balance
+      // yields { amount: 0, reason: "fee-exceeds-balance" }, an unpriceable
+      // destination yields "fee-unavailable", and a receiver advertising
+      // maxSendable 0 yields a zero cap — so gate on the amount itself.
+      //
+      // Each of those the user can act on (top up, retry, enter an amount by
+      // hand) explains itself: a tap that proposes nothing and says nothing
+      // is indistinguishable from a broken chip. Only a wordless zero — the
+      // zero-balance route, which cannot be tapped because the chip is
+      // disabled for it — falls through to null.
       if (result.amount <= 0) {
-        // An unpriceable destination is the one zero case the user can act
-        // on (enter an amount by hand), so it explains itself instead of
-        // making the tap look broken.
-        return noteDecision.kind === "fee-unknown" ? { note: strings.feeUnknown() } : null
-      }
-
-      let note: string | undefined
-      if (noteDecision.kind === "intraledger") {
-        note = strings.intraledger()
-      } else if (noteDecision.kind === "fee-reserved") {
-        const feeString = formatDisplayAmount(withAmount(noteDecision.feeReserved))
-        note = feeString ? strings.feeReserved(feeString) : undefined
-      } else if (noteDecision.kind === "recipient-cap") {
-        const capString = formatDisplayAmount(withAmount(noteDecision.cap))
-        note = capString ? strings.recipientCap(capString) : undefined
+        return note ? { note } : null
       }
 
       return {

--- a/app/screens/send-bitcoin-screen/max-amount-button.ts
+++ b/app/screens/send-bitcoin-screen/max-amount-button.ts
@@ -58,6 +58,17 @@ export type BuildMaxAmountButtonArgs<M extends MoneyAmountShape, F, P> = {
   receiverMaxSats: number | null
   /** The destination's lnurlParams.max in sats (USD-wallet LNURL path). */
   lnurlParamsMaxSats: number | null
+  /**
+   * Receiver's LNURL minSendable in sats, or null when unknown.
+   *
+   * The Breez probe reports this itself (as an `amount-below-min` error), but
+   * the LNURL mint does not: lnurl-pay throws a bare Error("Invalid amount")
+   * client-side for a sat count outside [min, max], which collapses into the
+   * same null as a network blip and produces "couldn't estimate the fee — tap
+   * MAX again" — a retry loop that cannot succeed. Checking here is what turns
+   * that into the receiver's actual minimum.
+   */
+  receiverMinSats: number | null
   /** Convert sats into the sending wallet's minor units. */
   convertSatsToWallet: (sats: number) => number
   /** Breez fee probe (BTC wallet). */
@@ -110,6 +121,7 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
   knownPayRequest,
   receiverMaxSats,
   lnurlParamsMaxSats,
+  receiverMinSats,
   convertSatsToWallet,
   fetchBreezFee,
   setAmount,
@@ -194,6 +206,24 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
     // nothing for the plain IBEX probe to price — mint one at the probe
     // amount and price that instead.
     if (paymentType === "lnurl") {
+      // The receiver's floor, checked before we ask them for an invoice.
+      // Below it the mint throws a bare Error("Invalid amount") that reads as
+      // "couldn't estimate the fee — tap MAX again", and no number of taps
+      // ever will: a $4.42 balance is 221 sats against a 1_000-sat
+      // minSendable. Report the bound instead — the only half of this the
+      // user can act on. (The recipient cap handles the other end: it clamps
+      // the probe, so a probe amount can only ever be too small here.)
+      if (
+        receiverMinSats !== null &&
+        Number.isFinite(receiverMinSats) &&
+        convertSatsToWallet(receiverMinSats) > probeAmount
+      ) {
+        lastFeeError = { kind: "amount-below-min", minSats: receiverMinSats }
+        return null
+      }
+      // Clear a minimum recorded by an earlier tap: a later generic failure
+      // must not borrow its message.
+      lastFeeError = null
       return probeLnurlFee(probeAmount)
     }
     const fee = await getIbexFee(setAmount(withAmount(probeAmount)).getFee)

--- a/app/screens/send-bitcoin-screen/max-amount-button.ts
+++ b/app/screens/send-bitcoin-screen/max-amount-button.ts
@@ -29,6 +29,8 @@ export type MaxAmountButtonStrings = {
   feeReserved: (fee: string) => string
   /** maxNoteRecipientCap: "Recipient can receive at most {max}." */
   recipientCap: (max: string) => string
+  /** maxNoteFeeUnknown — shown when the destination cannot be priced. */
+  feeUnknown: () => string
 }
 
 export type BuildMaxAmountButtonArgs<M extends MoneyAmountShape, F, P> = {
@@ -65,6 +67,18 @@ export type BuildMaxAmountButtonArgs<M extends MoneyAmountShape, F, P> = {
   setAmount?: (amount: M) => { getFee?: F }
   /** IBEX fee probe (USD wallet) over a probe detail's getFee. */
   getIbexFee: (getFee: F | undefined) => Promise<MoneyAmountShape | undefined>
+  /**
+   * Price an LNURL send of `probeAmount` (wallet minor units).
+   *
+   * An LNURL detail only gains a `getFee` once an invoice is attached
+   * (payment-details/lightning.ts sets canGetFee false until then), so the
+   * plain IBEX probe cannot price this destination at all — that gap is what
+   * made MAX offer an unsendable amount. Implementations mint a throwaway
+   * invoice at the probe amount purely to price it; it is never paid, and the
+   * send flow mints its own on Next. Resolve null when the destination cannot
+   * be priced.
+   */
+  probeLnurlFee?: (probeAmount: number) => Promise<number | null>
   /** moneyAmountToDisplayCurrencyString — undefined when no rate is known. */
   formatDisplayAmount: (moneyAmount: M) => string | undefined
   strings: MaxAmountButtonStrings
@@ -73,7 +87,7 @@ export type BuildMaxAmountButtonArgs<M extends MoneyAmountShape, F, P> = {
 /** Structurally matches the amount screen's MaxAmountButton prop. */
 export type BuiltMaxAmountButton<M extends MoneyAmountShape> = {
   disabled: boolean
-  compute: () => Promise<{ amount: M; note?: string } | null>
+  compute: () => Promise<{ amount?: M; note?: string } | null>
 }
 
 export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
@@ -91,6 +105,7 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
   fetchBreezFee,
   setAmount,
   getIbexFee,
+  probeLnurlFee,
   formatDisplayAmount,
   strings,
 }: BuildMaxAmountButtonArgs<M, F, P>): BuiltMaxAmountButton<M> | undefined => {
@@ -128,10 +143,12 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
       })
       return err ? null : fee
     }
-    // USD wallet: probe through the same fee probes the send flow already
-    // uses. LNURL destinations have no probe before an invoice exists —
-    // getIbexFee resolves undefined and the computation falls back to the
-    // full balance.
+    // USD wallet. An LNURL destination has no invoice yet, so there is
+    // nothing for the plain IBEX probe to price — mint one at the probe
+    // amount and price that instead.
+    if (paymentType === "lnurl") {
+      return probeLnurlFee ? probeLnurlFee(probeAmount) : null
+    }
     const fee = await getIbexFee(setAmount(withAmount(probeAmount)).getFee)
     return fee?.amount ?? null
   }
@@ -161,6 +178,8 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
         recipientCap,
       })
 
+      const noteDecision = noteForResult(result)
+
       // Nothing spendable: leave the pad untouched rather than filling an
       // empty amount under a solid MAX chip. A zero max arrives on several
       // routes, not just "zero-balance" — a fee estimate that meets or
@@ -168,10 +187,12 @@ export const buildMaxAmountButton = <M extends MoneyAmountShape, F, P>({
       // and a receiver advertising maxSendable 0 yields a zero cap — so
       // gate on the amount itself.
       if (result.amount <= 0) {
-        return null
+        // An unpriceable destination is the one zero case the user can act
+        // on (enter an amount by hand), so it explains itself instead of
+        // making the tap look broken.
+        return noteDecision.kind === "fee-unknown" ? { note: strings.feeUnknown() } : null
       }
 
-      const noteDecision = noteForResult(result)
       let note: string | undefined
       if (noteDecision.kind === "intraledger") {
         note = strings.intraledger()

--- a/app/screens/send-bitcoin-screen/max-send-amount.ts
+++ b/app/screens/send-bitcoin-screen/max-send-amount.ts
@@ -143,7 +143,10 @@ export type ComputeMaxSendAmountArgs = {
   fetchFee: (probeAmount: number) => Promise<number | null>
   /** Receiver's LNURL maxSendable converted to wallet minor units, if known. */
   recipientCap?: number | null
-  /** Fee estimates slower than this fall back to the full balance. */
+  /**
+   * Fee estimates slower than this are treated as unavailable — no amount is
+   * proposed.
+   */
   timeoutMs?: number
 }
 
@@ -164,7 +167,7 @@ const feeOrNull = async (
     ])
     return typeof fee === "number" && Number.isFinite(fee) && fee >= 0 ? fee : null
   } catch {
-    // A failed estimate must never block the tap — fall back to full balance.
+    // A failed estimate yields no proposal; the caller explains why.
     return null
   } finally {
     clearTimeout(timer)
@@ -232,8 +235,22 @@ export const computeMaxSendAmount = async ({
       // explains why instead of filling the pad with something doomed.
       result = { amount: 0, reason: "fee-unavailable" }
     } else {
+      // Reserve the fee ROUNDED UP plus one whole minor unit of slack.
+      //
+      // The estimate is not a cap. It was priced against a different invoice
+      // than the one the send will pay: this probe mints a throwaway invoice
+      // at the probe amount, and pressing Next mints a fresh one at
+      // balance − fee and re-prices THAT (send-bitcoin-details-screen.tsx,
+      // goToNextScreen). Amount-monotonicity says a smaller amount does not
+      // cost more on the same route; it says nothing about invoice-to-invoice
+      // route variance. Without slack the failure band is narrow but real —
+      // balance 442¢, probe fee 0.5¢ → MAX fills 441¢, the final invoice
+      // prices at 1.5¢, and fetchSendingFee blocks with "amount exceeds
+      // balance (amount + fee)". MAX filling an amount the very next screen
+      // refuses is exactly the bug this code exists to kill, so it gives up
+      // one minor unit to stay on the safe side of it.
       result = {
-        amount: Math.max(Math.floor(spendableBalance - fee), 0),
+        amount: Math.max(spendableBalance - Math.ceil(fee) - 1, 0),
         reason: "fee-reserved",
         feeReserved: fee,
       }

--- a/app/screens/send-bitcoin-screen/max-send-amount.ts
+++ b/app/screens/send-bitcoin-screen/max-send-amount.ts
@@ -81,6 +81,7 @@ export type MaxSendReason =
   | "zero-balance"
   | "intraledger-full-balance"
   | "fee-reserved"
+  | "fee-exceeds-balance"
   | "fee-unavailable"
   | "recipient-cap"
 
@@ -88,7 +89,10 @@ export type MaxSendResult = {
   /** Max sendable amount, in the sending wallet's minor units. */
   amount: number
   reason: MaxSendReason
-  /** Set when reason is "fee-reserved" — the estimated fee held back. */
+  /**
+   * Set when reason is "fee-reserved" (the estimated fee held back) or
+   * "fee-exceeds-balance" (the estimated fee that swallowed the balance).
+   */
   feeReserved?: number
 }
 
@@ -97,6 +101,7 @@ export type MaxSendNote =
   | { kind: "none" }
   | { kind: "intraledger" }
   | { kind: "fee-reserved"; feeReserved: number }
+  | { kind: "fee-too-large" }
   | { kind: "fee-unknown" }
   | { kind: "recipient-cap"; cap: number }
 
@@ -118,6 +123,8 @@ export const noteForResult = (result: MaxSendResult): MaxSendNote => {
         : { kind: "none" }
     // No amount was proposed, so the user is owed the reason — otherwise the
     // tap looks broken.
+    case "fee-exceeds-balance":
+      return { kind: "fee-too-large" }
     case "fee-unavailable":
       return { kind: "fee-unknown" }
     case "recipient-cap":
@@ -249,11 +256,17 @@ export const computeMaxSendAmount = async ({
       // balance (amount + fee)". MAX filling an amount the very next screen
       // refuses is exactly the bug this code exists to kill, so it gives up
       // one minor unit to stay on the safe side of it.
-      result = {
-        amount: Math.max(spendableBalance - Math.ceil(fee) - 1, 0),
-        reason: "fee-reserved",
-        feeReserved: fee,
-      }
+      const maxAmount = spendableBalance - Math.ceil(fee) - 1
+      result =
+        maxAmount > 0
+          ? { amount: maxAmount, reason: "fee-reserved", feeReserved: fee }
+          : // The fee (plus its slack) swallows the whole balance. That is a
+            // different outcome from "some of the balance was reserved":
+            // there is nothing to fill, so the user is owed the reason.
+            // Clamping to zero under the fee-reserved banner made the tap a
+            // silent no-op — 2_000 sats against a 2_500-sat channel-open fee
+            // spun the chip and then said nothing at all.
+            { amount: 0, reason: "fee-exceeds-balance", feeReserved: fee }
     }
   }
 

--- a/app/screens/send-bitcoin-screen/max-send-amount.ts
+++ b/app/screens/send-bitcoin-screen/max-send-amount.ts
@@ -88,11 +88,7 @@ export type MaxSendResult = {
   /** Max sendable amount, in the sending wallet's minor units. */
   amount: number
   reason: MaxSendReason
-  /**
-   * The amount held back for fees. On "fee-reserved" that is the estimate
-   * returned by the probe; on "fee-unavailable" it is the backend's fee cap,
-   * reserved because no estimate could be obtained.
-   */
+  /** Set when reason is "fee-reserved" — the estimated fee held back. */
   feeReserved?: number
 }
 
@@ -101,6 +97,7 @@ export type MaxSendNote =
   | { kind: "none" }
   | { kind: "intraledger" }
   | { kind: "fee-reserved"; feeReserved: number }
+  | { kind: "fee-unknown" }
   | { kind: "recipient-cap"; cap: number }
 
 /**
@@ -115,15 +112,14 @@ export const noteForResult = (result: MaxSendResult): MaxSendNote => {
   switch (result.reason) {
     case "intraledger-full-balance":
       return { kind: "intraledger" }
-    // Both reserve something, so both owe the user an explanation for why
-    // MAX is short of the balance they can see. They differ only in where
-    // the number came from — a probe estimate vs the backend's fee cap —
-    // which is not a distinction worth surfacing on the amount screen.
     case "fee-reserved":
-    case "fee-unavailable":
       return result.feeReserved
         ? { kind: "fee-reserved", feeReserved: result.feeReserved }
         : { kind: "none" }
+    // No amount was proposed, so the user is owed the reason — otherwise the
+    // tap looks broken.
+    case "fee-unavailable":
+      return { kind: "fee-unknown" }
     case "recipient-cap":
       return { kind: "recipient-cap", cap: result.amount }
     default:
@@ -141,9 +137,8 @@ export type ComputeMaxSendAmountArgs = {
    * amount matters: LNURL fee probes bounds-validate against the receiver's
    * LUD-06 limits, so a full-balance probe is guaranteed to fail whenever
    * the cap binds. Resolve null when no estimate is available — the
-   * computation then reserves the backend's own fee cap rather than
-   * offering the full balance, so the tap is never blocked but the amount
-   * it fills in is one the send flow will actually accept.
+   * computation then proposes nothing at all, because an unpriced send is
+   * one it cannot promise will be accepted.
    */
   fetchFee: (probeAmount: number) => Promise<number | null>
   /** Receiver's LNURL maxSendable converted to wallet minor units, if known. */
@@ -153,45 +148,6 @@ export type ComputeMaxSendAmountArgs = {
 }
 
 const FEE_ESTIMATE_TIMEOUT_MS = 10_000
-
-/**
- * The backend's own fee cap, mirrored here: `FEECAP_BASIS_POINTS = 50n` in
- * flash `src/domain/bitcoin/index.ts`, with a one-minor-unit floor from
- * `LnFees().maxProtocolAndBankFee`.
- *
- * This is not a guess at the fee. When the backend has no probed fee of its
- * own it reserves exactly this much — `payment-flow-builder.ts` uses
- * `state.usdProtocolAndBankFee || LnFees().maxProtocolAndBankFee(amount)` —
- * and then `checkBalanceForSend` rejects the payment unless
- * `balance >= amount + thatFee`. So an amount that ignores this cap is one
- * the backend is guaranteed to refuse.
- */
-const FEE_CAP_BASIS_POINTS = 50
-const BASIS_POINTS_PER_UNIT = 10_000
-
-/** What the backend will hold back for `amount`, in the same minor units. */
-export const reservedFeeCapFor = (amount: number): number =>
-  Math.max(Math.floor((amount * FEE_CAP_BASIS_POINTS) / BASIS_POINTS_PER_UNIT), 1)
-
-/**
- * Largest amount that still fits under `balance` once the backend's fee cap
- * is added to it — i.e. the largest `a` satisfying
- * `a + reservedFeeCapFor(a) <= balance`.
- *
- * Solved from the closed form and then corrected, because integer flooring
- * and the one-unit fee floor both perturb it by a unit or two; the loops
- * settle in at most a couple of steps rather than scanning.
- */
-export const maxAmountWithinFeeCap = (balance: number): number => {
-  if (!Number.isFinite(balance) || balance <= 0) return 0
-
-  let amount = Math.floor(balance / (1 + FEE_CAP_BASIS_POINTS / BASIS_POINTS_PER_UNIT))
-
-  while (amount > 0 && amount + reservedFeeCapFor(amount) > balance) amount -= 1
-  while (amount + 1 + reservedFeeCapFor(amount + 1) <= balance) amount += 1
-
-  return Math.max(amount, 0)
-}
 
 const feeOrNull = async (
   fetchFee: (probeAmount: number) => Promise<number | null>,
@@ -265,18 +221,16 @@ export const computeMaxSendAmount = async ({
       flooredCap === null ? spendableBalance : Math.min(spendableBalance, flooredCap)
     const fee = await feeOrNull(fetchFee, probeAmount, timeoutMs)
     if (fee === null) {
-      // No estimate available — the common case for LNURL destinations,
-      // where no invoice exists yet to probe against. Offering the full
-      // balance here used to guarantee failure: the backend adds its own
-      // fee cap on top and rejects anything over the balance, so MAX
-      // proposed an amount the send flow could never accept, and the user
-      // got a generic error. Reserve what the backend reserves instead.
-      const amount = maxAmountWithinFeeCap(spendableBalance)
-      result = {
-        amount,
-        reason: "fee-unavailable",
-        feeReserved: spendableBalance - amount,
-      }
+      // No estimate, so no honest maximum. Offering the full balance is what
+      // caused ENG-554 — the fee lands on top and the send is refused — but
+      // guessing a reserve is no better: nothing in this app knows what IBEX
+      // charges. There is no published bound in the flash config or the IBEX
+      // client, and the galoy fee cap (FEECAP_BASIS_POINTS) governs a code
+      // path this send never takes: lnNoAmountUsdInvoicePaymentSend calls
+      // Ibex.payInvoice directly, with the Payments layer commented out.
+      // Decline to propose a number rather than invent one; the caller
+      // explains why instead of filling the pad with something doomed.
+      result = { amount: 0, reason: "fee-unavailable" }
     } else {
       result = {
         amount: Math.max(Math.floor(spendableBalance - fee), 0),

--- a/app/screens/send-bitcoin-screen/max-send-amount.ts
+++ b/app/screens/send-bitcoin-screen/max-send-amount.ts
@@ -88,7 +88,11 @@ export type MaxSendResult = {
   /** Max sendable amount, in the sending wallet's minor units. */
   amount: number
   reason: MaxSendReason
-  /** Set when reason is "fee-reserved" — the estimated fee held back. */
+  /**
+   * The amount held back for fees. On "fee-reserved" that is the estimate
+   * returned by the probe; on "fee-unavailable" it is the backend's fee cap,
+   * reserved because no estimate could be obtained.
+   */
   feeReserved?: number
 }
 
@@ -111,7 +115,12 @@ export const noteForResult = (result: MaxSendResult): MaxSendNote => {
   switch (result.reason) {
     case "intraledger-full-balance":
       return { kind: "intraledger" }
+    // Both reserve something, so both owe the user an explanation for why
+    // MAX is short of the balance they can see. They differ only in where
+    // the number came from — a probe estimate vs the backend's fee cap —
+    // which is not a distinction worth surfacing on the amount screen.
     case "fee-reserved":
+    case "fee-unavailable":
       return result.feeReserved
         ? { kind: "fee-reserved", feeReserved: result.feeReserved }
         : { kind: "none" }
@@ -132,8 +141,9 @@ export type ComputeMaxSendAmountArgs = {
    * amount matters: LNURL fee probes bounds-validate against the receiver's
    * LUD-06 limits, so a full-balance probe is guaranteed to fail whenever
    * the cap binds. Resolve null when no estimate is available — the
-   * computation then falls back to the full balance so the existing
-   * pre-validation surfaces the typed fee error instead of blocking the tap.
+   * computation then reserves the backend's own fee cap rather than
+   * offering the full balance, so the tap is never blocked but the amount
+   * it fills in is one the send flow will actually accept.
    */
   fetchFee: (probeAmount: number) => Promise<number | null>
   /** Receiver's LNURL maxSendable converted to wallet minor units, if known. */
@@ -143,6 +153,45 @@ export type ComputeMaxSendAmountArgs = {
 }
 
 const FEE_ESTIMATE_TIMEOUT_MS = 10_000
+
+/**
+ * The backend's own fee cap, mirrored here: `FEECAP_BASIS_POINTS = 50n` in
+ * flash `src/domain/bitcoin/index.ts`, with a one-minor-unit floor from
+ * `LnFees().maxProtocolAndBankFee`.
+ *
+ * This is not a guess at the fee. When the backend has no probed fee of its
+ * own it reserves exactly this much — `payment-flow-builder.ts` uses
+ * `state.usdProtocolAndBankFee || LnFees().maxProtocolAndBankFee(amount)` —
+ * and then `checkBalanceForSend` rejects the payment unless
+ * `balance >= amount + thatFee`. So an amount that ignores this cap is one
+ * the backend is guaranteed to refuse.
+ */
+const FEE_CAP_BASIS_POINTS = 50
+const BASIS_POINTS_PER_UNIT = 10_000
+
+/** What the backend will hold back for `amount`, in the same minor units. */
+export const reservedFeeCapFor = (amount: number): number =>
+  Math.max(Math.floor((amount * FEE_CAP_BASIS_POINTS) / BASIS_POINTS_PER_UNIT), 1)
+
+/**
+ * Largest amount that still fits under `balance` once the backend's fee cap
+ * is added to it — i.e. the largest `a` satisfying
+ * `a + reservedFeeCapFor(a) <= balance`.
+ *
+ * Solved from the closed form and then corrected, because integer flooring
+ * and the one-unit fee floor both perturb it by a unit or two; the loops
+ * settle in at most a couple of steps rather than scanning.
+ */
+export const maxAmountWithinFeeCap = (balance: number): number => {
+  if (!Number.isFinite(balance) || balance <= 0) return 0
+
+  let amount = Math.floor(balance / (1 + FEE_CAP_BASIS_POINTS / BASIS_POINTS_PER_UNIT))
+
+  while (amount > 0 && amount + reservedFeeCapFor(amount) > balance) amount -= 1
+  while (amount + 1 + reservedFeeCapFor(amount + 1) <= balance) amount += 1
+
+  return Math.max(amount, 0)
+}
 
 const feeOrNull = async (
   fetchFee: (probeAmount: number) => Promise<number | null>,
@@ -215,14 +264,26 @@ export const computeMaxSendAmount = async ({
     const probeAmount =
       flooredCap === null ? spendableBalance : Math.min(spendableBalance, flooredCap)
     const fee = await feeOrNull(fetchFee, probeAmount, timeoutMs)
-    result =
-      fee === null
-        ? { amount: spendableBalance, reason: "fee-unavailable" }
-        : {
-            amount: Math.max(Math.floor(spendableBalance - fee), 0),
-            reason: "fee-reserved",
-            feeReserved: fee,
-          }
+    if (fee === null) {
+      // No estimate available — the common case for LNURL destinations,
+      // where no invoice exists yet to probe against. Offering the full
+      // balance here used to guarantee failure: the backend adds its own
+      // fee cap on top and rejects anything over the balance, so MAX
+      // proposed an amount the send flow could never accept, and the user
+      // got a generic error. Reserve what the backend reserves instead.
+      const amount = maxAmountWithinFeeCap(spendableBalance)
+      result = {
+        amount,
+        reason: "fee-unavailable",
+        feeReserved: spendableBalance - amount,
+      }
+    } else {
+      result = {
+        amount: Math.max(Math.floor(spendableBalance - fee), 0),
+        reason: "fee-reserved",
+        feeReserved: fee,
+      }
+    }
   }
 
   // LNURL receivers advertise a maxSendable bound (LUD-06) — never offer more

--- a/app/screens/send-bitcoin-screen/max-send-amount.ts
+++ b/app/screens/send-bitcoin-screen/max-send-amount.ts
@@ -157,7 +157,12 @@ export type ComputeMaxSendAmountArgs = {
   timeoutMs?: number
 }
 
-const FEE_ESTIMATE_TIMEOUT_MS = 10_000
+/**
+ * The whole chip's fee budget. Exported so anything that must stay under it
+ * (the LNURL price probe's own timeout) can assert against this number rather
+ * than a copy of it — a copy silently stops guarding the moment this changes.
+ */
+export const FEE_ESTIMATE_TIMEOUT_MS = 10_000
 
 const feeOrNull = async (
   fetchFee: (probeAmount: number) => Promise<number | null>,

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -53,9 +53,13 @@ import {
 } from "@app/types/amounts"
 import { isValidAmount } from "./payment-details"
 import { buildMaxAmountButton } from "./max-amount-button"
-import { makeLnurlFeeProbe, makeLnurlProbeCache } from "./lnurl-fee-probe"
+import {
+  makeLnurlFeeProbe,
+  makeLnurlProbeCache,
+  mintProbeInvoice,
+} from "./lnurl-fee-probe"
 import { MaxAmountButton } from "@app/components/amount-input-screen"
-import { requestInvoice, requestInvoiceWithServiceParams, utils } from "lnurl-pay"
+import { requestInvoice, utils } from "lnurl-pay"
 import { fetchBreezFee, fetchLnurlPayRequest } from "@app/utils/breez-sdk"
 import { LnurlLimits, lnurlLimitsFromPayRequest } from "@app/utils/breez-sdk/fee-errors"
 import { breezFeeErrorMessage } from "@app/utils/breez-sdk/fee-error-message"
@@ -453,11 +457,10 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
       destination: pd.destination,
       walletCurrency,
       balanceMoneyAmount: isBtcWallet ? btcBalanceMoneyAmount : usdBalanceMoneyAmount,
-      // The params-taking variant: pd.lnurlParams is already resolved, so
-      // this is one round-trip to the receiver's callback rather than two
-      // (re-resolving the pay service first) inside the probe's budget.
-      requestInvoice: ({ params, sats }) =>
-        requestInvoiceWithServiceParams({ params, tokens: utils.toSats(sats) }),
+      // Uses the params-taking lnurl-pay call (pd.lnurlParams is already
+      // resolved, so one round-trip to the receiver's callback rather than
+      // two) and enforces whole sats before the Satoshis cast.
+      requestInvoice: mintProbeInvoice,
       getIbexFee,
       cache: lnurlProbeCache.current,
     })
@@ -473,6 +476,13 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
       knownPayRequest: receiverPayRequest ?? undefined,
       receiverMaxSats: receiverLimits?.maxSats ?? null,
       lnurlParamsMaxSats: pd.paymentType === "lnurl" ? pd.lnurlParams?.max ?? null : null,
+      // receiverLimits is resolved for the BTC wallet only; the USD LNURL
+      // path reads the same bound straight off the detail's resolved params
+      // (mirroring lnurlParamsMaxSats above), and that is the path where the
+      // minimum has no other way to reach the user.
+      receiverMinSats:
+        receiverLimits?.minSats ??
+        (pd.paymentType === "lnurl" ? pd.lnurlParams?.min ?? null : null),
       convertSatsToWallet: (sats) =>
         pd.convertMoneyAmount(toBtcMoneyAmount(sats), walletCurrency).amount,
       fetchBreezFee,

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -64,6 +64,11 @@ type Props = StackScreenProps<RootStackParamList, "sendBitcoinDetails">
 
 const network = "mainnet" // data?.globals?.network
 
+// The MAX chip's LNURL price check hits the receiver's LNURL service; keep it
+// well under the chip's own 10s fee budget so a slow receiver degrades to
+// "couldn't estimate" instead of holding the tap.
+const LNURL_PROBE_TIMEOUT_MS = 7000
+
 const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
   const styles = useStyles()
   const { LL } = useI18nContext()
@@ -410,7 +415,7 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
           navigation.navigate("sendBitcoinConfirmation", {
             paymentDetail: paymentDetailForConfirmation,
             flashUserAddress,
-            selectedFeeType: selectedFeeType,
+            selectedFeeType,
             invoiceAmount,
           })
         }
@@ -436,6 +441,44 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
     const walletCurrency = pd.sendingWalletDescriptor.currency
     const isBtcWallet = walletCurrency === WalletCurrency.Btc
 
+    // Price an LNURL destination by minting a throwaway invoice for the probe
+    // amount. An LNURL payment detail has no `getFee` until an invoice is
+    // attached, so without this the IBEX probe returns nothing and MAX has no
+    // basis for a number (ENG-554). This invoice is only ever priced, never
+    // paid — pressing Next mints a fresh one for the actual send, which
+    // matters because these expire in 60s.
+    const probeLnurlFee = async (probeAmount: number): Promise<number | null> => {
+      if (pd.paymentType !== "lnurl" || !pd.setAmount) return null
+      try {
+        const probeDetail = pd.setAmount({
+          ...(isBtcWallet ? btcBalanceMoneyAmount : usdBalanceMoneyAmount),
+          amount: probeAmount,
+        })
+        const btcProbeAmount = probeDetail.convertMoneyAmount(
+          probeDetail.unitOfAccountAmount,
+          "BTC",
+        )
+        const { invoice } = await withTimeout(
+          requestInvoice({
+            lnUrlOrAddress: pd.destination,
+            tokens: utils.toSats(btcProbeAmount.amount),
+          }),
+          LNURL_PROBE_TIMEOUT_MS,
+        )
+        if (probeDetail.paymentType !== "lnurl") return null
+        const pricedDetail = probeDetail.setInvoice({
+          paymentRequest: invoice,
+          paymentRequestAmount: btcProbeAmount,
+        })
+        const fee = await getIbexFee(pricedDetail.getFee)
+        return fee?.amount ?? null
+      } catch {
+        // Unpriceable — the computation declines to propose an amount rather
+        // than guessing one the send would refuse.
+        return null
+      }
+    }
+
     return buildMaxAmountButton({
       canSetAmount: pd.canSetAmount,
       paymentType: pd.paymentType,
@@ -452,12 +495,14 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
       fetchBreezFee,
       setAmount: pd.setAmount,
       getIbexFee,
+      probeLnurlFee,
       formatDisplayAmount: (moneyAmount) =>
         moneyAmountToDisplayCurrencyString({ moneyAmount }),
       strings: {
         intraledger: () => LL.AmountInputScreen.maxNoteIntraledger(),
         feeReserved: (fee) => LL.AmountInputScreen.maxNoteFeeReserved({ fee }),
         recipientCap: (max) => LL.AmountInputScreen.maxNoteRecipientCap({ max }),
+        feeUnknown: () => LL.AmountInputScreen.maxNoteFeeUnknown(),
       },
     })
   }
@@ -532,9 +577,8 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
         </View>
       </Screen>
     )
-  } else {
-    return null
   }
+  return null
 }
 export default SendBitcoinDetailsScreen
 

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -53,7 +53,7 @@ import {
 } from "@app/types/amounts"
 import { isValidAmount } from "./payment-details"
 import { buildMaxAmountButton } from "./max-amount-button"
-import { priceLnurlSend } from "./lnurl-fee-probe"
+import { makeLnurlFeeProbe, makeLnurlProbeCache } from "./lnurl-fee-probe"
 import { MaxAmountButton } from "@app/components/amount-input-screen"
 import { requestInvoice, requestInvoiceWithServiceParams, utils } from "lnurl-pay"
 import { fetchBreezFee, fetchLnurlPayRequest } from "@app/utils/breez-sdk"
@@ -91,11 +91,11 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
   const [asyncErrorMessage, setAsyncErrorMessage] = useState("")
   const [selectedFeeType, setSelectedFeeType] = useState<"fast" | "medium" | "slow">()
   const [isProcessing, setIsProcessing] = useState(false)
-  // Prices already obtained from the LNURL probe, for the life of this screen.
-  // Keyed by destination + sending wallet + probe amount: the probe amount is
-  // in the sending wallet's minor units, so 1000 sats and 1000 cents to the
-  // same address are different questions with different answers.
-  const lnurlProbeCache = useRef(new Map<string, number>())
+  // What the LNURL probe already asked the receiver, for the life of this
+  // screen: completed prices and outstanding invoice mints. Every probe that
+  // reaches the receiver mints a real invoice, so the memo is what keeps
+  // repeated MAX taps from orphaning invoices and tripping rate limits.
+  const lnurlProbeCache = useRef(makeLnurlProbeCache())
   const { data } = useSendBitcoinDetailsScreenQuery({
     fetchPolicy: "cache-first",
     returnPartialData: true,
@@ -448,33 +448,19 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
     // basis for a number (ENG-554). This invoice is only ever priced, never
     // paid — pressing Next mints a fresh one for the actual send, which
     // matters because these expire in 60s.
-    const probeLnurlFee = async (probeAmount: number): Promise<number | null> => {
-      // Each completed probe mints a REAL invoice at the receiver. Without
-      // memoization, tap MAX → edit → tap MAX again leaves two orphaned
-      // invoices; against a Flash-address or flashcard receiver each is a real
-      // record, and against rate-limited services (BTCPay, LNbits) repeated
-      // taps trip the limit and the destination becomes unpriceable for the
-      // rest of the session. Cache successes only: a transient failure must
-      // not brand a destination unpriceable — the note invites another tap.
-      const cacheKey = `${pd.destination}:${walletCurrency}:${probeAmount}`
-      const cached = lnurlProbeCache.current.get(cacheKey)
-      if (cached !== undefined) return cached
-
-      const fee = await priceLnurlSend({
-        detail: pd,
-        probeAmount,
-        balanceMoneyAmount: isBtcWallet ? btcBalanceMoneyAmount : usdBalanceMoneyAmount,
-        // The params-taking variant: pd.lnurlParams is already resolved, so
-        // this is one round-trip to the receiver's callback rather than two
-        // (re-resolving the pay service first) inside the probe's budget.
-        requestInvoice: ({ params, sats }) =>
-          requestInvoiceWithServiceParams({ params, tokens: utils.toSats(sats) }),
-        getIbexFee,
-      })
-
-      if (fee !== null) lnurlProbeCache.current.set(cacheKey, fee)
-      return fee
-    }
+    const probeLnurlFee = makeLnurlFeeProbe({
+      detail: pd,
+      destination: pd.destination,
+      walletCurrency,
+      balanceMoneyAmount: isBtcWallet ? btcBalanceMoneyAmount : usdBalanceMoneyAmount,
+      // The params-taking variant: pd.lnurlParams is already resolved, so
+      // this is one round-trip to the receiver's callback rather than two
+      // (re-resolving the pay service first) inside the probe's budget.
+      requestInvoice: ({ params, sats }) =>
+        requestInvoiceWithServiceParams({ params, tokens: utils.toSats(sats) }),
+      getIbexFee,
+      cache: lnurlProbeCache.current,
+    })
 
     return buildMaxAmountButton({
       canSetAmount: pd.canSetAmount,
@@ -500,6 +486,7 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
         feeReserved: (fee) => LL.AmountInputScreen.maxNoteFeeReserved({ fee }),
         recipientCap: (max) => LL.AmountInputScreen.maxNoteRecipientCap({ max }),
         feeUnknown: () => LL.AmountInputScreen.maxNoteFeeUnknown(),
+        feeTooLarge: () => LL.AmountInputScreen.maxNoteFeeTooLarge(),
       },
     })
   }

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -416,7 +416,7 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
           navigation.navigate("sendBitcoinConfirmation", {
             paymentDetail: paymentDetailForConfirmation,
             flashUserAddress,
-            selectedFeeType: selectedFeeType,
+            selectedFeeType,
             invoiceAmount,
           })
         }
@@ -486,6 +486,10 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
         feeReserved: (fee) => LL.AmountInputScreen.maxNoteFeeReserved({ fee }),
         recipientCap: (max) => LL.AmountInputScreen.maxNoteRecipientCap({ max }),
         feeUnknown: () => LL.AmountInputScreen.maxNoteFeeUnknown(),
+        recipientMin: (minSats) =>
+          LL.SendBitcoinScreen.minReceiveAmountError({
+            amount: `${minSats} sats`,
+          }),
         feeTooLarge: () => LL.AmountInputScreen.maxNoteFeeTooLarge(),
       },
     })
@@ -561,9 +565,8 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
         </View>
       </Screen>
     )
-  } else {
-    return null
   }
+  return null
 }
 export default SendBitcoinDetailsScreen
 

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from "react"
+import React, { useEffect, useState, useCallback, useRef } from "react"
 import { View, Alert } from "react-native"
 import { makeStyles } from "@rneui/themed"
 import { StackScreenProps } from "@react-navigation/stack"
@@ -53,8 +53,9 @@ import {
 } from "@app/types/amounts"
 import { isValidAmount } from "./payment-details"
 import { buildMaxAmountButton } from "./max-amount-button"
+import { priceLnurlSend } from "./lnurl-fee-probe"
 import { MaxAmountButton } from "@app/components/amount-input-screen"
-import { requestInvoice, utils } from "lnurl-pay"
+import { requestInvoice, requestInvoiceWithServiceParams, utils } from "lnurl-pay"
 import { fetchBreezFee, fetchLnurlPayRequest } from "@app/utils/breez-sdk"
 import { LnurlLimits, lnurlLimitsFromPayRequest } from "@app/utils/breez-sdk/fee-errors"
 import { breezFeeErrorMessage } from "@app/utils/breez-sdk/fee-error-message"
@@ -63,11 +64,6 @@ import type { LnurlPayRequestDetails } from "@breeztech/breez-sdk-spark-react-na
 type Props = StackScreenProps<RootStackParamList, "sendBitcoinDetails">
 
 const network = "mainnet" // data?.globals?.network
-
-// The MAX chip's LNURL price check hits the receiver's LNURL service; keep it
-// well under the chip's own 10s fee budget so a slow receiver degrades to
-// "couldn't estimate" instead of holding the tap.
-const LNURL_PROBE_TIMEOUT_MS = 7000
 
 const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
   const styles = useStyles()
@@ -95,6 +91,11 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
   const [asyncErrorMessage, setAsyncErrorMessage] = useState("")
   const [selectedFeeType, setSelectedFeeType] = useState<"fast" | "medium" | "slow">()
   const [isProcessing, setIsProcessing] = useState(false)
+  // Prices already obtained from the LNURL probe, for the life of this screen.
+  // Keyed by destination + sending wallet + probe amount: the probe amount is
+  // in the sending wallet's minor units, so 1000 sats and 1000 cents to the
+  // same address are different questions with different answers.
+  const lnurlProbeCache = useRef(new Map<string, number>())
   const { data } = useSendBitcoinDetailsScreenQuery({
     fetchPolicy: "cache-first",
     returnPartialData: true,
@@ -415,7 +416,7 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
           navigation.navigate("sendBitcoinConfirmation", {
             paymentDetail: paymentDetailForConfirmation,
             flashUserAddress,
-            selectedFeeType,
+            selectedFeeType: selectedFeeType,
             invoiceAmount,
           })
         }
@@ -448,35 +449,31 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
     // paid — pressing Next mints a fresh one for the actual send, which
     // matters because these expire in 60s.
     const probeLnurlFee = async (probeAmount: number): Promise<number | null> => {
-      if (pd.paymentType !== "lnurl" || !pd.setAmount) return null
-      try {
-        const probeDetail = pd.setAmount({
-          ...(isBtcWallet ? btcBalanceMoneyAmount : usdBalanceMoneyAmount),
-          amount: probeAmount,
-        })
-        const btcProbeAmount = probeDetail.convertMoneyAmount(
-          probeDetail.unitOfAccountAmount,
-          "BTC",
-        )
-        const { invoice } = await withTimeout(
-          requestInvoice({
-            lnUrlOrAddress: pd.destination,
-            tokens: utils.toSats(btcProbeAmount.amount),
-          }),
-          LNURL_PROBE_TIMEOUT_MS,
-        )
-        if (probeDetail.paymentType !== "lnurl") return null
-        const pricedDetail = probeDetail.setInvoice({
-          paymentRequest: invoice,
-          paymentRequestAmount: btcProbeAmount,
-        })
-        const fee = await getIbexFee(pricedDetail.getFee)
-        return fee?.amount ?? null
-      } catch {
-        // Unpriceable — the computation declines to propose an amount rather
-        // than guessing one the send would refuse.
-        return null
-      }
+      // Each completed probe mints a REAL invoice at the receiver. Without
+      // memoization, tap MAX → edit → tap MAX again leaves two orphaned
+      // invoices; against a Flash-address or flashcard receiver each is a real
+      // record, and against rate-limited services (BTCPay, LNbits) repeated
+      // taps trip the limit and the destination becomes unpriceable for the
+      // rest of the session. Cache successes only: a transient failure must
+      // not brand a destination unpriceable — the note invites another tap.
+      const cacheKey = `${pd.destination}:${walletCurrency}:${probeAmount}`
+      const cached = lnurlProbeCache.current.get(cacheKey)
+      if (cached !== undefined) return cached
+
+      const fee = await priceLnurlSend({
+        detail: pd,
+        probeAmount,
+        balanceMoneyAmount: isBtcWallet ? btcBalanceMoneyAmount : usdBalanceMoneyAmount,
+        // The params-taking variant: pd.lnurlParams is already resolved, so
+        // this is one round-trip to the receiver's callback rather than two
+        // (re-resolving the pay service first) inside the probe's budget.
+        requestInvoice: ({ params, sats }) =>
+          requestInvoiceWithServiceParams({ params, tokens: utils.toSats(sats) }),
+        getIbexFee,
+      })
+
+      if (fee !== null) lnurlProbeCache.current.set(cacheKey, fee)
+      return fee
     }
 
     return buildMaxAmountButton({
@@ -577,8 +574,9 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
         </View>
       </Screen>
     )
+  } else {
+    return null
   }
-  return null
 }
 export default SendBitcoinDetailsScreen
 

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -53,6 +53,7 @@ import {
 } from "@app/types/amounts"
 import { isValidAmount } from "./payment-details"
 import { buildMaxAmountButton } from "./max-amount-button"
+import { maxAmountButtonStrings } from "./max-amount-button-strings"
 import {
   makeLnurlFeeProbe,
   makeLnurlProbeCache,
@@ -491,17 +492,9 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
       probeLnurlFee,
       formatDisplayAmount: (moneyAmount) =>
         moneyAmountToDisplayCurrencyString({ moneyAmount }),
-      strings: {
-        intraledger: () => LL.AmountInputScreen.maxNoteIntraledger(),
-        feeReserved: (fee) => LL.AmountInputScreen.maxNoteFeeReserved({ fee }),
-        recipientCap: (max) => LL.AmountInputScreen.maxNoteRecipientCap({ max }),
-        feeUnknown: () => LL.AmountInputScreen.maxNoteFeeUnknown(),
-        recipientMin: (minSats) =>
-          LL.SendBitcoinScreen.minReceiveAmountError({
-            amount: `${minSats} sats`,
-          }),
-        feeTooLarge: () => LL.AmountInputScreen.maxNoteFeeTooLarge(),
-      },
+      // Bound to the same formatSats the fee-error banner uses, so the
+      // receiver's minimum reads identically wherever it surfaces.
+      strings: maxAmountButtonStrings(LL, formatSats),
     })
   }
   const maxAmountButton = buildMaxButtonForPaymentDetail()


### PR DESCRIPTION
## What this fixes

Tapping **MAX** on the send amount screen filled the full wallet balance for
destinations the app could not price. The network fee then landed on top and
the send was refused with a generic error (ENG-554; reproduced on-device at a
$4.42 balance).

The gap is structural, not a rounding bug: an LNURL payment detail has no
`getFee` until an invoice is attached (`payment-details/lightning.ts` keeps
`canGetFee` false until then), so the ordinary IBEX fee probe had nothing to
price and silently returned nothing. MAX read "no fee" as "no fee to reserve".

## What it does instead

**Price the destination for real, and propose nothing when that fails.**

- `lnurl-fee-probe.ts` prices an LNURL send by minting a throwaway invoice at
  the probe amount and running the IBEX fee probe against it. The invoice is
  never paid — pressing Next mints a fresh one for the actual send, which
  matters because these expire in 60s. It is minted with
  `requestInvoiceWithServiceParams` against the pay-service params the screen
  already resolved, so pricing costs one round-trip inside its 7s budget
  rather than two.
- When nothing can price the destination — probe error, timeout, no estimate —
  `computeMaxSendAmount` returns `{ amount: 0, reason: "fee-unavailable" }`.
  The chip proposes **no amount at all** and shows `maxNoteFeeUnknown`
  ("Couldn't estimate the network fee right now — tap MAX again or enter an
  amount"). The chip stays outlined: nothing was applied, so it must not claim
  it was, visually or to VoiceOver.
- When it can be priced, MAX offers `balance − ceil(fee) − 1` minor unit. The
  slack is deliberate: the estimate was priced against the probe invoice, not
  the one the send will pay, and amount-monotonicity says nothing about
  invoice-to-invoice route variance. Without it, a 442c balance with a 0.5c
  probe fee filled 441c, the final invoice priced at 1.5c, and confirm blocked
  with "amount exceeds balance (amount + fee)".
- Completed probes are memoized per destination + wallet + probe amount for the
  life of the screen, so tap → edit → tap does not orphan a second real invoice
  at the receiver or trip a rate-limited LNURL service. Successes only: a
  transient failure must not brand a destination unpriceable for the session.

This applies to **every non-intraledger path**, BTC/Breez included. Only
USD-wallet Flash-to-Flash sends still offer the full balance, because those
genuinely have no fee.

### Deliberately not done

An earlier revision of this branch reserved a constant borrowed from galoy's
`FEECAP_BASIS_POINTS` (50bp with a one-minor-unit floor). That was dropped in
`670c8b6d`: the cap governs galoy's payment layer, and
`lnNoAmountUsdInvoicePaymentSend` bypasses it entirely to call
`Ibex.payInvoice`, so the number bounded nothing real. Guessing a reserve is
not more honest than declining to guess — it just fails later.

## Tests

- `__tests__/utils/lnurl-fee-probe.spec.ts` (new) — the probe itself: the
  whole-sat conversion of the probe amount, the resolved-params mint, that the
  fee returned belongs to the invoice it minted, and null on mint rejection,
  timeout, missing params, non-LNURL detail, sub-sat amount, and an IBEX probe
  that returns nothing or throws.
- `__tests__/utils/max-send-amount.spec.ts` — the reserve arithmetic, including
  the 442c/0.5c band that used to dead-end at confirm.
- `__tests__/utils/max-amount-button.spec.ts` — routing LNURL through the probe
  rather than the invoice-less IBEX probe, and the note mapping.
- `__tests__/components/amount-input-screen-max-chip.spec.tsx` — a note with no
  amount shows the note, leaves the pad untouched, and leaves the chip
  outlined and unselected.

## Note on the i18n diff

`app/i18n/raw-i18n/source/en.json` is generated from `app/i18n/en/index.ts` by
`yarn update-translations`. Regenerating it to add `maxNoteFeeUnknown` also
backfilled `TopupDetails.allowanceExhausted`, which #700 added to the source of
truth without re-exporting. Both keys are seeded into all 23 translation files
with the English string — the same convention the existing `maxNote*` keys
follow — so the `translation-drift` gate passes.
