### PR TITLE
fix(send): refuse to send an invoice that already expired

### DIFF
--- a/__mocks__/@react-native-firebase/analytics.js
+++ b/__mocks__/@react-native-firebase/analytics.js
@@ -1,5 +1,18 @@
+/* eslint-disable */
+
 const logEvent = jest.fn()
 
-export default () => ({
+const instance = {
   logEvent,
-})
+  setUserId: jest.fn(),
+  setUserProperty: jest.fn(),
+  setUserProperties: jest.fn(),
+  logScreenView: jest.fn(),
+}
+
+// Modular API (`import { getAnalytics } from "@react-native-firebase/analytics"`),
+// which is what app/utils/analytics.ts uses. Without it every logged event
+// throws "getAnalytics is not a function" and swallows the call it wrapped.
+export const getAnalytics = () => instance
+
+export default () => instance

--- a/__mocks__/@react-native-firebase/crashlytics.js
+++ b/__mocks__/@react-native-firebase/crashlytics.js
@@ -1,6 +1,13 @@
 /* eslint-disable */
 
-export default () => ({
+const instance = {
   log: (message) => {},
   recordError: (err) => {},
-})
+}
+
+// Modular API (`import { getCrashlytics } from "@react-native-firebase/crashlytics"`),
+// which is what the send flow uses. Without it, any code path that reports an
+// error throws "getCrashlytics is not a function" and masks the real failure.
+export const getCrashlytics = () => instance
+
+export default () => instance

--- a/__mocks__/breez-sdk.js
+++ b/__mocks__/breez-sdk.js
@@ -3,4 +3,7 @@ module.exports = {
   receivePaymentBreez: jest.fn(() => Promise.resolve({ paymentRequest: "" })),
   fetchBreezFee: jest.fn(() => Promise.resolve({ fee: 0, err: null })),
   fetchLnurlPayRequest: jest.fn(() => Promise.resolve(null)),
+  payLightningBreez: jest.fn(() => Promise.resolve({ success: true, error: undefined })),
+  payLnurlBreez: jest.fn(() => Promise.resolve({ success: true, error: undefined })),
+  payOnchainBreez: jest.fn(() => Promise.resolve({ success: true, error: undefined })),
 }

--- a/__tests__/payment-destination/lightning.spec.ts
+++ b/__tests__/payment-destination/lightning.spec.ts
@@ -20,7 +20,15 @@ jest.mock("@app/screens/send-bitcoin-screen/payment-details", () => {
     createNoAmountLightningPaymentDetails: mockCreateNoAmountLightningPaymentDetail,
   }
 })
-import { createLightningDestination } from "@app/screens/send-bitcoin-screen/payment-destination"
+import {
+  createLightningDestination,
+  resolveLightningDestination,
+} from "@app/screens/send-bitcoin-screen/payment-destination"
+import {
+  noteInvoiceFirstSight,
+  resetInvoiceFirstSight,
+} from "@app/screens/send-bitcoin-screen/invoice-expiry"
+import { InvalidLightningDestinationReason } from "@galoymoney/client"
 import { defaultPaymentDetailParams } from "./helpers"
 import { ZeroBtcMoneyAmount, toBtcMoneyAmount } from "@app/types/amounts"
 
@@ -31,6 +39,13 @@ describe("create lightning destination", () => {
     paymentRequest: "testinvoice",
     memo: "testmemo",
   } as const
+
+  // First sightings live in module state, and this file now writes to it.
+  beforeEach(resetInvoiceFirstSight)
+  afterEach(() => {
+    resetInvoiceFirstSight()
+    jest.restoreAllMocks()
+  })
 
   describe("with amount", () => {
     const parsedLightningDestinationWithAmount = {
@@ -72,6 +87,69 @@ describe("create lightning destination", () => {
         destinationSpecifiedMemo: parsedLightningDestinationWithoutAmount.memo,
         sendingWalletDescriptor: defaultPaymentDetailParams.sendingWalletDescriptor,
       })
+    })
+  })
+
+  // ENG-555. The expiry guard's primary signal is how long the invoice has
+  // been in front of THIS user, and that reading is only worth anything if it
+  // starts at a moment the invoice was provably alive. This is that moment:
+  // `parsePaymentDestination` rejects an already-expired bolt11, so a
+  // destination reaching `valid === true` was live one instant ago.
+  //
+  // Every later candidate is one screen too late. From here the user still has
+  // to tap Next, and on the paste/blur path the destination screen has already
+  // flipped to Valid and may be holding them in ConfirmDestinationModal — an
+  // unbounded pause on a 60-second invoice that a reading taken on the amount
+  // screen cannot see, which is how a corpse reaches the backend as "Something
+  // went wrong".
+  describe("first sight of the invoice", () => {
+    // The real invoice from the incident: issued 1787243982, expires
+    // 1787244042 — a 60-second window, per IBEX's cap.
+    const INCIDENT_INVOICE =
+      "lnbc1p4gwtwwpp5wwulk8jw0llvgjadwzuen6nxh7hgmddplj3evpgjc7n8l5kzqvmqdph2pshjgr5dusyvmrpwd5zq4mpd3kx2apq24ek2u36ypj8yetpv3kkz7qcqzzsxqzpusp5wane88x5twmdlpnu4cqrk4wd6g3tks7xgq798nt9zt68vmcnnp6q9qxpqysgqnszg0ycjk4255es2hdd3ajep3yquuvra6jn4k8shskhpzg80mrl9m9pgylahzq80aw9ekz6e47ycpcf558080xrxn6uljn54lc447rqpn9u06u"
+    const ISSUED = 1787243982
+    // The parse lands 4 seconds into the window, while the invoice is
+    // unambiguously alive.
+    const PARSED_SECONDS = ISSUED + 4
+
+    it("registers the moment the destination is proved valid", () => {
+      jest.spyOn(Date, "now").mockReturnValue(PARSED_SECONDS * 1000)
+
+      createLightningDestination({
+        ...baseParsedLightningDestination,
+        paymentRequest: INCIDENT_INVOICE,
+      })
+
+      // Read back through the registrar itself: it returns the sighting on
+      // record, so a later call reporting the parse instant proves this
+      // function put it there and that every downstream call (amount screen,
+      // confirm screen) is the no-op. If nothing had registered, this call
+      // would install ISSUED + 200 and return it — and the elapsed duration
+      // the guard measures would collapse to zero.
+      expect(noteInvoiceFirstSight(INCIDENT_INVOICE, ISSUED + 200)).toBe(PARSED_SECONDS)
+    })
+
+    it("never registers a destination that failed to parse", () => {
+      // Only `valid === true` destinations reach createLightningDestination,
+      // so a half-typed invoice cannot pin a sighting to a string the user is
+      // still editing — DestinationField re-parses on every keystroke. The
+      // partial is carried on the invalid result here so that hoisting the
+      // registration up into resolveLightningDestination, ahead of the
+      // validity check, is caught rather than silently accepted.
+      jest.spyOn(Date, "now").mockReturnValue(PARSED_SECONDS * 1000)
+
+      const partial = INCIDENT_INVOICE.slice(0, 40)
+      const result = resolveLightningDestination({
+        paymentType: "lightning",
+        valid: false,
+        paymentRequest: partial,
+        invalidReason: InvalidLightningDestinationReason.Unknown,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+
+      expect(result.valid).toBe(false)
+      // Nothing on record, so this call is what installs the reading.
+      expect(noteInvoiceFirstSight(partial, ISSUED + 200)).toBe(ISSUED + 200)
     })
   })
 })

--- a/__tests__/payment-details/amount-lightning-payment-details.spec.ts
+++ b/__tests__/payment-details/amount-lightning-payment-details.spec.ts
@@ -34,6 +34,11 @@ describe("amount lightning payment details", () => {
     expect(paymentDetails).toEqual(
       expect.objectContaining({
         destination: defaultParams.paymentRequest,
+        // The confirm screen checks this bolt11's expiry before sending
+        // (ENG-555). It is optional on the shared PaymentDetail type, so
+        // dropping it here would silently disable that check rather than
+        // fail to compile.
+        paymentRequest: defaultParams.paymentRequest,
         destinationSpecifiedAmount: defaultParams.paymentRequestAmount,
         settlementAmount: defaultParams.convertMoneyAmount(
           defaultParams.paymentRequestAmount,

--- a/__tests__/payment-details/lnurl-payment-details.spec.ts
+++ b/__tests__/payment-details/lnurl-payment-details.spec.ts
@@ -1,5 +1,6 @@
 import { WalletCurrency } from "@app/graphql/generated"
 import * as PaymentDetails from "@app/screens/send-bitcoin-screen/payment-details/lightning"
+import { PaymentType } from "@galoymoney/client"
 import { LnUrlPayServiceResponse, Satoshis } from "lnurl-pay/dist/types/types"
 import { createMock } from "ts-auto-mock"
 import {
@@ -90,11 +91,31 @@ describe("lnurl payment details", () => {
     )
   })
 
+  it("exposes the bolt11 only once one has been minted", () => {
+    // The confirm screen checks this bolt11's expiry before sending
+    // (ENG-555), and an LNURL detail's `destination` is the lightning
+    // address, not an invoice — so `paymentRequest` is the only way to reach
+    // it. It is optional on the shared PaymentDetail type, so dropping it
+    // would silently disable that check rather than fail to compile.
+    const beforeMinting = createLnurlPaymentDetails(defaultParamsWithoutInvoice)
+    expect(beforeMinting.paymentRequest).toBe(undefined)
+
+    if (beforeMinting.paymentType !== PaymentType.Lnurl) {
+      throw new Error("expected an lnurl payment detail")
+    }
+    const withInvoice = beforeMinting.setInvoice({
+      paymentRequest: defaultParamsWithInvoice.paymentRequest,
+      paymentRequestAmount: defaultParamsWithInvoice.paymentRequestAmount,
+    })
+    expect(withInvoice.paymentRequest).toBe(defaultParamsWithInvoice.paymentRequest)
+  })
+
   it("properly sets fields with invoice set", () => {
     const paymentDetails = createLnurlPaymentDetails(defaultParamsWithInvoice)
     expect(paymentDetails).toEqual(
       expect.objectContaining({
         destination: defaultParamsWithInvoice.lnurl,
+        paymentRequest: defaultParamsWithInvoice.paymentRequest,
         settlementAmount: defaultParamsWithInvoice.paymentRequestAmount,
         unitOfAccountAmount: defaultParamsWithInvoice.unitOfAccountAmount,
         sendingWalletDescriptor: defaultParamsWithInvoice.sendingWalletDescriptor,

--- a/__tests__/payment-details/no-amount-lightning-payment-details.spec.ts
+++ b/__tests__/payment-details/no-amount-lightning-payment-details.spec.ts
@@ -38,6 +38,11 @@ describe("no amount lightning payment details", () => {
     expect(paymentDetails).toEqual(
       expect.objectContaining({
         destination: defaultParams.paymentRequest,
+        // The confirm screen checks this bolt11's expiry before sending
+        // (ENG-555). It is optional on the shared PaymentDetail type, so
+        // dropping it here would silently disable that check rather than
+        // fail to compile.
+        paymentRequest: defaultParams.paymentRequest,
         settlementAmount: defaultParams.convertMoneyAmount(
           defaultParams.unitOfAccountAmount,
           defaultParams.sendingWalletDescriptor.currency,

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -5,7 +5,10 @@ import { Intraledger } from "../../app/screens/send-bitcoin-screen/send-bitcoin-
 import { ContextForScreen } from "./helper"
 
 import SendBitcoinConfirmationScreen from "@app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen"
-import { resetInvoiceFirstSight } from "@app/screens/send-bitcoin-screen/invoice-expiry"
+import {
+  noteInvoiceFirstSight,
+  resetInvoiceFirstSight,
+} from "@app/screens/send-bitcoin-screen/invoice-expiry"
 import {
   createAmountLightningPaymentDetails,
   createLnurlPaymentDetails,
@@ -63,10 +66,18 @@ describe("expired held invoice", () => {
     "lnbc1p4gwtwwpp5wwulk8jw0llvgjadwzuen6nxh7hgmddplj3evpgjc7n8l5kzqvmqdph2pshjgr5dusyvmrpwd5zq4mpd3kx2apq24ek2u36ypj8yetpv3kkz7qcqzzsxqzpusp5wane88x5twmdlpnu4cqrk4wd6g3tks7xgq798nt9zt68vmcnnp6q9qxpqysgqnszg0ycjk4255es2hdd3ajep3yquuvra6jn4k8shskhpzg80mrl9m9pgylahzq80aw9ekz6e47ycpcf558080xrxn6uljn54lc447rqpn9u06u"
   const ISSUED = 1787243982
   const EXPIRES = 1787244042
-  // The screen opens while the invoice is still alive — which is the only way
-  // it can open, since parsePaymentDestination rejects an already-dead bolt11
-  // at paste/scan time and an LNURL detail mints on the way in.
+  // This screen can perfectly well open on a dead invoice. parsePaymentDestination
+  // only rejects a bolt11 that is already expired at paste/scan time; the
+  // amount screen then holds a `lightning` detail unchanged for as long as the
+  // user takes to pick a wallet and type a number (only `lnurl` re-mints, at
+  // send-bitcoin-details-screen.tsx). So "alive at mount" is the common case,
+  // not the only one — see "refuses an invoice that was already dead when the
+  // screen opened" below.
   const MOUNTED_MS = (ISSUED + 4) * 1000
+  // The scan, four seconds into the 60-second window. Standing in for the
+  // amount screen's own noteInvoiceFirstSight call in the cases that need the
+  // invoice to have been seen before this screen mounted.
+  const SCANNED_SECONDS = ISSUED + 4
   // The user's retry from the report, ~18 minutes past expiry.
   const LONG_AFTER_EXPIRY_MS = (EXPIRES + 18 * 60) * 1000
   // An ordinary pause on the confirm screen: 90 seconds, which outlives a
@@ -231,6 +242,31 @@ describe("expired held invoice", () => {
     expect(getByText(en.SendBitcoinDestinationScreen.expiredInvoice)).toBeTruthy()
     expect(payLightningBreez).not.toHaveBeenCalled()
     expect(blockedEvents()).toHaveLength(1)
+  })
+
+  it("refuses an invoice that was already dead when the screen opened", async () => {
+    // ENG-555's actual shape. The user scanned a live 60-second invoice, then
+    // spent ~18 minutes on the amount screen — nothing there re-mints a
+    // `lightning` detail — so this screen mounts holding a corpse and the very
+    // first tap must be refused. That only works because the amount screen
+    // registered first sight at the scan; seeded here in its place.
+    noteInvoiceFirstSight(INCIDENT_INVOICE, SCANNED_SECONDS)
+    jest.spyOn(Date, "now").mockReturnValue(LONG_AFTER_EXPIRY_MS)
+
+    const paymentDetail = createAmountLightningPaymentDetails({
+      paymentRequest: INCIDENT_INVOICE,
+      paymentRequestAmount: amount,
+      convertMoneyAmount,
+      sendingWalletDescriptor: btcSendingWalletDescriptor,
+    })
+
+    const { getByText, confirm } = await renderConfirmation(paymentDetail)
+    // No pause on this screen at all: mount and tap read the same instant.
+    await confirm(LONG_AFTER_EXPIRY_MS)
+
+    expect(getByText(en.SendBitcoinDestinationScreen.expiredInvoice)).toBeTruthy()
+    expect(payLightningBreez).not.toHaveBeenCalled()
+    expect(blockedEvents()).toEqual([blockedEvent("lightning", WalletCurrency.Btc)])
   })
 
   // A USD send puts the held bolt11 in the GraphQL mutation input, so the

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -1,8 +1,35 @@
-import React from "react"
+import React, { PropsWithChildren } from "react"
 
-import { act, render, waitFor } from "@testing-library/react-native"
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native"
 import { Intraledger } from "../../app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.stories"
 import { ContextForScreen } from "./helper"
+
+import SendBitcoinConfirmationScreen from "@app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen"
+import {
+  createAmountLightningPaymentDetails,
+  createLnurlPaymentDetails,
+} from "@app/screens/send-bitcoin-screen/payment-details/lightning"
+import { ConvertMoneyAmount } from "@app/screens/send-bitcoin-screen/payment-details/index.types"
+import { BreezContext } from "@app/contexts/BreezContext"
+import { WalletCurrency } from "@app/graphql/generated"
+import { DisplayCurrency, toBtcMoneyAmount } from "@app/types/amounts"
+import { payLightningBreez, payLnurlBreez } from "@app/utils/breez-sdk"
+import baseTranslation from "@app/i18n/en"
+import type { Translation } from "@app/i18n/i18n-types"
+import { loadLocale } from "@app/i18n/i18n-util.sync"
+import { LnUrlPayServiceResponse, Satoshis } from "lnurl-pay/dist/types/types"
+import { createMock } from "ts-auto-mock"
+
+// ContextForScreen mounts TypesafeI18n but nothing loads the dictionary, so
+// every LL.*() renders as "" until this runs. The expiry assertions below are
+// about which copy the user sees, so they need the real strings.
+loadLocale("en")
+
+// The source dictionary is exported as the loose `BaseTranslation`; the
+// generated `Translation` shape is what actually describes it. Asserting
+// against these rather than string literals means renaming a key or editing
+// the copy cannot leave a test quietly asserting the wrong sentence.
+const en = baseTranslation as Translation
 
 it("SendScreen Confirmation", async () => {
   const { findByLabelText } = render(
@@ -19,5 +46,177 @@ it("SendScreen Confirmation", async () => {
   await waitFor(async () => {
     const { children } = await findByLabelText("Successful Fee")
     expect(children).toEqual(["₦0.00 ($0.00)"])
+  })
+})
+
+// ENG-555. The confirm screen holds whatever bolt11 was minted when the user
+// left the amount screen, and Flash receive invoices die after 60 seconds.
+// These drive the guard end to end: the detail factory really does surface
+// the invoice, the screen really does decode it, and the refusal really does
+// reach the user instead of a doomed round trip — while the one path that
+// re-mints at send time is left alone.
+describe("expired held invoice", () => {
+  // The real invoice from the incident: issued 1787243982, expires 1787244042.
+  const INCIDENT_INVOICE =
+    "lnbc1p4gwtwwpp5wwulk8jw0llvgjadwzuen6nxh7hgmddplj3evpgjc7n8l5kzqvmqdph2pshjgr5dusyvmrpwd5zq4mpd3kx2apq24ek2u36ypj8yetpv3kkz7qcqzzsxqzpusp5wane88x5twmdlpnu4cqrk4wd6g3tks7xgq798nt9zt68vmcnnp6q9qxpqysgqnszg0ycjk4255es2hdd3ajep3yquuvra6jn4k8shskhpzg80mrl9m9pgylahzq80aw9ekz6e47ycpcf558080xrxn6uljn54lc447rqpn9u06u"
+  const EXPIRES = 1787244042
+  // The user's retry from the report, ~18 minutes past expiry — well beyond
+  // the clock-skew grace, so this is a genuinely dead invoice.
+  const LONG_AFTER_EXPIRY_MS = (EXPIRES + 18 * 60) * 1000
+
+  const convertMoneyAmount: ConvertMoneyAmount = (moneyAmount, currency) => ({
+    amount: moneyAmount.amount,
+    currency,
+    currencyCode: currency === DisplayCurrency ? "NGN" : currency,
+  })
+
+  const btcSendingWalletDescriptor = {
+    currency: WalletCurrency.Btc,
+    id: "testwallet",
+  }
+  // Small enough to sit under the 158-cent USD balance the mocked
+  // SendBitcoinConfirmationScreen query returns, so Confirm is not disabled
+  // for balance reasons and the test cannot pass vacuously.
+  const amount = toBtcMoneyAmount(100)
+
+  const lnurlParams = () =>
+    createMock<LnUrlPayServiceResponse>({ min: 1 as Satoshis, max: 100000 as Satoshis })
+
+  // The Breez wallet's balance drives the screen's own amount validation for
+  // BTC sends; the context default is 0, which would disable Confirm.
+  const WithFundedBreezWallet: React.FC<PropsWithChildren> = ({ children }) => (
+    <BreezContext.Provider
+      value={
+        {
+          refreshBreez: () => {},
+          retryExternalWalletRegistration: async () => {},
+          loading: false,
+          externalWalletLoading: false,
+          externalWalletError: undefined,
+          btcWallet: {
+            id: "breezwallet",
+            walletCurrency: WalletCurrency.Btc,
+            balance: 1_000_000,
+            isExternal: true,
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any
+      }
+    >
+      {children}
+    </BreezContext.Provider>
+  )
+
+  const renderConfirmation = async (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    paymentDetail: any,
+  ) => {
+    const navigate = jest.fn()
+    const route = {
+      key: "sendBitcoinConfirmationScreen",
+      name: "sendBitcoinConfirmation",
+      params: { paymentDetail },
+    } as const
+
+    const screen = render(
+      <ContextForScreen>
+        <WithFundedBreezWallet>
+          <SendBitcoinConfirmationScreen
+            route={route}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            navigation={{ navigate } as any}
+          />
+        </WithFundedBreezWallet>
+      </ContextForScreen>,
+    )
+
+    await act(async () => {})
+    await act(async () => {})
+
+    const confirm = () =>
+      act(async () => {
+        fireEvent.press(screen.getByText(en.SendBitcoinConfirmationScreen.title))
+      })
+
+    return { ...screen, navigate, confirm }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(Date, "now").mockReturnValue(LONG_AFTER_EXPIRY_MS)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("refuses a payee-minted invoice that died, and names the right remedy", async () => {
+    const paymentDetail = createAmountLightningPaymentDetails({
+      paymentRequest: INCIDENT_INVOICE,
+      paymentRequestAmount: amount,
+      convertMoneyAmount,
+      sendingWalletDescriptor: btcSendingWalletDescriptor,
+    })
+
+    const { getByText, queryByText, confirm } = await renderConfirmation(paymentDetail)
+    await confirm()
+
+    // A scanned or pasted bolt11 cannot be re-minted by going back: setAmount
+    // returns the same invoice, and an amount-carrying invoice has no amount
+    // field at all. Telling this user to re-enter the amount would loop them
+    // forever, so they are told to get a new invoice from the payee.
+    expect(getByText(en.SendBitcoinDestinationScreen.expiredInvoice)).toBeTruthy()
+    expect(queryByText(en.SendBitcoinConfirmationScreen.invoiceExpired)).toBeNull()
+    // The whole point of the guard: no doomed round trip.
+    expect(payLightningBreez).not.toHaveBeenCalled()
+  })
+
+  it("tells an LNURL sender to go back, where a fresh invoice really is minted", async () => {
+    const lnurlDetail = createLnurlPaymentDetails({
+      lnurl: "someone@flashapp.me",
+      lnurlParams: lnurlParams(),
+      paymentRequest: INCIDENT_INVOICE,
+      paymentRequestAmount: amount,
+      unitOfAccountAmount: amount,
+      convertMoneyAmount,
+      // A USD send puts the held bolt11 in the GraphQL mutation input, so the
+      // guard applies here — unlike the Breez BTC wallet below.
+      sendingWalletDescriptor: { currency: WalletCurrency.Usd, id: "testwallet" },
+    })
+    const sendPaymentMutation = jest.fn()
+    const paymentDetail = { ...lnurlDetail, sendPaymentMutation }
+
+    const { getByText, queryByText, confirm } = await renderConfirmation(paymentDetail)
+    await confirm()
+
+    expect(getByText(en.SendBitcoinConfirmationScreen.invoiceExpired)).toBeTruthy()
+    expect(queryByText(en.SendBitcoinDestinationScreen.expiredInvoice)).toBeNull()
+    expect(sendPaymentMutation).not.toHaveBeenCalled()
+  })
+
+  it("does not block a BTC LNURL send, which mints a fresh invoice anyway", async () => {
+    // useSendPayment routes BTC + lnurl to payLnurlBreez, which re-resolves
+    // the lightning address and mints at send time. The held bolt11 never
+    // goes out, so refusing on its expiry would kill a payment Breez would
+    // have completed — the false positive this guard must never produce.
+    const paymentDetail = createLnurlPaymentDetails({
+      lnurl: "someone@flashapp.me",
+      lnurlParams: lnurlParams(),
+      paymentRequest: INCIDENT_INVOICE,
+      paymentRequestAmount: amount,
+      unitOfAccountAmount: amount,
+      convertMoneyAmount,
+      sendingWalletDescriptor: btcSendingWalletDescriptor,
+    })
+
+    const { queryByText, navigate, confirm } = await renderConfirmation(paymentDetail)
+    await confirm()
+
+    expect(queryByText(en.SendBitcoinConfirmationScreen.invoiceExpired)).toBeNull()
+    expect(queryByText(en.SendBitcoinDestinationScreen.expiredInvoice)).toBeNull()
+    expect(payLnurlBreez).toHaveBeenCalled()
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith("sendBitcoinSuccess", expect.anything()),
+    )
   })
 })

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -82,7 +82,7 @@ describe("expired held invoice", () => {
   const LONG_AFTER_EXPIRY_MS = (EXPIRES + 18 * 60) * 1000
   // An ordinary pause on the confirm screen: 90 seconds, which outlives a
   // 60-second Flash invoice but leaves it younger than expiry + the 120s
-  // clock-skew grace. Only the elapsed-since-mount reading can see this one.
+  // clock-skew grace. Only the elapsed-since-first-sight reading can see this one.
   const AFTER_ORDINARY_PAUSE_MS = MOUNTED_MS + 90 * 1000
 
   const convertMoneyAmount: ConvertMoneyAmount = (moneyAmount, currency) => ({
@@ -227,7 +227,7 @@ describe("expired held invoice", () => {
   it("refuses after an ordinary 90-second pause, which is younger than the grace", async () => {
     // The pause this guard exists to catch, and the one the absolute
     // expiry+120s comparison cannot see: 90 seconds on a 60-second invoice.
-    // Before the elapsed-since-mount reading, this user still spent the
+    // Before the elapsed-since-first-sight reading, this user still spent the
     // doomed round trip and got "Something went wrong".
     const paymentDetail = createAmountLightningPaymentDetails({
       paymentRequest: INCIDENT_INVOICE,

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -5,6 +5,7 @@ import { Intraledger } from "../../app/screens/send-bitcoin-screen/send-bitcoin-
 import { ContextForScreen } from "./helper"
 
 import SendBitcoinConfirmationScreen from "@app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen"
+import { resetInvoiceFirstSight } from "@app/screens/send-bitcoin-screen/invoice-expiry"
 import {
   createAmountLightningPaymentDetails,
   createLnurlPaymentDetails,
@@ -172,6 +173,10 @@ describe("expired held invoice", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.spyOn(Date, "now").mockReturnValue(MOUNTED_MS)
+    // First-sight readings are keyed by invoice in module state so they
+    // survive a screen remount in production. Clear them between cases, or a
+    // fixture reused across tests carries the previous test's clock in.
+    resetInvoiceFirstSight()
   })
 
   afterEach(() => {

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -14,6 +14,7 @@ import { BreezContext } from "@app/contexts/BreezContext"
 import { WalletCurrency } from "@app/graphql/generated"
 import { DisplayCurrency, toBtcMoneyAmount } from "@app/types/amounts"
 import { payLightningBreez, payLnurlBreez } from "@app/utils/breez-sdk"
+import { getAnalytics } from "@react-native-firebase/analytics"
 import baseTranslation from "@app/i18n/en"
 import type { Translation } from "@app/i18n/i18n-types"
 import { loadLocale } from "@app/i18n/i18n-util.sync"
@@ -59,10 +60,18 @@ describe("expired held invoice", () => {
   // The real invoice from the incident: issued 1787243982, expires 1787244042.
   const INCIDENT_INVOICE =
     "lnbc1p4gwtwwpp5wwulk8jw0llvgjadwzuen6nxh7hgmddplj3evpgjc7n8l5kzqvmqdph2pshjgr5dusyvmrpwd5zq4mpd3kx2apq24ek2u36ypj8yetpv3kkz7qcqzzsxqzpusp5wane88x5twmdlpnu4cqrk4wd6g3tks7xgq798nt9zt68vmcnnp6q9qxpqysgqnszg0ycjk4255es2hdd3ajep3yquuvra6jn4k8shskhpzg80mrl9m9pgylahzq80aw9ekz6e47ycpcf558080xrxn6uljn54lc447rqpn9u06u"
+  const ISSUED = 1787243982
   const EXPIRES = 1787244042
-  // The user's retry from the report, ~18 minutes past expiry — well beyond
-  // the clock-skew grace, so this is a genuinely dead invoice.
+  // The screen opens while the invoice is still alive — which is the only way
+  // it can open, since parsePaymentDestination rejects an already-dead bolt11
+  // at paste/scan time and an LNURL detail mints on the way in.
+  const MOUNTED_MS = (ISSUED + 4) * 1000
+  // The user's retry from the report, ~18 minutes past expiry.
   const LONG_AFTER_EXPIRY_MS = (EXPIRES + 18 * 60) * 1000
+  // An ordinary pause on the confirm screen: 90 seconds, which outlives a
+  // 60-second Flash invoice but leaves it younger than expiry + the 120s
+  // clock-skew grace. Only the elapsed-since-mount reading can see this one.
+  const AFTER_ORDINARY_PAUSE_MS = MOUNTED_MS + 90 * 1000
 
   const convertMoneyAmount: ConvertMoneyAmount = (moneyAmount, currency) => ({
     amount: moneyAmount.amount,
@@ -133,17 +142,36 @@ describe("expired held invoice", () => {
     await act(async () => {})
     await act(async () => {})
 
-    const confirm = () =>
+    // The screen reads the clock twice: once at mount, once when Send is
+    // tapped. Advancing it between the two is what turns "the invoice looks
+    // old" into "the user sat on this invoice", which is the only reading a
+    // wrong device clock cannot fake.
+    const confirm = (atMs: number = LONG_AFTER_EXPIRY_MS) =>
       act(async () => {
+        jest.spyOn(Date, "now").mockReturnValue(atMs)
         fireEvent.press(screen.getByText(en.SendBitcoinConfirmationScreen.title))
       })
 
     return { ...screen, navigate, confirm }
   }
 
+  const blockedEvents = () =>
+    (getAnalytics().logEvent as jest.Mock).mock.calls.filter(
+      ([event]) => event === "payment_blocked_expired_invoice",
+    )
+
+  // Firebase event params are snake_case by convention — app/utils/analytics.ts
+  // turns the rule off file-wide for the same reason.
+  /* eslint-disable camelcase */
+  const blockedEvent = (payment_type: string, sending_wallet: WalletCurrency) => [
+    "payment_blocked_expired_invoice",
+    { payment_type, sending_wallet },
+  ]
+  /* eslint-enable camelcase */
+
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.spyOn(Date, "now").mockReturnValue(LONG_AFTER_EXPIRY_MS)
+    jest.spyOn(Date, "now").mockReturnValue(MOUNTED_MS)
   })
 
   afterEach(() => {
@@ -161,37 +189,115 @@ describe("expired held invoice", () => {
     const { getByText, queryByText, confirm } = await renderConfirmation(paymentDetail)
     await confirm()
 
-    // A scanned or pasted bolt11 cannot be re-minted by going back: setAmount
-    // returns the same invoice, and an amount-carrying invoice has no amount
-    // field at all. Telling this user to re-enter the amount would loop them
-    // forever, so they are told to get a new invoice from the payee.
+    // A scanned or pasted bolt11 cannot be re-minted by going back: going
+    // back and forward returns the same invoice, and an amount-carrying
+    // invoice has no amount field at all. Telling this user to confirm again
+    // would loop them forever, so they are told to get a new invoice from the
+    // payee.
     expect(getByText(en.SendBitcoinDestinationScreen.expiredInvoice)).toBeTruthy()
-    expect(queryByText(en.SendBitcoinConfirmationScreen.invoiceExpired)).toBeNull()
+    expect(queryByText(en.SendBitcoinConfirmationScreen.heldInvoiceExpired)).toBeNull()
     // The whole point of the guard: no doomed round trip.
     expect(payLightningBreez).not.toHaveBeenCalled()
+    // ...and the refusal is countable. logPaymentAttempt deliberately does
+    // not fire here, so without this event a blocked send leaves no trace at
+    // all — client or server — and ENG-555 stays unanswerable.
+    expect(blockedEvents()).toEqual([blockedEvent("lightning", WalletCurrency.Btc)])
+    expect(getAnalytics().logEvent).not.toHaveBeenCalledWith(
+      "payment_attempt",
+      expect.anything(),
+    )
   })
 
-  it("tells an LNURL sender to go back, where a fresh invoice really is minted", async () => {
+  it("refuses after an ordinary 90-second pause, which is younger than the grace", async () => {
+    // The pause this guard exists to catch, and the one the absolute
+    // expiry+120s comparison cannot see: 90 seconds on a 60-second invoice.
+    // Before the elapsed-since-mount reading, this user still spent the
+    // doomed round trip and got "Something went wrong".
+    const paymentDetail = createAmountLightningPaymentDetails({
+      paymentRequest: INCIDENT_INVOICE,
+      paymentRequestAmount: amount,
+      convertMoneyAmount,
+      sendingWalletDescriptor: btcSendingWalletDescriptor,
+    })
+
+    const { getByText, confirm } = await renderConfirmation(paymentDetail)
+    await confirm(AFTER_ORDINARY_PAUSE_MS)
+
+    expect(getByText(en.SendBitcoinDestinationScreen.expiredInvoice)).toBeTruthy()
+    expect(payLightningBreez).not.toHaveBeenCalled()
+    expect(blockedEvents()).toHaveLength(1)
+  })
+
+  // A USD send puts the held bolt11 in the GraphQL mutation input, so the
+  // guard applies — unlike the Breez BTC wallet further down.
+  const usdLnurlPaymentDetail = (lnurlPayParams = lnurlParams()) => {
     const lnurlDetail = createLnurlPaymentDetails({
       lnurl: "someone@flashapp.me",
-      lnurlParams: lnurlParams(),
+      lnurlParams: lnurlPayParams,
       paymentRequest: INCIDENT_INVOICE,
       paymentRequestAmount: amount,
       unitOfAccountAmount: amount,
       convertMoneyAmount,
-      // A USD send puts the held bolt11 in the GraphQL mutation input, so the
-      // guard applies here — unlike the Breez BTC wallet below.
       sendingWalletDescriptor: { currency: WalletCurrency.Usd, id: "testwallet" },
     })
     const sendPaymentMutation = jest.fn()
-    const paymentDetail = { ...lnurlDetail, sendPaymentMutation }
+    return { paymentDetail: { ...lnurlDetail, sendPaymentMutation }, sendPaymentMutation }
+  }
+
+  it("tells an LNURL sender to go back, where a fresh invoice really is minted", async () => {
+    const { paymentDetail, sendPaymentMutation } = usdLnurlPaymentDetail()
 
     const { getByText, queryByText, confirm } = await renderConfirmation(paymentDetail)
-    await confirm()
+    await confirm(AFTER_ORDINARY_PAUSE_MS)
 
-    expect(getByText(en.SendBitcoinConfirmationScreen.invoiceExpired)).toBeTruthy()
+    expect(getByText(en.SendBitcoinConfirmationScreen.heldInvoiceExpired)).toBeTruthy()
     expect(queryByText(en.SendBitcoinDestinationScreen.expiredInvoice)).toBeNull()
     expect(sendPaymentMutation).not.toHaveBeenCalled()
+    expect(blockedEvents()).toEqual([blockedEvent("lnurl", WalletCurrency.Usd)])
+  })
+
+  it("gives a fixed-amount LNURL sender a remedy they can actually follow", async () => {
+    // min === max (a flashcard reload, a fixed-price merchant QR) makes the
+    // amount a destination-specified one, which renders the amount input
+    // disabled. "Enter the amount again" would send this user hunting for a
+    // field that is not there; going back and forward re-mints on its own.
+    const { paymentDetail } = usdLnurlPaymentDetail(
+      createMock<LnUrlPayServiceResponse>({
+        min: 100 as Satoshis,
+        max: 100 as Satoshis,
+      }),
+    )
+    expect(paymentDetail.canSetAmount).toBe(false)
+
+    const { getByText, confirm } = await renderConfirmation(paymentDetail)
+    await confirm(AFTER_ORDINARY_PAUSE_MS)
+
+    const remedy = en.SendBitcoinConfirmationScreen.heldInvoiceExpired
+    expect(getByText(remedy)).toBeTruthy()
+    expect(remedy).not.toMatch(/enter the amount/i)
+  })
+
+  it("does not block a badly fast handset on a freshly minted LNURL invoice", async () => {
+    // A handset more than expiry + 120s fast reads every invoice it is ever
+    // shown as long dead. Refusing on that reading makes an LNURL send
+    // impossible — the "fresh one" the copy promises reads expired too — for
+    // a payment that works today. The elapsed reading is 0 here, exactly as
+    // it is on a correct clock, so the send goes out.
+    const tenMinutesFastMs = (ISSUED + 10 * 60) * 1000
+    jest.spyOn(Date, "now").mockReturnValue(tenMinutesFastMs)
+
+    const { paymentDetail, sendPaymentMutation } = usdLnurlPaymentDetail()
+    sendPaymentMutation.mockResolvedValue({
+      data: { lnInvoicePaymentSend: { status: "SUCCESS", errors: [] } },
+    })
+
+    const { queryByText, confirm } = await renderConfirmation(paymentDetail)
+    await confirm(tenMinutesFastMs)
+
+    expect(queryByText(en.SendBitcoinConfirmationScreen.heldInvoiceExpired)).toBeNull()
+    expect(queryByText(en.SendBitcoinDestinationScreen.expiredInvoice)).toBeNull()
+    expect(blockedEvents()).toHaveLength(0)
+    expect(sendPaymentMutation).toHaveBeenCalled()
   })
 
   it("does not block a BTC LNURL send, which mints a fresh invoice anyway", async () => {
@@ -212,8 +318,9 @@ describe("expired held invoice", () => {
     const { queryByText, navigate, confirm } = await renderConfirmation(paymentDetail)
     await confirm()
 
-    expect(queryByText(en.SendBitcoinConfirmationScreen.invoiceExpired)).toBeNull()
+    expect(queryByText(en.SendBitcoinConfirmationScreen.heldInvoiceExpired)).toBeNull()
     expect(queryByText(en.SendBitcoinDestinationScreen.expiredInvoice)).toBeNull()
+    expect(blockedEvents()).toHaveLength(0)
     expect(payLnurlBreez).toHaveBeenCalled()
     await waitFor(() =>
       expect(navigate).toHaveBeenCalledWith("sendBitcoinSuccess", expect.anything()),

--- a/__tests__/screens/send-details.spec.tsx
+++ b/__tests__/screens/send-details.spec.tsx
@@ -24,12 +24,14 @@ it("SendScreen Details", async () => {
   await act(async () => {})
 })
 
-// ENG-555. A scanned bolt11 enters the send flow HERE, and nothing on this
-// screen re-mints a `lightning` detail — the user's time choosing a wallet and
-// typing an amount is unbounded, and a Flash receive invoice dies after 60
-// seconds. If the expiry clock only starts on the confirm screen, that whole
-// pause is invisible: confirm's first reading is its own mount, elapsed is 0 by
-// construction, and the corpse is waved through to the backend.
+// ENG-555. The clock on a held bolt11 starts at parse time (see
+// __tests__/payment-destination/lightning.spec.ts); this screen keeps a
+// backstop reading for anything holding an invoice that arrived another way.
+// Nothing here re-mints a `lightning` detail, the user's time choosing a wallet
+// and typing an amount is unbounded, and a Flash receive invoice dies after 60
+// seconds — so if the clock only started on the confirm screen, that whole
+// pause would be invisible: confirm's first reading is its own mount, elapsed
+// is 0 by construction, and the corpse is waved through to the backend.
 describe("first sight of a held invoice", () => {
   // The real invoice from the incident: issued 1787243982, expires 1787244042.
   const INCIDENT_INVOICE =

--- a/__tests__/screens/send-details.spec.tsx
+++ b/__tests__/screens/send-details.spec.tsx
@@ -1,9 +1,19 @@
-import React from "react"
+import React, { PropsWithChildren } from "react"
 
-import { act, render } from "@testing-library/react-native"
+import { act, render, waitFor } from "@testing-library/react-native"
 import { ContextForScreen } from "./helper"
 
 import { Intraledger } from "../../app/screens/send-bitcoin-screen/send-bitcoin-details-screen.stories"
+import SendBitcoinDetailsScreen from "@app/screens/send-bitcoin-screen/send-bitcoin-details-screen"
+import * as invoiceExpiry from "@app/screens/send-bitcoin-screen/invoice-expiry"
+import { createAmountLightningPaymentDetails } from "@app/screens/send-bitcoin-screen/payment-details/lightning"
+import {
+  DestinationDirection,
+  PaymentDestination,
+} from "@app/screens/send-bitcoin-screen/payment-destination/index.types"
+import { PersistentStateContext } from "@app/store/persistent-state"
+import { WalletCurrency } from "@app/graphql/generated"
+import { toBtcMoneyAmount } from "@app/types/amounts"
 
 it("SendScreen Details", async () => {
   render(
@@ -12,4 +22,113 @@ it("SendScreen Details", async () => {
     </ContextForScreen>,
   )
   await act(async () => {})
+})
+
+// ENG-555. A scanned bolt11 enters the send flow HERE, and nothing on this
+// screen re-mints a `lightning` detail — the user's time choosing a wallet and
+// typing an amount is unbounded, and a Flash receive invoice dies after 60
+// seconds. If the expiry clock only starts on the confirm screen, that whole
+// pause is invisible: confirm's first reading is its own mount, elapsed is 0 by
+// construction, and the corpse is waved through to the backend.
+describe("first sight of a held invoice", () => {
+  // The real invoice from the incident: issued 1787243982, expires 1787244042.
+  const INCIDENT_INVOICE =
+    "lnbc1p4gwtwwpp5wwulk8jw0llvgjadwzuen6nxh7hgmddplj3evpgjc7n8l5kzqvmqdph2pshjgr5dusyvmrpwd5zq4mpd3kx2apq24ek2u36ypj8yetpv3kkz7qcqzzsxqzpusp5wane88x5twmdlpnu4cqrk4wd6g3tks7xgq798nt9zt68vmcnnp6q9qxpqysgqnszg0ycjk4255es2hdd3ajep3yquuvra6jn4k8shskhpzg80mrl9m9pgylahzq80aw9ekz6e47ycpcf558080xrxn6uljn54lc447rqpn9u06u"
+  const ISSUED = 1787243982
+  // The scan lands 4 seconds into the 60-second window, while the invoice is
+  // unambiguously alive — parsePaymentDestination would have rejected it
+  // otherwise.
+  const SCANNED_SECONDS = ISSUED + 4
+
+  // The screen only builds its payment detail once it has a default wallet;
+  // the storybook wrapper's persistent state has none, so supply one closer to
+  // the screen than that wrapper is.
+  const WithDefaultWallet: React.FC<PropsWithChildren> = ({ children }) => (
+    <PersistentStateContext.Provider
+      value={
+        {
+          persistentState: {
+            schemaVersion: 7,
+            galoyInstance: { id: "Main" },
+            galoyAuthToken: "",
+            hasInitializedBreezSDK: false,
+            unclaimedDeposits: 0,
+            closedQuickStartTypes: [],
+            defaultWallet: {
+              id: "testwallet",
+              walletCurrency: WalletCurrency.Usd,
+              balance: 100_000,
+            },
+          },
+          updateState: () => {},
+          resetState: () => {},
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any
+      }
+    >
+      {children}
+    </PersistentStateContext.Provider>
+  )
+
+  const paymentDestination = {
+    valid: true,
+    destinationDirection: DestinationDirection.Send,
+    validDestination: { valid: true, paymentType: "lightning" },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    createPaymentDetail: ({ convertMoneyAmount, sendingWalletDescriptor }: any) =>
+      createAmountLightningPaymentDetails({
+        paymentRequest: INCIDENT_INVOICE,
+        paymentRequestAmount: toBtcMoneyAmount(100),
+        convertMoneyAmount,
+        sendingWalletDescriptor,
+      }),
+  } as unknown as PaymentDestination
+
+  beforeEach(invoiceExpiry.resetInvoiceFirstSight)
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("starts the expiry clock when the amount screen shows the invoice", async () => {
+    jest.spyOn(Date, "now").mockReturnValue(SCANNED_SECONDS * 1000)
+    // Spied rather than probed: reading the recorded sighting back would mean
+    // calling noteInvoiceFirstSight, which registers one if none exists — so a
+    // probe cannot tell "the screen recorded it" from "the probe just did".
+    // The real implementation is left in place; only the call is observed.
+    const noteFirstSight = jest.spyOn(invoiceExpiry, "noteInvoiceFirstSight")
+
+    render(
+      <ContextForScreen>
+        <WithDefaultWallet>
+          <SendBitcoinDetailsScreen
+            route={
+              {
+                key: "sendBitcoinDetailsScreen",
+                name: "sendBitcoinDetails",
+                params: { paymentDestination },
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              } as any
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            navigation={{ navigate: jest.fn() } as any}
+          />
+        </WithDefaultWallet>
+      </ContextForScreen>,
+    )
+
+    // The screen renders nothing until its GraphQL queries settle and it can
+    // build a payment detail, so wait for the registration rather than
+    // guessing at a number of ticks.
+    await waitFor(() =>
+      expect(noteFirstSight).toHaveBeenCalledWith(INCIDENT_INVOICE, SCANNED_SECONDS),
+    )
+
+    // And the reading that lands is the scan, not some later moment: the
+    // confirm screen's own identical call has to be the no-op, or the elapsed
+    // duration collapses to zero there and ENG-555's exact symptom survives.
+    expect(
+      invoiceExpiry.noteInvoiceFirstSight(INCIDENT_INVOICE, SCANNED_SECONDS + 120),
+    ).toBe(SCANNED_SECONDS)
+  })
 })

--- a/__tests__/utils/invoice-expiry.spec.ts
+++ b/__tests__/utils/invoice-expiry.spec.ts
@@ -2,6 +2,7 @@ import { decodeInvoiceString } from "@galoymoney/client"
 
 import {
   CLOCK_SKEW_GRACE_SECONDS,
+  MAX_TRACKED_INVOICES,
   isHeldInvoiceExpired,
   isInvoiceExpired,
   networkForPaymentRequest,
@@ -306,6 +307,93 @@ describe("isInvoiceExpired with a first-seen reading", () => {
       ).toBe(true)
     }
   })
+
+  it("does not refuse on elapsed time the clock manufactured mid-flow", () => {
+    // Elapsed time cancels a constant OFFSET, but not a clock that MOVES
+    // between the two samples. A handset five minutes slow (cold boot on a
+    // dead RTC, airplane mode off after a flight) scans a live 60-second
+    // invoice — firstSeen reads 300s before the real instant — the OS resyncs
+    // while the user types an amount, and 25 seconds later they tap Confirm.
+    //
+    // The subtraction now reads 325s on an invoice with 35 seconds of life
+    // left. Refusing here would tell the user to fetch a new invoice for a
+    // payment that works, and disable Confirm permanently — the one failure
+    // this guard must not introduce. The raw expiry is the tiebreak: it still
+    // says alive, and it and the elapsed reading cannot both be right.
+    expect(
+      isInvoiceExpired({
+        timeExpireDate: EXPIRES,
+        timestamp: ISSUED,
+        firstSeenSeconds: ISSUED - 300,
+        nowSeconds: ISSUED + 25,
+      }),
+    ).toBe(false)
+
+    // The corroboration only ever holds the guard back — it never fires on its
+    // own. Same invoice, same clock jump, but the user genuinely sits past the
+    // stated expiry: both readings agree and the send is refused.
+    expect(
+      isInvoiceExpired({
+        timeExpireDate: EXPIRES,
+        timestamp: ISSUED,
+        firstSeenSeconds: ISSUED - 300,
+        nowSeconds: EXPIRES + 1,
+      }),
+    ).toBe(true)
+  })
+})
+
+// The map behind noteInvoiceFirstSight is the guard's only memory. If the
+// entry for the invoice in flight is dropped, the elapsed reading collapses to
+// 0 and the guard silently reverts to fail-open — with every other test in
+// this file still green. That makes the eviction rule worth pinning down.
+describe("noteInvoiceFirstSight (module state)", () => {
+  beforeEach(resetInvoiceFirstSight)
+  afterEach(resetInvoiceFirstSight)
+
+  const fakeInvoice = (n: number) => `lnbc1fakeinvoice${n}`
+
+  it("keeps the first sighting and ignores later ones", () => {
+    expect(noteInvoiceFirstSight(fakeInvoice(0), 1000)).toBe(1000)
+    expect(noteInvoiceFirstSight(fakeInvoice(0), 9999)).toBe(1000)
+  })
+
+  it("evicts the oldest entry, never the newest, when the cap is reached", () => {
+    // Fill the map exactly to the cap.
+    for (let i = 0; i < MAX_TRACKED_INVOICES; i += 1) {
+      expect(noteInvoiceFirstSight(fakeInvoice(i), 1000)).toBe(1000)
+    }
+
+    // One more than it holds. Something has to go, and it must be the oldest
+    // insertion — the entry least likely to be the invoice in flight.
+    expect(noteInvoiceFirstSight(fakeInvoice(MAX_TRACKED_INVOICES), 2000)).toBe(2000)
+
+    // The newest entry — the one a user could be mid-send on — survives.
+    expect(noteInvoiceFirstSight(fakeInvoice(MAX_TRACKED_INVOICES), 9999)).toBe(2000)
+
+    // So does the second-oldest. Probed BEFORE the evicted one below: a miss
+    // inserts, which at a full map evicts again, so asking about #0 first
+    // would take #1 out and make this assertion lie.
+    expect(noteInvoiceFirstSight(fakeInvoice(1), 9999)).toBe(1000)
+
+    // ...and the oldest is gone: no sighting on record, so this call installs
+    // a fresh one rather than reporting t=1000.
+    expect(noteInvoiceFirstSight(fakeInvoice(0), 9999)).toBe(9999)
+  })
+
+  it("does not let a repeat sighting reshuffle the eviction order", () => {
+    for (let i = 0; i < MAX_TRACKED_INVOICES; i += 1) {
+      noteInvoiceFirstSight(fakeInvoice(i), 1000)
+    }
+
+    // Re-seeing the oldest invoice is a read, not a write: it must not move
+    // that entry to the back of the queue, or the eviction below takes #1.
+    expect(noteInvoiceFirstSight(fakeInvoice(0), 1500)).toBe(1000)
+    noteInvoiceFirstSight(fakeInvoice(MAX_TRACKED_INVOICES), 2000)
+
+    expect(noteInvoiceFirstSight(fakeInvoice(1), 9999)).toBe(1000)
+    expect(noteInvoiceFirstSight(fakeInvoice(0), 9999)).toBe(9999)
+  })
 })
 
 // The BTC (Breez/Spark) wallet does not transmit the held bolt11 on every
@@ -410,9 +498,9 @@ describe("isHeldInvoiceExpired (the decision the send flow makes)", () => {
     // would have worked is the one failure this guard must not introduce, so
     // the elapsed term stays in charge and the backend does the rejecting.
     //
-    // This is not the ENG-555 path being waved through: there, the amount
-    // screen registers first sight when the invoice is scanned (see
-    // send-bitcoin-details-screen.tsx), so by the time confirm asks, a prior
+    // This is not the ENG-555 path being waved through: there, first sight is
+    // registered the instant the bolt11 parses valid (see
+    // payment-destination/lightning.ts), so by the time confirm asks, a prior
     // reading exists and the case above applies. Change that registration and
     // this expectation is the one that should be revisited.
     expect(
@@ -424,11 +512,12 @@ describe("isHeldInvoiceExpired (the decision the send flow makes)", () => {
     ).toBe(false)
   })
 
-  it("catches the amount-screen pause once first sight is registered there", () => {
-    // The production sequence ENG-555 describes: the invoice is scanned while
-    // alive, the user spends two minutes on the amount screen choosing a
-    // wallet and typing a number, then taps Next. Confirm's own reading would
-    // start here and see nothing; the amount screen's reading spans the pause.
+  it("catches the pre-confirm pause once first sight is registered at parse", () => {
+    // The production sequence ENG-555 describes: the invoice parses valid
+    // while alive, the user spends two minutes getting to Confirm — the
+    // destination modal, picking a wallet, typing a number — then taps Next.
+    // Confirm's own reading would start at its mount and see nothing; the
+    // reading taken at parse spans the whole pause.
     noteInvoiceFirstSight(INCIDENT_INVOICE, ISSUED + 4)
 
     expect(

--- a/__tests__/utils/invoice-expiry.spec.ts
+++ b/__tests__/utils/invoice-expiry.spec.ts
@@ -1,4 +1,13 @@
-import { isInvoiceExpired } from "../../app/screens/send-bitcoin-screen/invoice-expiry"
+import { readFileSync } from "fs"
+import { join } from "path"
+
+import { decodeInvoiceString } from "@galoymoney/client"
+
+import {
+  isHeldInvoiceExpired,
+  isInvoiceExpired,
+  networkForPaymentRequest,
+} from "../../app/screens/send-bitcoin-screen/invoice-expiry"
 
 // The real invoice from the ENG-555 report, decoded:
 //   issued  1787243982 (2026-08-20T16:39:42Z)
@@ -56,5 +65,102 @@ describe("isInvoiceExpired", () => {
     expect(isInvoiceExpired({ timeExpireDate: EXPIRES, nowSeconds: Number.NaN })).toBe(
       false,
     )
+  })
+})
+
+// The guard reads paymentDetail.paymentRequest. If a detail factory does not
+// expose it the check silently passes everything through — and because the
+// field is optional, TypeScript says nothing. The first version of this fix
+// shipped exactly that hole: only the LNURL factory set it, so scanned and
+// pasted invoices (also 60-second Flash invoices) kept failing generically.
+describe("every invoice-backed payment detail exposes its bolt11", () => {
+  const source = readFileSync(
+    join(__dirname, "../../app/screens/send-bitcoin-screen/payment-details/lightning.ts"),
+    "utf8",
+  )
+
+  const factories = [
+    "createNoAmountLightningPaymentDetails",
+    "createAmountLightningPaymentDetails",
+    "createLnurlPaymentDetails",
+  ]
+
+  it("every factory returns paymentRequest", () => {
+    for (const factory of factories) {
+      const start = source.indexOf(`export const ${factory}`)
+      expect(start).toBeGreaterThan(-1)
+
+      const nextExport = source.indexOf("export const ", start + 10)
+      const body = source.slice(start, nextExport === -1 ? undefined : nextExport)
+      const returnStart = body.lastIndexOf("return {")
+      const returned = body.slice(returnStart, body.indexOf("as const", returnStart))
+
+      // Named per factory so a failure says which one regressed.
+      expect({
+        factory,
+        exposesPaymentRequest: /^\s{4}paymentRequest,/m.test(returned),
+      }).toEqual({ factory, exposesPaymentRequest: true })
+    }
+  })
+})
+
+// The real invoice from the incident, decoded with the real decoder — the
+// guard's whole job is to reach a correct verdict on strings like this one.
+const INCIDENT_INVOICE =
+  "lnbc1p4gwtwwpp5wwulk8jw0llvgjadwzuen6nxh7hgmddplj3evpgjc7n8l5kzqvmqdph2pshjgr5dusyvmrpwd5zq4mpd3kx2apq24ek2u36ypj8yetpv3kkz7qcqzzsxqzpusp5wane88x5twmdlpnu4cqrk4wd6g3tks7xgq798nt9zt68vmcnnp6q9qxpqysgqnszg0ycjk4255es2hdd3ajep3yquuvra6jn4k8shskhpzg80mrl9m9pgylahzq80aw9ekz6e47ycpcf558080xrxn6uljn54lc447rqpn9u06u"
+
+describe("networkForPaymentRequest", () => {
+  it("reads the network off the prefix", () => {
+    expect(networkForPaymentRequest(INCIDENT_INVOICE)).toBe("mainnet")
+    expect(networkForPaymentRequest("lnbc1abc")).toBe("mainnet")
+    expect(networkForPaymentRequest("lntbs1abc")).toBe("signet")
+    // "lnbcrt" also starts with "lnbc" — the longer prefix has to win, or
+    // every regtest invoice decodes as mainnet and throws.
+    expect(networkForPaymentRequest("lnbcrt1abc")).toBe("regtest")
+  })
+
+  it("returns undefined for anything it does not recognise", () => {
+    expect(networkForPaymentRequest("not-an-invoice")).toBeUndefined()
+    expect(networkForPaymentRequest("")).toBeUndefined()
+  })
+})
+
+describe("isHeldInvoiceExpired (the decision the confirm screen makes)", () => {
+  // Exercised through the real decoder, not a stub: a hand-rolled fake would
+  // agree with whatever the guard does and prove nothing.
+  const decode = (paymentRequest: string, network: "mainnet" | "signet" | "regtest") =>
+    decodeInvoiceString(paymentRequest, network as never)
+
+  it("lets the send through 38s into the window (the first attempt)", () => {
+    expect(
+      isHeldInvoiceExpired({
+        paymentRequest: INCIDENT_INVOICE,
+        nowSeconds: 1787244004,
+        decode,
+      }),
+    ).toBe(false)
+  })
+
+  it("refuses the 19-minute-old retry (the second attempt)", () => {
+    expect(
+      isHeldInvoiceExpired({
+        paymentRequest: INCIDENT_INVOICE,
+        nowSeconds: 1787245132,
+        decode,
+      }),
+    ).toBe(true)
+  })
+
+  it("fails open with no invoice, a bad prefix, or a decode failure", () => {
+    const now = 1787245132
+    expect(
+      isHeldInvoiceExpired({ paymentRequest: undefined, nowSeconds: now, decode }),
+    ).toBe(false)
+    expect(
+      isHeldInvoiceExpired({ paymentRequest: "not-an-invoice", nowSeconds: now, decode }),
+    ).toBe(false)
+    expect(
+      isHeldInvoiceExpired({ paymentRequest: "lnbc1garbage", nowSeconds: now, decode }),
+    ).toBe(false)
   })
 })

--- a/__tests__/utils/invoice-expiry.spec.ts
+++ b/__tests__/utils/invoice-expiry.spec.ts
@@ -1,0 +1,60 @@
+import { isInvoiceExpired } from "../../app/screens/send-bitcoin-screen/invoice-expiry"
+
+// The real invoice from the ENG-555 report, decoded:
+//   issued  1787243982 (2026-08-20T16:39:42Z)
+//   expires 1787244042 (2026-08-20T16:40:42Z)  -> a 60-second window
+const ISSUED = 1787243982
+const EXPIRES = 1787244042
+
+describe("isInvoiceExpired", () => {
+  it("accepts an invoice inside its window", () => {
+    // The user's first attempt: 16:40:04Z, 38s before expiry. This one was
+    // NOT an expiry failure, and the guard must not claim it was.
+    expect(isInvoiceExpired({ timeExpireDate: EXPIRES, nowSeconds: 1787244004 })).toBe(
+      false,
+    )
+  })
+
+  it("rejects the 19-minute-old retry from the report", () => {
+    // Second attempt: 16:58:52Z, ~18 minutes past expiry. Same invoice,
+    // resubmitted, which is what produced a second identical error.
+    expect(isInvoiceExpired({ timeExpireDate: EXPIRES, nowSeconds: 1787245132 })).toBe(
+      true,
+    )
+  })
+
+  it("treats the expiry second itself as expired", () => {
+    // Boundary: bolt11 expiry is inclusive of the deadline, and sending on
+    // the exact second is a race the backend would win anyway.
+    expect(isInvoiceExpired({ timeExpireDate: EXPIRES, nowSeconds: EXPIRES })).toBe(true)
+    expect(isInvoiceExpired({ timeExpireDate: EXPIRES, nowSeconds: EXPIRES - 1 })).toBe(
+      false,
+    )
+  })
+
+  it("is live for the whole 60-second window and dead after it", () => {
+    for (let offset = 0; offset < 60; offset += 1) {
+      expect(
+        isInvoiceExpired({ timeExpireDate: EXPIRES, nowSeconds: ISSUED + offset }),
+      ).toBe(false)
+    }
+    expect(isInvoiceExpired({ timeExpireDate: EXPIRES, nowSeconds: ISSUED + 60 })).toBe(
+      true,
+    )
+  })
+
+  it("does not block the send when the expiry is unknown", () => {
+    // A decode quirk must never turn into a blocked payment — the backend
+    // still rejects a genuinely dead invoice, so a false negative costs
+    // nothing beyond the status quo while a false positive costs a payment.
+    for (const timeExpireDate of [undefined, null, Number.NaN, Infinity]) {
+      expect(isInvoiceExpired({ timeExpireDate, nowSeconds: 1787245132 })).toBe(false)
+    }
+  })
+
+  it("does not block the send when the clock is unusable", () => {
+    expect(isInvoiceExpired({ timeExpireDate: EXPIRES, nowSeconds: Number.NaN })).toBe(
+      false,
+    )
+  })
+})

--- a/__tests__/utils/invoice-expiry.spec.ts
+++ b/__tests__/utils/invoice-expiry.spec.ts
@@ -1,12 +1,11 @@
-import { readFileSync } from "fs"
-import { join } from "path"
-
 import { decodeInvoiceString } from "@galoymoney/client"
 
 import {
+  CLOCK_SKEW_GRACE_SECONDS,
   isHeldInvoiceExpired,
   isInvoiceExpired,
   networkForPaymentRequest,
+  willTransmitHeldInvoice,
 } from "../../app/screens/send-bitcoin-screen/invoice-expiry"
 
 // The real invoice from the ENG-555 report, decoded:
@@ -19,37 +18,117 @@ describe("isInvoiceExpired", () => {
   it("accepts an invoice inside its window", () => {
     // The user's first attempt: 16:40:04Z, 38s before expiry. This one was
     // NOT an expiry failure, and the guard must not claim it was.
-    expect(isInvoiceExpired({ timeExpireDate: EXPIRES, nowSeconds: 1787244004 })).toBe(
-      false,
-    )
+    expect(
+      isInvoiceExpired({
+        timeExpireDate: EXPIRES,
+        timestamp: ISSUED,
+        nowSeconds: 1787244004,
+      }),
+    ).toBe(false)
   })
 
   it("rejects the 19-minute-old retry from the report", () => {
     // Second attempt: 16:58:52Z, ~18 minutes past expiry. Same invoice,
-    // resubmitted, which is what produced a second identical error.
+    // resubmitted, which is what produced a second identical error. Well
+    // clear of the skew grace, so it is still caught.
+    expect(
+      isInvoiceExpired({
+        timeExpireDate: EXPIRES,
+        timestamp: ISSUED,
+        nowSeconds: 1787245132,
+      }),
+    ).toBe(true)
+  })
+
+  it("only refuses once the reading is past plausible clock drift", () => {
+    // `nowSeconds` is the device wall clock, not the issuer's, so the stated
+    // expiry second on its own is not evidence of a dead invoice. The refusal
+    // starts one second past the grace window.
+    expect(
+      isInvoiceExpired({
+        timeExpireDate: EXPIRES,
+        timestamp: ISSUED,
+        nowSeconds: EXPIRES,
+      }),
+    ).toBe(false)
+    expect(
+      isInvoiceExpired({
+        timeExpireDate: EXPIRES,
+        timestamp: ISSUED,
+        nowSeconds: EXPIRES + CLOCK_SKEW_GRACE_SECONDS,
+      }),
+    ).toBe(false)
+    expect(
+      isInvoiceExpired({
+        timeExpireDate: EXPIRES,
+        timestamp: ISSUED,
+        nowSeconds: EXPIRES + CLOCK_SKEW_GRACE_SECONDS + 1,
+      }),
+    ).toBe(true)
+  })
+
+  it("is live for the whole 60-second window", () => {
+    for (let offset = 0; offset < 60; offset += 1) {
+      expect(
+        isInvoiceExpired({
+          timeExpireDate: EXPIRES,
+          timestamp: ISSUED,
+          nowSeconds: ISSUED + offset,
+        }),
+      ).toBe(false)
+    }
+  })
+
+  it("does not kill a fresh invoice on a device whose clock runs fast", () => {
+    // Regression: a handset two minutes ahead of the issuer reads every
+    // freshly minted 60-second Flash invoice as already dead. Failing closed
+    // there would leave that user permanently unable to send — a state the
+    // backend, validating against server time, would never have produced.
+    for (let skew = 1; skew <= CLOCK_SKEW_GRACE_SECONDS; skew += 1) {
+      expect(
+        isInvoiceExpired({
+          timeExpireDate: EXPIRES,
+          timestamp: ISSUED,
+          // Mint instant, as misread by a clock `skew` seconds fast.
+          nowSeconds: ISSUED + skew,
+        }),
+      ).toBe(false)
+    }
+  })
+
+  it("fails open when the device clock is behind the invoice's issue time", () => {
+    // An invoice cannot have been issued in the future: a "now" that precedes
+    // its timestamp proves the local clock is wrong, so nothing derived from
+    // it may block a send.
+    expect(
+      isInvoiceExpired({
+        timeExpireDate: EXPIRES,
+        timestamp: ISSUED,
+        nowSeconds: ISSUED - 1,
+      }),
+    ).toBe(false)
+    // Even a reading long past the expiry is discarded when the same clock
+    // also claims the invoice has not been issued yet.
+    expect(
+      isInvoiceExpired({
+        timeExpireDate: EXPIRES,
+        timestamp: EXPIRES + 10_000,
+        nowSeconds: 1787245132,
+      }),
+    ).toBe(false)
+  })
+
+  it("still decides without a timestamp", () => {
+    // The skew detector is an extra safeguard, not a precondition.
     expect(isInvoiceExpired({ timeExpireDate: EXPIRES, nowSeconds: 1787245132 })).toBe(
       true,
     )
-  })
-
-  it("treats the expiry second itself as expired", () => {
-    // Boundary: bolt11 expiry is inclusive of the deadline, and sending on
-    // the exact second is a race the backend would win anyway.
-    expect(isInvoiceExpired({ timeExpireDate: EXPIRES, nowSeconds: EXPIRES })).toBe(true)
-    expect(isInvoiceExpired({ timeExpireDate: EXPIRES, nowSeconds: EXPIRES - 1 })).toBe(
-      false,
-    )
-  })
-
-  it("is live for the whole 60-second window and dead after it", () => {
-    for (let offset = 0; offset < 60; offset += 1) {
+    expect(isInvoiceExpired({ timeExpireDate: EXPIRES, nowSeconds: ISSUED })).toBe(false)
+    for (const timestamp of [undefined, null, Number.NaN, Infinity]) {
       expect(
-        isInvoiceExpired({ timeExpireDate: EXPIRES, nowSeconds: ISSUED + offset }),
-      ).toBe(false)
+        isInvoiceExpired({ timeExpireDate: EXPIRES, timestamp, nowSeconds: 1787245132 }),
+      ).toBe(true)
     }
-    expect(isInvoiceExpired({ timeExpireDate: EXPIRES, nowSeconds: ISSUED + 60 })).toBe(
-      true,
-    )
   })
 
   it("does not block the send when the expiry is unknown", () => {
@@ -57,49 +136,50 @@ describe("isInvoiceExpired", () => {
     // still rejects a genuinely dead invoice, so a false negative costs
     // nothing beyond the status quo while a false positive costs a payment.
     for (const timeExpireDate of [undefined, null, Number.NaN, Infinity]) {
-      expect(isInvoiceExpired({ timeExpireDate, nowSeconds: 1787245132 })).toBe(false)
+      expect(
+        isInvoiceExpired({ timeExpireDate, timestamp: ISSUED, nowSeconds: 1787245132 }),
+      ).toBe(false)
     }
   })
 
   it("does not block the send when the clock is unusable", () => {
-    expect(isInvoiceExpired({ timeExpireDate: EXPIRES, nowSeconds: Number.NaN })).toBe(
-      false,
-    )
+    expect(
+      isInvoiceExpired({
+        timeExpireDate: EXPIRES,
+        timestamp: ISSUED,
+        nowSeconds: Number.NaN,
+      }),
+    ).toBe(false)
   })
 })
 
-// The guard reads paymentDetail.paymentRequest. If a detail factory does not
-// expose it the check silently passes everything through — and because the
-// field is optional, TypeScript says nothing. The first version of this fix
-// shipped exactly that hole: only the LNURL factory set it, so scanned and
-// pasted invoices (also 60-second Flash invoices) kept failing generically.
-describe("every invoice-backed payment detail exposes its bolt11", () => {
-  const source = readFileSync(
-    join(__dirname, "../../app/screens/send-bitcoin-screen/payment-details/lightning.ts"),
-    "utf8",
-  )
+// The BTC (Breez/Spark) wallet does not transmit the held bolt11 on every
+// path: `useSendPayment` routes BTC + lnurl/intraledger to `payLnurlBreez`,
+// which mints a fresh invoice at send time. Checking the held invoice's
+// expiry there would refuse a payment that would have succeeded.
+describe("willTransmitHeldInvoice", () => {
+  it("is true for every non-BTC wallet, whatever the payment type", () => {
+    for (const sendingWalletCurrency of ["USD", "USDT"] as const) {
+      for (const paymentType of ["lightning", "lnurl", "intraledger"] as const) {
+        expect(willTransmitHeldInvoice({ sendingWalletCurrency, paymentType })).toBe(true)
+      }
+    }
+  })
 
-  const factories = [
-    "createNoAmountLightningPaymentDetails",
-    "createAmountLightningPaymentDetails",
-    "createLnurlPaymentDetails",
-  ]
+  it("is true for BTC + lightning — payLightningBreez sends the held bolt11", () => {
+    expect(
+      willTransmitHeldInvoice({
+        sendingWalletCurrency: "BTC",
+        paymentType: "lightning",
+      }),
+    ).toBe(true)
+  })
 
-  it("every factory returns paymentRequest", () => {
-    for (const factory of factories) {
-      const start = source.indexOf(`export const ${factory}`)
-      expect(start).toBeGreaterThan(-1)
-
-      const nextExport = source.indexOf("export const ", start + 10)
-      const body = source.slice(start, nextExport === -1 ? undefined : nextExport)
-      const returnStart = body.lastIndexOf("return {")
-      const returned = body.slice(returnStart, body.indexOf("as const", returnStart))
-
-      // Named per factory so a failure says which one regressed.
-      expect({
-        factory,
-        exposesPaymentRequest: /^\s{4}paymentRequest,/m.test(returned),
-      }).toEqual({ factory, exposesPaymentRequest: true })
+  it("is false for the BTC paths that re-mint at send time", () => {
+    for (const paymentType of ["lnurl", "intraledger"] as const) {
+      expect(willTransmitHeldInvoice({ sendingWalletCurrency: "BTC", paymentType })).toBe(
+        false,
+      )
     }
   })
 })
@@ -149,6 +229,32 @@ describe("isHeldInvoiceExpired (the decision the confirm screen makes)", () => {
         decode,
       }),
     ).toBe(true)
+  })
+
+  it("reads the issue time off the real invoice and tolerates a fast clock", () => {
+    // Sanity-check the fixture: the decoder really does hand back both
+    // timestamps, so the skew detector below is exercising real data.
+    const decoded = decode(INCIDENT_INVOICE, "mainnet")
+    expect(decoded.timestamp).toBe(ISSUED)
+    expect(decoded.timeExpireDate).toBe(EXPIRES)
+
+    // Confirm tapped at the mint instant on a clock two minutes fast.
+    expect(
+      isHeldInvoiceExpired({
+        paymentRequest: INCIDENT_INVOICE,
+        nowSeconds: ISSUED + CLOCK_SKEW_GRACE_SECONDS,
+        decode,
+      }),
+    ).toBe(false)
+
+    // Same tap on a clock two minutes slow — "now" predates the issue time.
+    expect(
+      isHeldInvoiceExpired({
+        paymentRequest: INCIDENT_INVOICE,
+        nowSeconds: ISSUED - CLOCK_SKEW_GRACE_SECONDS,
+        decode,
+      }),
+    ).toBe(false)
   })
 
   it("fails open with no invoice, a bad prefix, or a decode failure", () => {

--- a/__tests__/utils/invoice-expiry.spec.ts
+++ b/__tests__/utils/invoice-expiry.spec.ts
@@ -360,27 +360,81 @@ describe("networkForPaymentRequest", () => {
   })
 })
 
-describe("isHeldInvoiceExpired (the decision the confirm screen makes)", () => {
+describe("isHeldInvoiceExpired (the decision the send flow makes)", () => {
   // Exercised through the real decoder, not a stub: a hand-rolled fake would
   // agree with whatever the guard does and prove nothing.
   const decode = (paymentRequest: string, network: "mainnet" | "signet" | "regtest") =>
     decodeInvoiceString(paymentRequest, network as never)
 
+  // First sightings live in module state so they can survive a remount in
+  // production. Without this, a case silently inherits the previous case's
+  // baseline and passes on borrowed evidence — which is how the retry test
+  // below used to "prove" a verdict the guard could not actually reach.
+  beforeEach(resetInvoiceFirstSight)
+
+  // 16:40:04Z — the user's first attempt, 38s into the 60s window.
+  const FIRST_ATTEMPT = 1787244004
+  // 16:58:52Z — the retry from the report, ~18 minutes past expiry.
+  const RETRY = 1787245132
+
   it("lets the send through 38s into the window (the first attempt)", () => {
     expect(
       isHeldInvoiceExpired({
         paymentRequest: INCIDENT_INVOICE,
-        nowSeconds: 1787244004,
+        nowSeconds: FIRST_ATTEMPT,
         decode,
       }),
     ).toBe(false)
   })
 
   it("refuses the 19-minute-old retry (the second attempt)", () => {
+    // The premise, stated rather than leaked from a neighbouring test: the
+    // send flow met this invoice at the first attempt. The retry reuses the
+    // same bolt11, so the original sighting is still on record and the guard
+    // can see that ~18 minutes have passed under the user.
+    noteInvoiceFirstSight(INCIDENT_INVOICE, FIRST_ATTEMPT)
+
     expect(
       isHeldInvoiceExpired({
         paymentRequest: INCIDENT_INVOICE,
-        nowSeconds: 1787245132,
+        nowSeconds: RETRY,
+        decode,
+      }),
+    ).toBe(true)
+  })
+
+  it("fails open on an invoice it is meeting for the first time", () => {
+    // No prior sighting: elapsed reads 0 by construction, and a "now" this far
+    // past the stated expiry is equally the signature of a handset running
+    // fast — the two are indistinguishable from here. Blocking a send that
+    // would have worked is the one failure this guard must not introduce, so
+    // the elapsed term stays in charge and the backend does the rejecting.
+    //
+    // This is not the ENG-555 path being waved through: there, the amount
+    // screen registers first sight when the invoice is scanned (see
+    // send-bitcoin-details-screen.tsx), so by the time confirm asks, a prior
+    // reading exists and the case above applies. Change that registration and
+    // this expectation is the one that should be revisited.
+    expect(
+      isHeldInvoiceExpired({
+        paymentRequest: INCIDENT_INVOICE,
+        nowSeconds: RETRY,
+        decode,
+      }),
+    ).toBe(false)
+  })
+
+  it("catches the amount-screen pause once first sight is registered there", () => {
+    // The production sequence ENG-555 describes: the invoice is scanned while
+    // alive, the user spends two minutes on the amount screen choosing a
+    // wallet and typing a number, then taps Next. Confirm's own reading would
+    // start here and see nothing; the amount screen's reading spans the pause.
+    noteInvoiceFirstSight(INCIDENT_INVOICE, ISSUED + 4)
+
+    expect(
+      isHeldInvoiceExpired({
+        paymentRequest: INCIDENT_INVOICE,
+        nowSeconds: ISSUED + 4 + 120,
         decode,
       }),
     ).toBe(true)

--- a/__tests__/utils/invoice-expiry.spec.ts
+++ b/__tests__/utils/invoice-expiry.spec.ts
@@ -5,6 +5,8 @@ import {
   isHeldInvoiceExpired,
   isInvoiceExpired,
   networkForPaymentRequest,
+  noteInvoiceFirstSight,
+  resetInvoiceFirstSight,
   willTransmitHeldInvoice,
 } from "../../app/screens/send-bitcoin-screen/invoice-expiry"
 
@@ -236,13 +238,21 @@ describe("isInvoiceExpired with a first-seen reading", () => {
     ).toBe(true)
   })
 
-  it("keeps the absolute backstop for an invoice that aged before we saw it", () => {
-    // A long-lived invoice (1h) scanned 59 minutes in: elapsed-since-mount
-    // will not reach an hour, and the first sighting was plausible, so the
-    // absolute comparison is still the one doing the work.
+  it("trusts elapsed time over the absolute clock once both are known", () => {
+    // A long-lived invoice (1h) first seen 59 minutes in. The absolute
+    // comparison would call this expired; the elapsed one would not, and
+    // they cannot both be right — a reading that far past issue is equally
+    // the signature of a handset running fast.
+    //
+    // Elapsed wins deliberately: it is measured against one clock and cannot
+    // be inflated by skew. The cost is that an invoice already stale when we
+    // first saw it is allowed through to the backend, which rejects it; the
+    // alternative is blocking sends that would have worked, which is the one
+    // failure this guard must not introduce.
     const longIssued = ISSUED
     const longExpires = ISSUED + 3600
     const firstSeenSeconds = longIssued + 59 * 60
+
     expect(
       isInvoiceExpired({
         timeExpireDate: longExpires,
@@ -250,15 +260,17 @@ describe("isInvoiceExpired with a first-seen reading", () => {
         firstSeenSeconds,
         nowSeconds: longExpires + CLOCK_SKEW_GRACE_SECONDS + 1,
       }),
-    ).toBe(true)
+    ).toBe(false)
+
+    // Once a full lifetime has genuinely passed under the user, it fires.
     expect(
       isInvoiceExpired({
         timeExpireDate: longExpires,
         timestamp: longIssued,
         firstSeenSeconds,
-        nowSeconds: longExpires + CLOCK_SKEW_GRACE_SECONDS,
+        nowSeconds: firstSeenSeconds + 3601,
       }),
-    ).toBe(false)
+    ).toBe(true)
   })
 
   it("ignores the elapsed reading when the invoice states no lifetime", () => {
@@ -381,7 +393,10 @@ describe("isHeldInvoiceExpired (the decision the confirm screen makes)", () => {
     expect(decoded.timestamp).toBe(ISSUED)
     expect(decoded.timeExpireDate).toBe(EXPIRES)
 
-    // Confirm tapped at the mint instant on a clock two minutes fast.
+    // Confirm tapped at the mint instant on a clock two minutes fast. The
+    // screen registers first sight on mount, so seed it the same way.
+    resetInvoiceFirstSight()
+    noteInvoiceFirstSight(INCIDENT_INVOICE, ISSUED + CLOCK_SKEW_GRACE_SECONDS)
     expect(
       isHeldInvoiceExpired({
         paymentRequest: INCIDENT_INVOICE,
@@ -406,19 +421,21 @@ describe("isHeldInvoiceExpired (the decision the confirm screen makes)", () => {
     // screen, so the same 90-second pause is caught whether the handset is
     // right or ten minutes fast.
     for (const skew of [0, 10 * 60]) {
+      resetInvoiceFirstSight()
+      noteInvoiceFirstSight(INCIDENT_INVOICE, ISSUED + skew)
       expect(
         isHeldInvoiceExpired({
           paymentRequest: INCIDENT_INVOICE,
-          firstSeenSeconds: ISSUED + skew,
           nowSeconds: ISSUED + skew + 90,
           decode,
         }),
       ).toBe(true)
       // ...and the same handset, tapping straight away, is not.
+      resetInvoiceFirstSight()
+      noteInvoiceFirstSight(INCIDENT_INVOICE, ISSUED + skew)
       expect(
         isHeldInvoiceExpired({
           paymentRequest: INCIDENT_INVOICE,
-          firstSeenSeconds: ISSUED + skew,
           nowSeconds: ISSUED + skew,
           decode,
         }),

--- a/__tests__/utils/invoice-expiry.spec.ts
+++ b/__tests__/utils/invoice-expiry.spec.ts
@@ -153,6 +153,149 @@ describe("isInvoiceExpired", () => {
   })
 })
 
+// `firstSeenSeconds` is the device clock as it read when the confirm screen
+// mounted. Subtracting it from `nowSeconds` compares that clock against
+// *itself*, so the result is an elapsed duration and any constant offset
+// cancels. That is what makes it the primary signal: the absolute comparison
+// against the issuer's stated expiry is off by however wrong the handset is.
+describe("isInvoiceExpired with a first-seen reading", () => {
+  const LIFETIME = EXPIRES - ISSUED // 60s, per IBEX's cap on Flash invoices
+
+  it("blocks an ordinary confirm-screen pause the absolute check cannot see", () => {
+    // The case this module exists for: the user opens confirm on a live
+    // 60-second invoice and taps Send 90 seconds later. The invoice is 30s
+    // dead, but only 90s old — inside expiry + 120s grace, so the absolute
+    // comparison alone still waves it through and spends the doomed round
+    // trip. Elapsed-since-mount catches it.
+    const args = {
+      timeExpireDate: EXPIRES,
+      timestamp: ISSUED,
+      firstSeenSeconds: ISSUED,
+      nowSeconds: ISSUED + 90,
+    }
+    expect(isInvoiceExpired(args)).toBe(true)
+    // Proof the absolute term is not what fired: drop the elapsed reading and
+    // the very same moment is allowed through.
+    expect(isInvoiceExpired({ ...args, firstSeenSeconds: undefined })).toBe(false)
+  })
+
+  it("does not fire before the invoice's whole lifetime has elapsed", () => {
+    for (let elapsed = 0; elapsed <= LIFETIME; elapsed += 1) {
+      expect(
+        isInvoiceExpired({
+          timeExpireDate: EXPIRES,
+          timestamp: ISSUED,
+          firstSeenSeconds: ISSUED,
+          nowSeconds: ISSUED + elapsed,
+        }),
+      ).toBe(false)
+    }
+    expect(
+      isInvoiceExpired({
+        timeExpireDate: EXPIRES,
+        timestamp: ISSUED,
+        firstSeenSeconds: ISSUED,
+        nowSeconds: ISSUED + LIFETIME + 1,
+      }),
+    ).toBe(true)
+  })
+
+  it("lets a badly wrong-but-fast handset pay a freshly minted invoice", () => {
+    // Regression: a handset ten minutes fast reads every 60-second invoice as
+    // 600s dead the instant it is minted, so the absolute comparison refuses
+    // an LNURL send that works today — and tells the user to fetch another
+    // invoice, which will read expired too. Unpayable, forever.
+    //
+    // Elapsed-since-mount reads 0 on that handset exactly as it does on a
+    // correct one, and the absolute term is muted because the first sighting
+    // was already impossible (see invoice-expiry.ts).
+    for (const skew of [CLOCK_SKEW_GRACE_SECONDS + 61, 10 * 60, 60 * 60, 26 * 60 * 60]) {
+      // Mount and tap at the mint instant, as misread by the fast clock.
+      expect(
+        isInvoiceExpired({
+          timeExpireDate: EXPIRES,
+          timestamp: ISSUED,
+          firstSeenSeconds: ISSUED + skew,
+          nowSeconds: ISSUED + skew,
+        }),
+      ).toBe(false)
+    }
+  })
+
+  it("still blocks that handset once it has genuinely sat on the invoice", () => {
+    // Fail-open on skew must not become fail-open forever: the same
+    // ten-minutes-fast handset, paused 90 seconds on the confirm screen, is
+    // still refused — the elapsed reading does not care about the offset.
+    expect(
+      isInvoiceExpired({
+        timeExpireDate: EXPIRES,
+        timestamp: ISSUED,
+        firstSeenSeconds: ISSUED + 10 * 60,
+        nowSeconds: ISSUED + 10 * 60 + 90,
+      }),
+    ).toBe(true)
+  })
+
+  it("keeps the absolute backstop for an invoice that aged before we saw it", () => {
+    // A long-lived invoice (1h) scanned 59 minutes in: elapsed-since-mount
+    // will not reach an hour, and the first sighting was plausible, so the
+    // absolute comparison is still the one doing the work.
+    const longIssued = ISSUED
+    const longExpires = ISSUED + 3600
+    const firstSeenSeconds = longIssued + 59 * 60
+    expect(
+      isInvoiceExpired({
+        timeExpireDate: longExpires,
+        timestamp: longIssued,
+        firstSeenSeconds,
+        nowSeconds: longExpires + CLOCK_SKEW_GRACE_SECONDS + 1,
+      }),
+    ).toBe(true)
+    expect(
+      isInvoiceExpired({
+        timeExpireDate: longExpires,
+        timestamp: longIssued,
+        firstSeenSeconds,
+        nowSeconds: longExpires + CLOCK_SKEW_GRACE_SECONDS,
+      }),
+    ).toBe(false)
+  })
+
+  it("ignores the elapsed reading when the invoice states no lifetime", () => {
+    // Without a timestamp there is no lifetime to compare elapsed time
+    // against, and a non-positive one is malformed. Either way the elapsed
+    // term must stay silent rather than fire on a zero-length window.
+    expect(
+      isInvoiceExpired({
+        timeExpireDate: EXPIRES,
+        firstSeenSeconds: ISSUED,
+        nowSeconds: ISSUED + 90,
+      }),
+    ).toBe(false)
+    expect(
+      isInvoiceExpired({
+        timeExpireDate: ISSUED,
+        timestamp: ISSUED,
+        firstSeenSeconds: ISSUED,
+        nowSeconds: ISSUED + 90,
+      }),
+    ).toBe(false)
+  })
+
+  it("ignores an unusable first-seen reading", () => {
+    for (const firstSeenSeconds of [undefined, null, Number.NaN, Infinity]) {
+      expect(
+        isInvoiceExpired({
+          timeExpireDate: EXPIRES,
+          timestamp: ISSUED,
+          firstSeenSeconds,
+          nowSeconds: 1787245132,
+        }),
+      ).toBe(true)
+    }
+  })
+})
+
 // The BTC (Breez/Spark) wallet does not transmit the held bolt11 on every
 // path: `useSendPayment` routes BTC + lnurl/intraledger to `payLnurlBreez`,
 // which mints a fresh invoice at send time. Checking the held invoice's
@@ -255,6 +398,32 @@ describe("isHeldInvoiceExpired (the decision the confirm screen makes)", () => {
         decode,
       }),
     ).toBe(false)
+  })
+
+  it("refuses a 90-second pause on the real invoice, on any clock", () => {
+    // End to end through the real decoder: the lifetime is read off the
+    // bolt11 (60s) and compared against time actually spent on the confirm
+    // screen, so the same 90-second pause is caught whether the handset is
+    // right or ten minutes fast.
+    for (const skew of [0, 10 * 60]) {
+      expect(
+        isHeldInvoiceExpired({
+          paymentRequest: INCIDENT_INVOICE,
+          firstSeenSeconds: ISSUED + skew,
+          nowSeconds: ISSUED + skew + 90,
+          decode,
+        }),
+      ).toBe(true)
+      // ...and the same handset, tapping straight away, is not.
+      expect(
+        isHeldInvoiceExpired({
+          paymentRequest: INCIDENT_INVOICE,
+          firstSeenSeconds: ISSUED + skew,
+          nowSeconds: ISSUED + skew,
+          decode,
+        }),
+      ).toBe(false)
+    }
   })
 
   it("fails open with no invoice, a bad prefix, or a decode failure", () => {

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -993,7 +993,9 @@ const en: BaseTranslation = {
     maxFeeSelected:
       "This is the maximum fee you will be charged for this transaction.  It may end up being less once the payment has been made.",
     feeError: "Failed to calculate fee",
-    breezFeeText: "There may be a small fee for routing"
+    breezFeeText: "There may be a small fee for routing",
+    invoiceExpired:
+      "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   SendBitcoinDestinationScreen: {
     usernameNowAddress:

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -994,8 +994,8 @@ const en: BaseTranslation = {
       "This is the maximum fee you will be charged for this transaction.  It may end up being less once the payment has been made.",
     feeError: "Failed to calculate fee",
     breezFeeText: "There may be a small fee for routing",
-    invoiceExpired:
-      "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    heldInvoiceExpired:
+      "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   SendBitcoinDestinationScreen: {
     usernameNowAddress:

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -3158,9 +3158,9 @@ type RootTranslation = {
 		 */
 		breezFeeText: string
 		/**
-		 * T​h​i​s​ ​i​n​v​o​i​c​e​ ​e​x​p​i​r​e​d​ ​b​e​f​o​r​e​ ​t​h​e​ ​p​a​y​m​e​n​t​ ​w​a​s​ ​s​e​n​t​.​ ​G​o​ ​b​a​c​k​ ​a​n​d​ ​e​n​t​e​r​ ​t​h​e​ ​a​m​o​u​n​t​ ​a​g​a​i​n​ ​t​o​ ​g​e​t​ ​a​ ​f​r​e​s​h​ ​o​n​e​.
+		 * T​h​i​s​ ​i​n​v​o​i​c​e​ ​e​x​p​i​r​e​d​ ​b​e​f​o​r​e​ ​t​h​e​ ​p​a​y​m​e​n​t​ ​w​a​s​ ​s​e​n​t​.​ ​G​o​ ​b​a​c​k​ ​a​n​d​ ​c​o​n​f​i​r​m​ ​a​g​a​i​n​ ​t​o​ ​g​e​t​ ​a​ ​f​r​e​s​h​ ​o​n​e​.
 		 */
-		invoiceExpired: string
+		heldInvoiceExpired: string
 	}
 	SendBitcoinDestinationScreen: {
 		/**
@@ -9463,9 +9463,9 @@ export type TranslationFunctions = {
 		 */
 		breezFeeText: () => LocalizedString
 		/**
-		 * This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one.
+		 * This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.
 		 */
-		invoiceExpired: () => LocalizedString
+		heldInvoiceExpired: () => LocalizedString
 	}
 	SendBitcoinDestinationScreen: {
 		/**

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -3157,6 +3157,10 @@ type RootTranslation = {
 		 * T​h​e​r​e​ ​m​a​y​ ​b​e​ ​a​ ​s​m​a​l​l​ ​f​e​e​ ​f​o​r​ ​r​o​u​t​i​n​g
 		 */
 		breezFeeText: string
+		/**
+		 * T​h​i​s​ ​i​n​v​o​i​c​e​ ​e​x​p​i​r​e​d​ ​b​e​f​o​r​e​ ​t​h​e​ ​p​a​y​m​e​n​t​ ​w​a​s​ ​s​e​n​t​.​ ​G​o​ ​b​a​c​k​ ​a​n​d​ ​e​n​t​e​r​ ​t​h​e​ ​a​m​o​u​n​t​ ​a​g​a​i​n​ ​t​o​ ​g​e​t​ ​a​ ​f​r​e​s​h​ ​o​n​e​.
+		 */
+		invoiceExpired: string
 	}
 	SendBitcoinDestinationScreen: {
 		/**
@@ -9458,6 +9462,10 @@ export type TranslationFunctions = {
 		 * There may be a small fee for routing
 		 */
 		breezFeeText: () => LocalizedString
+		/**
+		 * This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one.
+		 */
+		invoiceExpired: () => LocalizedString
 	}
 	SendBitcoinDestinationScreen: {
 		/**

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -894,7 +894,7 @@
         "maxFeeSelected": "This is the maximum fee you will be charged for this transaction.  It may end up being less once the payment has been made.",
         "feeError": "Failed to calculate fee",
         "breezFeeText": "There may be a small fee for routing",
-        "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+        "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
     },
     "SendBitcoinDestinationScreen": {
         "usernameNowAddress": "{bankName: string} usernames are now {bankName: string} addresses.",

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -663,6 +663,7 @@
         "paymentSetupFailed": "Failed to initiate payment. Please try again.",
         "changeAmount": "Change amount",
         "allowanceRemaining": "{remaining} of {limit} left today",
+        "allowanceExhausted": "You've used today's {limit} top-up limit",
         "allowanceHeld": "{held} is held by a payment link you haven't completed",
         "allowanceResets": "More becomes available at {when: string}",
         "bankTransfer": "Bank Transfer",
@@ -892,7 +893,8 @@
         "totalExceed": "Total exceeds your balance of {balance: string}",
         "maxFeeSelected": "This is the maximum fee you will be charged for this transaction.  It may end up being less once the payment has been made.",
         "feeError": "Failed to calculate fee",
-        "breezFeeText": "There may be a small fee for routing"
+        "breezFeeText": "There may be a small fee for routing",
+        "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
     },
     "SendBitcoinDestinationScreen": {
         "usernameNowAddress": "{bankName: string} usernames are now {bankName: string} addresses.",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -642,7 +642,8 @@
     "totalExceed": "Die totaal is meer as jou saldo van {balance: string}",
     "maxFeeSelected": "Hierdie is die maksimum fooi wat jy sal betaal vir hierdie transaksie. Dit mag dalk minder wees as die betaling voltooi is.",
     "feeError": "Kon nie fooi bereken nie",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} gebruikersname is nou {bankName: string} adresse. ",
@@ -1583,6 +1584,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -643,7 +643,7 @@
     "maxFeeSelected": "Hierdie is die maksimum fooi wat jy sal betaal vir hierdie transaksie. Dit mag dalk minder wees as die betaling voltooi is.",
     "feeError": "Kon nie fooi bereken nie",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} gebruikersname is nou {bankName: string} adresse. ",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -634,7 +634,8 @@
     "totalExceed": "الإجمالي أكبر من ميزانيتك التي تبلغ {balance}",
     "maxFeeSelected": "هذا هو الحد الأقصى للرسوم التي ستُقتضى منك لهذه المعاملة. قد تكون أقل من ذلك عند إتمام الدفع.",
     "feeError": "فشل في حساب العمولة",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "أسماء المستخدمين في {bankName} أصبحت عناوين في {bankName}",
@@ -1588,6 +1589,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -635,7 +635,7 @@
     "maxFeeSelected": "هذا هو الحد الأقصى للرسوم التي ستُقتضى منك لهذه المعاملة. قد تكون أقل من ذلك عند إتمام الدفع.",
     "feeError": "فشل في حساب العمولة",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "أسماء المستخدمين في {bankName} أصبحت عناوين في {bankName}",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Aquesta és la comissió màxima que se't cobrarà per aquesta transacció. Pot acabar sent inferior un cop s'hagi realitzat el pagament.",
     "feeError": "No s'ha pogut calcular la comissió",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName} nom d'usuari és ara la adreça {bankName}.",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -684,7 +684,8 @@
     "totalExceed": "El total supera el teu saldo de {balance:}",
     "maxFeeSelected": "Aquesta és la comissió màxima que se't cobrarà per aquesta transacció. Pot acabar sent inferior un cop s'hagi realitzat el pagament.",
     "feeError": "No s'ha pogut calcular la comissió",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName} nom d'usuari és ara la adreça {bankName}.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Jedná se o maximální poplatek, který vám bude za tuto transakci účtován. Po provedení platby může být nakonec nižší.",
     "feeError": "Nepodařilo se vypočítat poplatek",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Uživatelská jména {bankName} jsou nyní adresy {bankName}.",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -684,7 +684,8 @@
     "totalExceed": "Celková částka přesahuje váš zůstatek ve výši {balance}",
     "maxFeeSelected": "Jedná se o maximální poplatek, který vám bude za tuto transakci účtován. Po provedení platby může být nakonec nižší.",
     "feeError": "Nepodařilo se vypočítat poplatek",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Uživatelská jména {bankName} jsou nyní adresy {bankName}.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Dette er det maksimale gebyr, du vil blive opkrævet for denne transaktion. Det kan ende med at være mindre, når betalingen er foretaget.",
     "feeError": "Kunne ikke beregne gebyr",
     "breezFeeText": "Der kan være et lille gebyr for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} brugernavne er nu {bankName: string} adresser.",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -684,7 +684,8 @@
     "totalExceed": "Totalen overstiger din saldo på {balance: string}",
     "maxFeeSelected": "Dette er det maksimale gebyr, du vil blive opkrævet for denne transaktion. Det kan ende med at være mindre, når betalingen er foretaget.",
     "feeError": "Kunne ikke beregne gebyr",
-    "breezFeeText": "Der kan være et lille gebyr for routing"
+    "breezFeeText": "Der kan være et lille gebyr for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} brugernavne er nu {bankName: string} adresser.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -684,7 +684,8 @@
     "totalExceed": "Der Gesamtbetrag übersteigt dein Guthaben von {balance}",
     "maxFeeSelected": "Dies ist die maximale Transaktionsgebühr. Die tatsächlich gezahlte Gebühr kann weniger betragen.",
     "feeError": "Gebühr konnte nicht berechnet werden",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName} Benutzernamen sind nun {bankName} Adressen.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Dies ist die maximale Transaktionsgebühr. Die tatsächlich gezahlte Gebühr kann weniger betragen.",
     "feeError": "Gebühr konnte nicht berechnet werden",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName} Benutzernamen sind nun {bankName} Adressen.",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -684,7 +684,8 @@
     "totalExceed": "Το συνολικό ποσό υπερβαίνει το υπόλοιπό σας {balance: string}",
     "maxFeeSelected": "Αυτή είναι τα περισσότερα τέλη που θα χρεωθείτε για αυτή τη συναλλαγή. Μπορεί να είναι λιγότερα όταν πραγματοποιηθεί η πληρωμή.",
     "feeError": "Απέτυχε ο υπολογισμός των τελών",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Τα ονόματα χρηστών {bankName: string} είναι τώρα διευθύνσεις {bankName: string}.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Αυτή είναι τα περισσότερα τέλη που θα χρεωθείτε για αυτή τη συναλλαγή. Μπορεί να είναι λιγότερα όταν πραγματοποιηθεί η πληρωμή.",
     "feeError": "Απέτυχε ο υπολογισμός των τελών",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Τα ονόματα χρηστών {bankName: string} είναι τώρα διευθύνσεις {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -684,7 +684,8 @@
     "totalExceed": "El total excede su saldo de {balance: string}",
     "maxFeeSelected": "Tarifa máxima que se cobrará por esta transacción. Podría ser menor una vez se realice el pago.",
     "feeError": "Error al calcular la tarifa",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Los nombres de usuario de {bankName} ahora son direcciones de {bankName}.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Tarifa máxima que se cobrará por esta transacción. Podría ser menor una vez se realice el pago.",
     "feeError": "Error al calcular la tarifa",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Los nombres de usuario de {bankName} ahora son direcciones de {bankName}.",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -684,7 +684,8 @@
     "totalExceed": "Le total excède votre solde de {balance: string}",
     "maxFeeSelected": "Il s’agit des frais maximums qui vous seront facturés pour cette transaction. Il peut s’avérer inférieur une fois le paiement effectué.",
     "feeError": "Échec du calcul des frais",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Les identifiants {bankName: string} sont maintenant les adresses {bankName: string}.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Il s’agit des frais maximums qui vous seront facturés pour cette transaction. Il peut s’avérer inférieur une fois le paiement effectué.",
     "feeError": "Échec du calcul des frais",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Les identifiants {bankName: string} sont maintenant les adresses {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -684,7 +684,8 @@
     "totalExceed": "Ukupno premašuje vaš saldo od {balance: string}",
     "maxFeeSelected": "Ovo je najveća naknada koja će vam biti naplaćena za ovu transakciju. Nakon izvršenja plaćanja može ispasti manje.",
     "feeError": "Neuspješno izračunavanje naknade",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} korisnička imena sada su {bankName: string} adrese.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Ovo je najveća naknada koja će vam biti naplaćena za ovu transakciju. Nakon izvršenja plaćanja može ispasti manje.",
     "feeError": "Neuspješno izračunavanje naknade",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} korisnička imena sada su {bankName: string} adrese.",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -684,7 +684,8 @@
     "totalExceed": "Az összeg meghaladja az egyenleged, amely {balance: string}",
     "maxFeeSelected": "Ez a maximális díj, amit ezen tranzakcióért felszámíthatunk. Lehet, hogy kevesebb lesz, miután a fizetés megtörtént.",
     "feeError": "Nem sikerült kiszámítani a díjat",
-    "breezFeeText": "Lehet, hogy egy kis díj van a útvonalért"
+    "breezFeeText": "Lehet, hogy egy kis díj van a útvonalért",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Mostantól a {bankName: string} felhasználónevek {bankName: string} címek is.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Ez a maximális díj, amit ezen tranzakcióért felszámíthatunk. Lehet, hogy kevesebb lesz, miután a fizetés megtörtént.",
     "feeError": "Nem sikerült kiszámítani a díjat",
     "breezFeeText": "Lehet, hogy egy kis díj van a útvonalért",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Mostantól a {bankName: string} felhasználónevek {bankName: string} címek is.",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -684,7 +684,8 @@
     "totalExceed": "Ընդհանուր գումարը գերազանցում է {balance: string}ի Ձեր հաշվեկշիռը",
     "maxFeeSelected": "Սա առավելագույն վճարն է, որը Ձեզանից կգանձվի այս գործառնության համար: Վճարումը կատարելուց հետո այն կարող է նվազել։ ",
     "feeError": "Չհաջողվեց հաշվել վճարը",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} օգտանունները հիմա {bankName: string} հասցեներն են։ ",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Սա առավելագույն վճարն է, որը Ձեզանից կգանձվի այս գործառնության համար: Վճարումը կատարելուց հետո այն կարող է նվազել։ ",
     "feeError": "Չհաջողվեց հաշվել վճարը",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} օգտանունները հիմա {bankName: string} հասցեներն են։ ",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -684,7 +684,8 @@
     "totalExceed": "Il totale supera il saldo {balance: string}",
     "maxFeeSelected": "Questa è la commissione massima che ti verrà addebitata per questa transazione. Una volta effettuato il pagamento, il costo potrebbe risultare inferiore.",
     "feeError": "Impossibile calcolare la fee",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Gli username {bankName: string} sono ora indirizzi {bankName: string}.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Questa è la commissione massima che ti verrà addebitata per questa transazione. Una volta effettuato il pagamento, il costo potrebbe risultare inferiore.",
     "feeError": "Impossibile calcolare la fee",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Gli username {bankName: string} sono ora indirizzi {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Ini adalah cas bayaran maksimum yang akan dikenakan untuk transaksi ini. Tapi cas ni mungkin akan lagi rendah bila bayaran telah dibuat.",
     "feeError": "Gagal untuk kira berapa cas dikenakan",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{NamaBank: string} id pengguna sekarang adalah {NamaBank: string} alamatnya.",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -684,7 +684,8 @@
     "totalExceed": "Jumlah yang melebihi baki anda {baki: string}",
     "maxFeeSelected": "Ini adalah cas bayaran maksimum yang akan dikenakan untuk transaksi ini. Tapi cas ni mungkin akan lagi rendah bila bayaran telah dibuat.",
     "feeError": "Gagal untuk kira berapa cas dikenakan",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{NamaBank: string} id pengguna sekarang adalah {NamaBank: string} alamatnya.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -684,7 +684,8 @@
     "totalExceed": "Totaal overschrijdt uw saldo van {balance: string}",
     "maxFeeSelected": "Dit zijn de maximale kosten die voor deze transactie in rekening worden gebracht. Het kan uiteindelijk minder zijn zodra de betaling is gedaan.",
     "feeError": "Het berekenen van de kosten is mislukt",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} gebruikersnamen zijn nu {bankName: string} adressen.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Dit zijn de maximale kosten die voor deze transactie in rekening worden gebracht. Het kan uiteindelijk minder zijn zodra de betaling is gedaan.",
     "feeError": "Het berekenen van de kosten is mislukt",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} gebruikersnamen zijn nu {bankName: string} adressen.",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Esta é a taxa máxima que será cobrada por esta transação. Pode acabar sendo menor uma vez que o pagamento foi feito.",
     "feeError": "Falha ao calcular a taxa",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Nomes de usuário {bankName: string} agora são endereços {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -684,7 +684,8 @@
     "totalExceed": "O total excede seu saldo de {balance}",
     "maxFeeSelected": "Esta é a taxa máxima que será cobrada por esta transação. Pode acabar sendo menor uma vez que o pagamento foi feito.",
     "feeError": "Falha ao calcular a taxa",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Nomes de usuário {bankName: string} agora são endereços {bankName: string}.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -684,7 +684,8 @@
     "totalExceed": "Kaniyta rikuyta munanpi, kaniyta rikuyta munanpi ch'usaq kayniyta rikuy munanpi kawsayniyta qillqata sutichinaqinmi. Chaynamanta kaniyta rikuyta munanpi, {balance: string} kawsayniyta qillqata sutichinaqinmi ch'usaq kayniyta rikuy munanpi ch'usaqta munanpi kawsayniyta qillqata sutichinaqinmi.",
     "maxFeeSelected": "Chaynamanta kaniyta rikuyta munanpi, kaniyta rikuyta munanpi ch'usaq kayniyta rikuy munanpi kawsayniyta qillqata sutichinaqinmi. Kaniytaikuyta munanpi kawsayniyta qillqata sutichinaqinmi chaypi ch'usaq kayniyta rikuy munanpi ch'usaqta munanpi kawsayniyta qillqata sutichinaqinmi.",
     "feeError": "Chaynamanta kaniyta rikuyta munanpi, ch'usaq kayniyta rikuyta munanpi ch'usaqta munanpi kawsayniyta qillqata sutichinaqin.",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} kaniyta yachanakuyta sutichinaqinmi, {bankName: string} kawsayniyta qillqata sutichinaqinmi kaniyta rikuyta munanpi.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Chaynamanta kaniyta rikuyta munanpi, kaniyta rikuyta munanpi ch'usaq kayniyta rikuy munanpi kawsayniyta qillqata sutichinaqinmi. Kaniytaikuyta munanpi kawsayniyta qillqata sutichinaqinmi chaypi ch'usaq kayniyta rikuy munanpi ch'usaqta munanpi kawsayniyta qillqata sutichinaqinmi.",
     "feeError": "Chaynamanta kaniyta rikuyta munanpi, ch'usaq kayniyta rikuyta munanpi ch'usaqta munanpi kawsayniyta qillqata sutichinaqin.",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} kaniyta yachanakuyta sutichinaqinmi, {bankName: string} kawsayniyta qillqata sutichinaqinmi kaniyta rikuyta munanpi.",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Ово је максимална накнада која ће вам бити наплаћена за ову трансакцију. Може се испоставити да је мања након што је плаћање извршено.",
     "feeError": "Неуспешно рачунање накнаде",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} корисничка имена су сада {bankName: string} адресе.",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -684,7 +684,8 @@
     "totalExceed": "Укупан износ прелази ваше стање од {balance: string}",
     "maxFeeSelected": "Ово је максимална накнада која ће вам бити наплаћена за ову трансакцију. Може се испоставити да је мања након што је плаћање извршено.",
     "feeError": "Неуспешно рачунање накнаде",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} корисничка имена су сада {bankName: string} адресе.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -635,7 +635,7 @@
     "maxFeeSelected": "Hii ndio ada ya juu zaidi ambayo unawezalipishwa kwa malipo haya. Inaweza kuishia kuwa kidogo malipo yatakapofanyika.",
     "feeError": "Imeshindwa kuhesabu ada",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} majina ya watumiaji sasa ni anwani za {bankName: string} ",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -634,7 +634,8 @@
     "totalExceed": "Jumla imezidi baki lako la {balance: string}",
     "maxFeeSelected": "Hii ndio ada ya juu zaidi ambayo unawezalipishwa kwa malipo haya. Inaweza kuishia kuwa kidogo malipo yatakapofanyika.",
     "feeError": "Imeshindwa kuhesabu ada",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} majina ya watumiaji sasa ni anwani za {bankName: string} ",
@@ -1588,6 +1589,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "นี่คือค่าธรรมเนียมสูงสุดที่จะถูกเรียกเก็บในธุรกรรมนี้ได้ มันอาจน้อยกว่านี้เมื่อมีการทำธุรกรรมกันจริงๆ",
     "feeError": "การคำนวณค่าธรรมเนียมล้มเหลว",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "ชื่อผู้ใช้{bankName: string} เป็นแอดเดรส{bankName: string}ของคุณในขณะนี้",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -684,7 +684,8 @@
     "totalExceed": "ยอดเงินรวมของคุณเกินกว่า {balance: string}",
     "maxFeeSelected": "นี่คือค่าธรรมเนียมสูงสุดที่จะถูกเรียกเก็บในธุรกรรมนี้ได้ มันอาจน้อยกว่านี้เมื่อมีการทำธุรกรรมกันจริงๆ",
     "feeError": "การคำนวณค่าธรรมเนียมล้มเหลว",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "ชื่อผู้ใช้{bankName: string} เป็นแอดเดรส{bankName: string}ของคุณในขณะนี้",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -684,7 +684,8 @@
     "totalExceed": "Toplam tutar {balance: string} bakiyenizi aşıyor",
     "maxFeeSelected": "Bu, bu işlem için sizden tahsil edilecek maksimum ücrettir. Ödeme yapıldıktan sonra daha az olabilir.",
     "feeError": "Gönderi ücreti hesaplanamadı",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{BankName: string} kullanıcı adları artık {bankName: string} adresleridir.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Bu, bu işlem için sizden tahsil edilecek maksimum ücrettir. Ödeme yapıldıktan sonra daha az olabilir.",
     "feeError": "Gönderi ücreti hesaplanamadı",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{BankName: string} kullanıcı adları artık {bankName: string} adresleridir.",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -684,7 +684,8 @@
     "totalExceed": "Tổng vượt quá số dư của bạn là {balance: string}",
     "maxFeeSelected": "Đây là mức phí tối đa bạn sẽ phải trả cho giao dịch này. Nó có thể sẽ ít hơn sau khi thanh toán được thực hiện.",
     "feeError": "Không thể tính phí",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Tên người dùng {bankName: string} hiện là địa chỉ {bankName: string}.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Đây là mức phí tối đa bạn sẽ phải trả cho giao dịch này. Nó có thể sẽ ít hơn sau khi thanh toán được thực hiện.",
     "feeError": "Không thể tính phí",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Tên người dùng {bankName: string} hiện là địa chỉ {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -685,7 +685,7 @@
     "maxFeeSelected": "Lo ngowona mrhumo uphezulu oza kubizwa ngawo kule ntengiselwano. Inokuphela incinci xa intlawulo yenziwe.",
     "feeError": "Ayiphumelelanga ukubala umrhumo",
     "breezFeeText": "There may be a small fee for routing",
-    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "bankName:} amagama abasebenzisi ngoku {bankName: string} iidilesi.",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -684,7 +684,8 @@
     "totalExceed": "Iyonke igqithile kwibhalansi yakho {balance: }",
     "maxFeeSelected": "Lo ngowona mrhumo uphezulu oza kubizwa ngawo kule ntengiselwano. Inokuphela incinci xa intlawulo yenziwe.",
     "feeError": "Ayiphumelelanga ukubala umrhumo",
-    "breezFeeText": "There may be a small fee for routing"
+    "breezFeeText": "There may be a small fee for routing",
+    "invoiceExpired": "This invoice expired before the payment was sent. Go back and enter the amount again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "bankName:} amagama abasebenzisi ngoku {bankName: string} iidilesi.",
@@ -1582,6 +1583,7 @@
     "checkoutProblemTitle": "Couldn't start your payment",
     "changeAmount": "Change amount",
     "allowanceRemaining": "{remaining} of {limit} left today",
+    "allowanceExhausted": "You've used today's {limit} top-up limit",
     "allowanceHeld": "{held} is held by a payment link you haven't completed",
     "allowanceResets": "More becomes available at {when: string}",
     "checkoutTimedOut": "We couldn't reach Flash to set up your payment. Nothing has been charged — please check your connection and try again.",

--- a/app/screens/send-bitcoin-screen/invoice-expiry.ts
+++ b/app/screens/send-bitcoin-screen/invoice-expiry.ts
@@ -62,6 +62,11 @@ export const CLOCK_SKEW_GRACE_SECONDS = 120
 // it. A per-mount reading restarts at zero there and the invoice looks fresh;
 // keyed by the invoice, the original sighting is still on record and the guard
 // can see that a full lifetime has passed under the user.
+//
+// Keying by the invoice is also what lets the reading START on the amount
+// screen, which is where a scanned bolt11 actually enters the flow and where
+// the user's pause is unbounded. Both screens register unconditionally; the
+// first sighting wins, so the later call is a no-op.
 const firstSightByInvoice = new Map<string, number>()
 
 // A send flow visits a handful of invoices; this cap only stops a very long
@@ -102,8 +107,10 @@ export type InvoiceExpiryArgs = {
   /** Current time in epoch SECONDS, per the device clock. */
   nowSeconds: number
   /**
-   * The device clock's reading when the confirm screen mounted, in epoch
-   * SECONDS — i.e. before the user could have paused on it.
+   * The device clock's reading when the send flow first saw this bolt11, in
+   * epoch SECONDS — the amount screen for a scanned/pasted invoice, the
+   * confirm screen for one LNURL minted on the way in. Either way, before the
+   * user could have paused on it.
    *
    * Read off the same clock as `nowSeconds`, so `nowSeconds - firstSeenSeconds`
    * is an elapsed *duration*, not a comparison against someone else's clock:
@@ -121,15 +128,22 @@ const isFiniteNumber = (value: unknown): value is number =>
  *
  * Two signals, in order of trustworthiness:
  *
- *  1. Elapsed since first sight (primary, offset-immune). The confirm screen
- *     cannot have mounted before the invoice was minted, so the time it has
- *     spent in front of *this* user never overstates the invoice's real age.
- *     Once that exceeds the invoice's whole stated lifetime, the invoice is
- *     dead whatever the handset thinks the wall-clock time is. This is what
- *     catches the ordinary confirm-screen pause on a 60-second invoice, which
- *     the absolute comparison below cannot see until the invoice is 180s old.
- *  2. Absolute expiry + grace (backstop), for the invoice that was already
- *     old when the screen first saw it.
+ *  1. Elapsed since first sight (primary, offset-immune). The send flow
+ *     cannot have laid eyes on the invoice before it was minted, so the time
+ *     it has spent in front of *this* user never overstates the invoice's real
+ *     age. Once that exceeds the invoice's whole stated lifetime, the invoice
+ *     is dead whatever the handset thinks the wall-clock time is. This is what
+ *     catches the ordinary pause on a 60-second invoice, which the absolute
+ *     comparison below cannot see until the invoice is 180s old.
+ *  2. Absolute expiry + grace (backstop) — reached ONLY when the invoice
+ *     states no usable issue time, or when no first-sight reading exists. An
+ *     invoice already dead at its first sighting is deliberately NOT caught:
+ *     that reading is indistinguishable from a fast handset clock, so the
+ *     elapsed term wins and the backend does the rejecting. See the tradeoff
+ *     note at the elapsed branch below. What keeps this from mattering in
+ *     practice is registering first sight where the invoice ENTERS the flow
+ *     (send-bitcoin-details-screen.tsx) rather than at confirm-mount, so the
+ *     elapsed reading spans the whole time the invoice was under the user.
  *
  * Fails open on every unknown, and on a device clock that is provably wrong:
  *

--- a/app/screens/send-bitcoin-screen/invoice-expiry.ts
+++ b/app/screens/send-bitcoin-screen/invoice-expiry.ts
@@ -1,44 +1,80 @@
 // Invoice-expiry rules for the send flow.
 //
-// Free of react-native / SDK imports so the rules stay unit-testable under
-// plain jest (mirrors max-send-amount.ts). Decoding is the caller's job —
-// this module only reasons about the decoded expiry timestamp.
+// Runtime-import-free (the two imports below are type-only and erase at
+// compile time) so the rules stay unit-testable under plain jest, mirroring
+// max-send-amount.ts. Decoding is the caller's job — this module only reasons
+// about the decoded timestamps.
+//
+// Related: @galoymoney/client exports `lightningInvoiceHasExpired(payReq)`,
+// which `parsePaymentDestination` uses to reject an already-dead invoice at
+// paste/scan time. It is deliberately NOT reused here. That helper answers
+// "is this invoice expired?" strictly (`now < timeExpireDate`, no tolerance),
+// which is the right question when the user has just supplied a destination
+// and a wrong answer only costs them a re-scan. This module answers a
+// different question — "should we refuse to transmit an invoice the user is
+// actively trying to pay?" — where a wrong answer costs them the payment, so
+// it deliberately allows a clock-skew grace window and fails open on a device
+// clock that is provably wrong. Keep the two apart; do not "unify" them.
+import type { WalletCurrency } from "@app/graphql/generated"
+import type { PaymentType } from "@galoymoney/client"
+
+// Why any of this exists: Flash IBEX receive invoices are short-lived, and
+// the window is not a client-side convention — IBEX enforces it.
+//
+//   // flash src/domain/bitcoin/lightning/invoice-expiration.ts
+//   // IBEX caps BOLT11 receive-invoice expiry by the account's currency type:
+//   //   - msat currency accounts: up to 900s
+//   //   - all other currency accounts (USD/USDT/JMD): up to 60s
+//   export const IBEX_RECEIVE_MAX_EXPIRATION_SECONDS = SECS_PER_MIN
+//
+// Verified against a real failing invoice (ENG-555): issued 16:39:42Z,
+// expiring 16:40:42Z — exactly 60 seconds.
+//
+// A minute is short enough that an ordinary confirm-screen pause outlives it,
+// so the send flow must treat a held invoice as perishable rather than as a
+// stable property of the payment.
 
 /**
- * Flash IBEX receive invoices are short-lived, and the window is not a
- * client-side convention — IBEX enforces it:
+ * How far past the stated expiry we still let a send through, in seconds.
  *
- *   // flash src/domain/bitcoin/lightning/invoice-expiration.ts
- *   // IBEX caps BOLT11 receive-invoice expiry by the account's currency type:
- *   //   - msat currency accounts: up to 900s
- *   //   - all other currency accounts (USD/USDT/JMD): up to 60s
- *   export const IBEX_RECEIVE_MAX_EXPIRATION_SECONDS = SECS_PER_MIN
+ * `nowSeconds` comes from the device wall clock, which is not authoritative:
+ * the issuer's clock is. Without a tolerance the guard fails CLOSED on skew —
+ * a handset running two minutes fast would mark every freshly minted 60-second
+ * Flash invoice expired the instant it was created, and the user could never
+ * send at all, where before this guard existed the backend (validating against
+ * server time) would have accepted the payment.
  *
- * Verified against a real failing invoice (ENG-555): issued 16:39:42Z,
- * expiring 16:40:42Z — exactly 60 seconds.
- *
- * A minute is short enough that an ordinary confirm-screen pause outlives
- * it, so the send flow must treat a held invoice as perishable rather than
- * as a stable property of the payment.
+ * 120s is chosen to swallow ordinary handset drift while still catching the
+ * ENG-555 case with a wide margin — that retry landed ~18 minutes late.
  */
+export const CLOCK_SKEW_GRACE_SECONDS = 120
+
 export type InvoiceExpiryArgs = {
   /** Decoded bolt11 `timeExpireDate`, in epoch SECONDS. */
   timeExpireDate?: number | null
-  /** Current time in epoch SECONDS. */
+  /** Decoded bolt11 `timestamp` (issue time), in epoch SECONDS. */
+  timestamp?: number | null
+  /** Current time in epoch SECONDS, per the device clock. */
   nowSeconds: number
 }
 
 /**
- * Whether a held invoice is past its expiry.
+ * Whether a held invoice is far enough past its expiry to refuse the send.
  *
- * Returns false when the expiry is unknown or unparseable. Refusing to send
- * on a value we could not read would turn a decode quirk into a blocked
- * payment; the backend still rejects a genuinely expired invoice, so the
- * cost of a false negative is the status quo, while a false positive would
- * block a perfectly good send.
+ * Fails open on every unknown, and on a device clock that is provably wrong:
+ *
+ *  - Unknown/unparseable expiry — a decode quirk must not become a blocked
+ *    payment. The backend still rejects a genuinely expired invoice, so a
+ *    false negative only restores the status quo, while a false positive
+ *    costs a payment that would have worked.
+ *  - `nowSeconds` before the invoice's own issue time — the device clock is
+ *    behind the issuer's, so nothing derived from it can be trusted.
+ *  - Inside CLOCK_SKEW_GRACE_SECONDS past the expiry — plausible drift rather
+ *    than a genuinely dead invoice.
  */
 export const isInvoiceExpired = ({
   timeExpireDate,
+  timestamp,
   nowSeconds,
 }: InvoiceExpiryArgs): boolean => {
   if (typeof timeExpireDate !== "number" || !Number.isFinite(timeExpireDate)) {
@@ -46,7 +82,17 @@ export const isInvoiceExpired = ({
   }
   if (!Number.isFinite(nowSeconds)) return false
 
-  return nowSeconds >= timeExpireDate
+  // Skew detector: an invoice cannot have been issued in the future, so a
+  // "now" that precedes its issue time proves the device clock is behind.
+  if (
+    typeof timestamp === "number" &&
+    Number.isFinite(timestamp) &&
+    nowSeconds < timestamp
+  ) {
+    return false
+  }
+
+  return nowSeconds > timeExpireDate + CLOCK_SKEW_GRACE_SECONDS
 }
 
 /** The networks @galoymoney/client's decoder accepts. */
@@ -82,7 +128,7 @@ export type HeldInvoiceExpiredArgs = {
   decode: (
     paymentRequest: string,
     network: InvoiceNetwork,
-  ) => { timeExpireDate?: number | null }
+  ) => { timeExpireDate?: number | null; timestamp?: number | null }
 }
 
 /**
@@ -104,9 +150,39 @@ export const isHeldInvoiceExpired = ({
   if (!network) return false
 
   try {
-    const { timeExpireDate } = decode(paymentRequest, network)
-    return isInvoiceExpired({ timeExpireDate, nowSeconds })
+    const { timeExpireDate, timestamp } = decode(paymentRequest, network)
+    return isInvoiceExpired({ timeExpireDate, timestamp, nowSeconds })
   } catch {
     return false
   }
 }
+
+export type HeldInvoiceTransmissionArgs = {
+  /** `sendingWalletDescriptor.currency` of the detail being confirmed. */
+  sendingWalletCurrency?: WalletCurrency
+  /** `paymentType` of the detail being confirmed. */
+  paymentType?: PaymentType
+}
+
+/**
+ * Whether the bolt11 the confirm screen is holding is the one that will
+ * actually be transmitted — and therefore whether its expiry says anything
+ * about the send that is about to happen.
+ *
+ * It usually is, but not on the Breez/Spark BTC wallet's LNURL and
+ * intraledger paths: `useSendPayment` routes those to `payLnurlBreez`, which
+ * re-resolves the lightning address and mints a *brand-new* invoice at send
+ * time (app/utils/breez-sdk/spark.ts). The held bolt11 is dead weight there,
+ * so checking its expiry would refuse a payment Breez would have completed —
+ * exactly the false positive the guard exists to avoid.
+ *
+ * BTC + `lightning` is the opposite case: `payLightningBreez` is handed the
+ * detail's `destination`, which *is* the held bolt11, so the check applies.
+ * Every non-BTC wallet sends through GraphQL with `paymentRequest` in the
+ * mutation input, so the check applies there too.
+ */
+export const willTransmitHeldInvoice = ({
+  sendingWalletCurrency,
+  paymentType,
+}: HeldInvoiceTransmissionArgs): boolean =>
+  sendingWalletCurrency !== "BTC" || paymentType === "lightning"

--- a/app/screens/send-bitcoin-screen/invoice-expiry.ts
+++ b/app/screens/send-bitcoin-screen/invoice-expiry.ts
@@ -63,15 +63,18 @@ export const CLOCK_SKEW_GRACE_SECONDS = 120
 // keyed by the invoice, the original sighting is still on record and the guard
 // can see that a full lifetime has passed under the user.
 //
-// Keying by the invoice is also what lets the reading START on the amount
-// screen, which is where a scanned bolt11 actually enters the flow and where
-// the user's pause is unbounded. Both screens register unconditionally; the
-// first sighting wins, so the later call is a no-op.
+// Keying by the invoice is also what lets the reading START where the bolt11
+// is first proved alive — `createLightningDestination`, one instant after
+// `parsePaymentDestination` certified it (payment-destination/lightning.ts) —
+// rather than at some later screen mount. Everything downstream (the amount
+// screen, the confirm screen) registers unconditionally too; the first
+// sighting wins, so those calls are no-ops.
 const firstSightByInvoice = new Map<string, number>()
 
 // A send flow visits a handful of invoices; this cap only stops a very long
-// session from growing the map without bound.
-const MAX_TRACKED_INVOICES = 50
+// session from growing the map without bound. Exported so the eviction test
+// tracks the real cap instead of a copy of it.
+export const MAX_TRACKED_INVOICES = 50
 
 /**
  * Record (once) when this device first saw `paymentRequest`, and return that
@@ -108,9 +111,9 @@ export type InvoiceExpiryArgs = {
   nowSeconds: number
   /**
    * The device clock's reading when the send flow first saw this bolt11, in
-   * epoch SECONDS — the amount screen for a scanned/pasted invoice, the
-   * confirm screen for one LNURL minted on the way in. Either way, before the
-   * user could have paused on it.
+   * epoch SECONDS — destination parse for a scanned/pasted/deep-linked
+   * invoice, the confirm screen for one LNURL minted on the way in. Either
+   * way, before the user could have paused on it.
    *
    * Read off the same clock as `nowSeconds`, so `nowSeconds - firstSeenSeconds`
    * is an elapsed *duration*, not a comparison against someone else's clock:
@@ -134,16 +137,19 @@ const isFiniteNumber = (value: unknown): value is number =>
  *     age. Once that exceeds the invoice's whole stated lifetime, the invoice
  *     is dead whatever the handset thinks the wall-clock time is. This is what
  *     catches the ordinary pause on a 60-second invoice, which the absolute
- *     comparison below cannot see until the invoice is 180s old.
+ *     comparison below cannot see until the invoice is 180s old. It refuses
+ *     only with the raw expiry corroborating, so a clock that JUMPS between
+ *     the two readings cannot manufacture elapsed time — see the branch below.
  *  2. Absolute expiry + grace (backstop) — reached ONLY when the invoice
  *     states no usable issue time, or when no first-sight reading exists. An
  *     invoice already dead at its first sighting is deliberately NOT caught:
  *     that reading is indistinguishable from a fast handset clock, so the
  *     elapsed term wins and the backend does the rejecting. See the tradeoff
  *     note at the elapsed branch below. What keeps this from mattering in
- *     practice is registering first sight where the invoice ENTERS the flow
- *     (send-bitcoin-details-screen.tsx) rather than at confirm-mount, so the
- *     elapsed reading spans the whole time the invoice was under the user.
+ *     practice is registering first sight at the moment the bolt11 is proved
+ *     alive (payment-destination/lightning.ts) rather than at confirm-mount,
+ *     so the elapsed reading spans the whole time the invoice was under the
+ *     user.
  *
  * Fails open on every unknown, and on a device clock that is provably wrong:
  *
@@ -154,6 +160,8 @@ const isFiniteNumber = (value: unknown): value is number =>
  *  - `nowSeconds` before the invoice's own issue time — the device clock is
  *    behind the issuer's, so nothing derived from it can be trusted.
  *  - A first sighting that already read as long dead — see below.
+ *  - An elapsed reading the raw expiry contradicts — the clock moved between
+ *    the two samples, so the duration between them is not elapsed time.
  *  - Inside CLOCK_SKEW_GRACE_SECONDS past the expiry — plausible drift rather
  *    than a genuinely dead invoice.
  */
@@ -179,17 +187,36 @@ export const isInvoiceExpired = ({
     // Flash receive invoice, per IBEX's cap.
     const lifetimeSeconds = timeExpireDate - timestamp
 
-    // Sole signal when it is available. Both readings come from the device
-    // clock, so this is a true elapsed duration: a handset ten minutes fast
-    // reads zero on a fresh invoice, exactly like a correct one. It fires
-    // only once the invoice's whole lifetime has passed under the user.
+    // Primary signal. Both readings come from the device clock, so this is a
+    // true elapsed duration: a handset ten minutes fast reads zero on a fresh
+    // invoice, exactly like a correct one. It fires only once the invoice's
+    // whole lifetime has passed under the user.
     //
-    // The absolute comparison below is deliberately NOT consulted as a
-    // second opinion here. It cannot tell a stale invoice from a fast clock,
-    // so letting it override this would block good payments on skewed
-    // handsets — and blocking a send that would have worked is the one
-    // failure this guard must not introduce.
-    return nowSeconds - firstSeenSeconds > lifetimeSeconds
+    // Elapsed time is immune to a clock with a constant OFFSET — but not to a
+    // clock that MOVES between the two readings. `Date.now()` is sampled once
+    // at first sight and again at the tap, so an OS time resync in between
+    // lands entirely in this term. A handset five minutes slow when it scans a
+    // live 60-second invoice, resynced while the user types an amount, reads
+    // 320s elapsed on an invoice with 40 seconds of life left — and refusing
+    // there is a blocked good payment, the one failure this guard must not
+    // introduce.
+    //
+    // So the absolute reading has to corroborate before we refuse. On any
+    // STABLE clock this second term is implied and changes nothing: the flow
+    // cannot have seen the invoice before it was minted, so with a constant
+    // offset d we have firstSeen >= timestamp + d, hence
+    // now > firstSeen + lifetime >= timeExpireDate + d — which for a fast or
+    // correct clock is already past timeExpireDate. (Verified against every
+    // elapsed-branch case in __tests__/utils/invoice-expiry.spec.ts and
+    // __tests__/screens/send-confirmation.spec.tsx.) It only bites when the
+    // clock jumped, and on a slow clock the `nowSeconds < timestamp` detector
+    // above has usually already muted the guard anyway.
+    //
+    // Note it is a corroboration, not a second opinion: the absolute term can
+    // only ever HOLD THE GUARD BACK here, never fire it on its own. It cannot
+    // tell a stale invoice from a fast clock, so letting it refuse a send by
+    // itself would block good payments on skewed handsets.
+    return nowSeconds - firstSeenSeconds > lifetimeSeconds && nowSeconds > timeExpireDate
   }
 
   // Fallback for invoices with no usable issue time, where no elapsed

--- a/app/screens/send-bitcoin-screen/invoice-expiry.ts
+++ b/app/screens/send-bitcoin-screen/invoice-expiry.ts
@@ -1,0 +1,50 @@
+// Invoice-expiry rules for the send flow.
+//
+// Free of react-native / SDK imports so the rules stay unit-testable under
+// plain jest (mirrors max-send-amount.ts). Decoding is the caller's job —
+// this module only reasons about the decoded expiry timestamp.
+
+/**
+ * Flash IBEX receive invoices are short-lived, and the window is not a
+ * client-side convention — IBEX enforces it:
+ *
+ *   // flash src/domain/bitcoin/lightning/invoice-expiration.ts
+ *   // IBEX caps BOLT11 receive-invoice expiry by the account's currency type:
+ *   //   - msat currency accounts: up to 900s
+ *   //   - all other currency accounts (USD/USDT/JMD): up to 60s
+ *   export const IBEX_RECEIVE_MAX_EXPIRATION_SECONDS = SECS_PER_MIN
+ *
+ * Verified against a real failing invoice (ENG-555): issued 16:39:42Z,
+ * expiring 16:40:42Z — exactly 60 seconds.
+ *
+ * A minute is short enough that an ordinary confirm-screen pause outlives
+ * it, so the send flow must treat a held invoice as perishable rather than
+ * as a stable property of the payment.
+ */
+export type InvoiceExpiryArgs = {
+  /** Decoded bolt11 `timeExpireDate`, in epoch SECONDS. */
+  timeExpireDate?: number | null
+  /** Current time in epoch SECONDS. */
+  nowSeconds: number
+}
+
+/**
+ * Whether a held invoice is past its expiry.
+ *
+ * Returns false when the expiry is unknown or unparseable. Refusing to send
+ * on a value we could not read would turn a decode quirk into a blocked
+ * payment; the backend still rejects a genuinely expired invoice, so the
+ * cost of a false negative is the status quo, while a false positive would
+ * block a perfectly good send.
+ */
+export const isInvoiceExpired = ({
+  timeExpireDate,
+  nowSeconds,
+}: InvoiceExpiryArgs): boolean => {
+  if (typeof timeExpireDate !== "number" || !Number.isFinite(timeExpireDate)) {
+    return false
+  }
+  if (!Number.isFinite(nowSeconds)) return false
+
+  return nowSeconds >= timeExpireDate
+}

--- a/app/screens/send-bitcoin-screen/invoice-expiry.ts
+++ b/app/screens/send-bitcoin-screen/invoice-expiry.ts
@@ -35,17 +35,20 @@ import type { PaymentType } from "@galoymoney/client"
 // stable property of the payment.
 
 /**
- * How far past the stated expiry we still let a send through, in seconds.
+ * How far past the stated expiry the absolute backstop still lets a send
+ * through, in seconds.
  *
- * `nowSeconds` comes from the device wall clock, which is not authoritative:
- * the issuer's clock is. Without a tolerance the guard fails CLOSED on skew —
- * a handset running two minutes fast would mark every freshly minted 60-second
+ * Comparing `nowSeconds` against the stated expiry compares two *different*
+ * clocks — the device's against the issuer's — and only the issuer's is
+ * authoritative. Without a tolerance that comparison fails CLOSED on skew: a
+ * handset running two minutes fast would mark every freshly minted 60-second
  * Flash invoice expired the instant it was created, and the user could never
  * send at all, where before this guard existed the backend (validating against
  * server time) would have accepted the payment.
  *
- * 120s is chosen to swallow ordinary handset drift while still catching the
- * ENG-555 case with a wide margin — that retry landed ~18 minutes late.
+ * 120s swallows ordinary handset drift. It is not the primary signal — see
+ * `firstSeenSeconds` below, which measures the device clock against *itself*
+ * and so cannot be fooled by any offset at all.
  */
 export const CLOCK_SKEW_GRACE_SECONDS = 120
 
@@ -56,10 +59,35 @@ export type InvoiceExpiryArgs = {
   timestamp?: number | null
   /** Current time in epoch SECONDS, per the device clock. */
   nowSeconds: number
+  /**
+   * The device clock's reading when the confirm screen mounted, in epoch
+   * SECONDS — i.e. before the user could have paused on it.
+   *
+   * Read off the same clock as `nowSeconds`, so `nowSeconds - firstSeenSeconds`
+   * is an elapsed *duration*, not a comparison against someone else's clock:
+   * any constant offset cancels. Optional — omitted, only the absolute
+   * backstop is available.
+   */
+  firstSeenSeconds?: number | null
 }
 
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value)
+
 /**
- * Whether a held invoice is far enough past its expiry to refuse the send.
+ * Whether a held invoice is dead enough to refuse the send.
+ *
+ * Two signals, in order of trustworthiness:
+ *
+ *  1. Elapsed since first sight (primary, offset-immune). The confirm screen
+ *     cannot have mounted before the invoice was minted, so the time it has
+ *     spent in front of *this* user never overstates the invoice's real age.
+ *     Once that exceeds the invoice's whole stated lifetime, the invoice is
+ *     dead whatever the handset thinks the wall-clock time is. This is what
+ *     catches the ordinary confirm-screen pause on a 60-second invoice, which
+ *     the absolute comparison below cannot see until the invoice is 180s old.
+ *  2. Absolute expiry + grace (backstop), for the invoice that was already
+ *     old when the screen first saw it.
  *
  * Fails open on every unknown, and on a device clock that is provably wrong:
  *
@@ -69,6 +97,7 @@ export type InvoiceExpiryArgs = {
  *    costs a payment that would have worked.
  *  - `nowSeconds` before the invoice's own issue time — the device clock is
  *    behind the issuer's, so nothing derived from it can be trusted.
+ *  - A first sighting that already read as long dead — see below.
  *  - Inside CLOCK_SKEW_GRACE_SECONDS past the expiry — plausible drift rather
  *    than a genuinely dead invoice.
  */
@@ -76,20 +105,43 @@ export const isInvoiceExpired = ({
   timeExpireDate,
   timestamp,
   nowSeconds,
+  firstSeenSeconds,
 }: InvoiceExpiryArgs): boolean => {
-  if (typeof timeExpireDate !== "number" || !Number.isFinite(timeExpireDate)) {
-    return false
-  }
-  if (!Number.isFinite(nowSeconds)) return false
+  if (!isFiniteNumber(timeExpireDate)) return false
+  if (!isFiniteNumber(nowSeconds)) return false
 
   // Skew detector: an invoice cannot have been issued in the future, so a
   // "now" that precedes its issue time proves the device clock is behind.
+  if (isFiniteNumber(timestamp) && nowSeconds < timestamp) return false
+
   if (
-    typeof timestamp === "number" &&
-    Number.isFinite(timestamp) &&
-    nowSeconds < timestamp
+    isFiniteNumber(timestamp) &&
+    isFiniteNumber(firstSeenSeconds) &&
+    timeExpireDate > timestamp
   ) {
-    return false
+    // The invoice's own lifetime, straight off the bolt11 — 60 seconds for a
+    // Flash receive invoice, per IBEX's cap.
+    const lifetimeSeconds = timeExpireDate - timestamp
+
+    // (1) Primary signal. Both readings come from the device clock, so this
+    // is a true elapsed duration: a handset ten minutes fast reads 0 here on
+    // a fresh invoice, exactly like a correct one. It can only fire once the
+    // invoice's entire lifetime has genuinely passed under the user's nose.
+    if (nowSeconds - firstSeenSeconds > lifetimeSeconds) return true
+
+    // (2) Mute the backstop when this screen's *first* reading already put
+    // the invoice well past its lifetime. That reading cannot distinguish a
+    // genuinely stale invoice from a fast handset — and a genuinely stale one
+    // barely exists here, because parsePaymentDestination already rejects an
+    // expired bolt11 at paste/scan time (@galoymoney/client's
+    // lightningInvoiceHasExpired). What is left is overwhelmingly skew: an
+    // LNURL detail mints its invoice on the way into this screen, so "already
+    // long dead on arrival" is the signature of a wrong clock, not a wrong
+    // invoice. Signal (1) still covers this user; the backstop would only be
+    // guessing, and guessing wrong costs them the payment.
+    if (firstSeenSeconds - timestamp > lifetimeSeconds + CLOCK_SKEW_GRACE_SECONDS) {
+      return false
+    }
   }
 
   return nowSeconds > timeExpireDate + CLOCK_SKEW_GRACE_SECONDS
@@ -124,6 +176,8 @@ export type HeldInvoiceExpiredArgs = {
   paymentRequest?: string
   /** Current time in epoch SECONDS. */
   nowSeconds: number
+  /** Device-clock reading from when the confirm screen mounted, in SECONDS. */
+  firstSeenSeconds?: number | null
   /** Injected so this decision stays testable without the screen. */
   decode: (
     paymentRequest: string,
@@ -142,6 +196,7 @@ export type HeldInvoiceExpiredArgs = {
 export const isHeldInvoiceExpired = ({
   paymentRequest,
   nowSeconds,
+  firstSeenSeconds,
   decode,
 }: HeldInvoiceExpiredArgs): boolean => {
   if (!paymentRequest) return false
@@ -151,7 +206,12 @@ export const isHeldInvoiceExpired = ({
 
   try {
     const { timeExpireDate, timestamp } = decode(paymentRequest, network)
-    return isInvoiceExpired({ timeExpireDate, timestamp, nowSeconds })
+    return isInvoiceExpired({
+      timeExpireDate,
+      timestamp,
+      nowSeconds,
+      firstSeenSeconds,
+    })
   } catch {
     return false
   }

--- a/app/screens/send-bitcoin-screen/invoice-expiry.ts
+++ b/app/screens/send-bitcoin-screen/invoice-expiry.ts
@@ -48,3 +48,65 @@ export const isInvoiceExpired = ({
 
   return nowSeconds >= timeExpireDate
 }
+
+/** The networks @galoymoney/client's decoder accepts. */
+export type InvoiceNetwork = "mainnet" | "signet" | "regtest"
+
+/**
+ * The network a bolt11 belongs to, read from its human-readable prefix.
+ *
+ * Derived rather than hardcoded so the expiry check works on every build.
+ * The send flow hardcodes "mainnet" elsewhere, which would make this guard
+ * silently useless on a signet or regtest build: the decoder throws on a
+ * prefix mismatch, the catch swallows it, and nothing is ever checked.
+ *
+ * Order matters — "lnbcrt" also starts with "lnbc", so the longer prefix has
+ * to be tested first.
+ */
+export const networkForPaymentRequest = (
+  paymentRequest: string,
+): InvoiceNetwork | undefined => {
+  const pr = paymentRequest.trim().toLowerCase()
+  if (pr.startsWith("lnbcrt")) return "regtest"
+  if (pr.startsWith("lntbs")) return "signet"
+  if (pr.startsWith("lnbc")) return "mainnet"
+  return undefined
+}
+
+export type HeldInvoiceExpiredArgs = {
+  /** The bolt11 the confirm screen is holding, if it has one. */
+  paymentRequest?: string
+  /** Current time in epoch SECONDS. */
+  nowSeconds: number
+  /** Injected so this decision stays testable without the screen. */
+  decode: (
+    paymentRequest: string,
+    network: InvoiceNetwork,
+  ) => { timeExpireDate?: number | null }
+}
+
+/**
+ * Whether the send should be refused because the held invoice is dead.
+ *
+ * Fails open on every unknown: no invoice, an unrecognised prefix, or a
+ * decode failure all resolve to false. The backend still rejects a genuinely
+ * expired invoice, so a false negative only restores today's behaviour —
+ * whereas a false positive blocks a payment that would have worked.
+ */
+export const isHeldInvoiceExpired = ({
+  paymentRequest,
+  nowSeconds,
+  decode,
+}: HeldInvoiceExpiredArgs): boolean => {
+  if (!paymentRequest) return false
+
+  const network = networkForPaymentRequest(paymentRequest)
+  if (!network) return false
+
+  try {
+    const { timeExpireDate } = decode(paymentRequest, network)
+    return isInvoiceExpired({ timeExpireDate, nowSeconds })
+  } catch {
+    return false
+  }
+}

--- a/app/screens/send-bitcoin-screen/invoice-expiry.ts
+++ b/app/screens/send-bitcoin-screen/invoice-expiry.ts
@@ -52,6 +52,48 @@ import type { PaymentType } from "@galoymoney/client"
  */
 export const CLOCK_SKEW_GRACE_SECONDS = 120
 
+// When each bolt11 was first seen, keyed by the invoice itself rather than by a
+// screen mount.
+//
+// This is what makes the elapsed-time signal survive the reported retry. After
+// a failed send the confirm screen disables its button, so the user goes Back,
+// changes the amount and comes forward again — remounting the screen but
+// reusing the SAME bolt11, because setAmount only rebuilds the detail around
+// it. A per-mount reading restarts at zero there and the invoice looks fresh;
+// keyed by the invoice, the original sighting is still on record and the guard
+// can see that a full lifetime has passed under the user.
+const firstSightByInvoice = new Map<string, number>()
+
+// A send flow visits a handful of invoices; this cap only stops a very long
+// session from growing the map without bound.
+const MAX_TRACKED_INVOICES = 50
+
+/**
+ * Record (once) when this device first saw `paymentRequest`, and return that
+ * reading. It shares a clock with `nowSeconds`, so the difference is a true
+ * elapsed duration — a handset ten minutes fast reads zero on a fresh invoice,
+ * exactly like a correct one.
+ */
+export const noteInvoiceFirstSight = (
+  paymentRequest: string,
+  nowSeconds: number,
+): number => {
+  const seen = firstSightByInvoice.get(paymentRequest)
+  if (seen !== undefined) return seen
+
+  if (firstSightByInvoice.size >= MAX_TRACKED_INVOICES) {
+    const oldest = firstSightByInvoice.keys().next()
+    if (!oldest.done) firstSightByInvoice.delete(oldest.value)
+  }
+  firstSightByInvoice.set(paymentRequest, nowSeconds)
+  return nowSeconds
+}
+
+/** Test seam — module state would otherwise leak between cases. */
+export const resetInvoiceFirstSight = (): void => {
+  firstSightByInvoice.clear()
+}
+
 export type InvoiceExpiryArgs = {
   /** Decoded bolt11 `timeExpireDate`, in epoch SECONDS. */
   timeExpireDate?: number | null
@@ -123,27 +165,21 @@ export const isInvoiceExpired = ({
     // Flash receive invoice, per IBEX's cap.
     const lifetimeSeconds = timeExpireDate - timestamp
 
-    // (1) Primary signal. Both readings come from the device clock, so this
-    // is a true elapsed duration: a handset ten minutes fast reads 0 here on
-    // a fresh invoice, exactly like a correct one. It can only fire once the
-    // invoice's entire lifetime has genuinely passed under the user's nose.
-    if (nowSeconds - firstSeenSeconds > lifetimeSeconds) return true
-
-    // (2) Mute the backstop when this screen's *first* reading already put
-    // the invoice well past its lifetime. That reading cannot distinguish a
-    // genuinely stale invoice from a fast handset — and a genuinely stale one
-    // barely exists here, because parsePaymentDestination already rejects an
-    // expired bolt11 at paste/scan time (@galoymoney/client's
-    // lightningInvoiceHasExpired). What is left is overwhelmingly skew: an
-    // LNURL detail mints its invoice on the way into this screen, so "already
-    // long dead on arrival" is the signature of a wrong clock, not a wrong
-    // invoice. Signal (1) still covers this user; the backstop would only be
-    // guessing, and guessing wrong costs them the payment.
-    if (firstSeenSeconds - timestamp > lifetimeSeconds + CLOCK_SKEW_GRACE_SECONDS) {
-      return false
-    }
+    // Sole signal when it is available. Both readings come from the device
+    // clock, so this is a true elapsed duration: a handset ten minutes fast
+    // reads zero on a fresh invoice, exactly like a correct one. It fires
+    // only once the invoice's whole lifetime has passed under the user.
+    //
+    // The absolute comparison below is deliberately NOT consulted as a
+    // second opinion here. It cannot tell a stale invoice from a fast clock,
+    // so letting it override this would block good payments on skewed
+    // handsets — and blocking a send that would have worked is the one
+    // failure this guard must not introduce.
+    return nowSeconds - firstSeenSeconds > lifetimeSeconds
   }
 
+  // Fallback for invoices with no usable issue time, where no elapsed
+  // duration can be computed. Skew moves this one, hence the grace window.
   return nowSeconds > timeExpireDate + CLOCK_SKEW_GRACE_SECONDS
 }
 
@@ -176,8 +212,6 @@ export type HeldInvoiceExpiredArgs = {
   paymentRequest?: string
   /** Current time in epoch SECONDS. */
   nowSeconds: number
-  /** Device-clock reading from when the confirm screen mounted, in SECONDS. */
-  firstSeenSeconds?: number | null
   /** Injected so this decision stays testable without the screen. */
   decode: (
     paymentRequest: string,
@@ -196,7 +230,6 @@ export type HeldInvoiceExpiredArgs = {
 export const isHeldInvoiceExpired = ({
   paymentRequest,
   nowSeconds,
-  firstSeenSeconds,
   decode,
 }: HeldInvoiceExpiredArgs): boolean => {
   if (!paymentRequest) return false
@@ -204,13 +237,17 @@ export const isHeldInvoiceExpired = ({
   const network = networkForPaymentRequest(paymentRequest)
   if (!network) return false
 
+  // Resolved here rather than passed in: the reading has to be per-invoice to
+  // survive a remount, and every caller would otherwise have to know that.
+  const seenAt = noteInvoiceFirstSight(paymentRequest, nowSeconds)
+
   try {
     const { timeExpireDate, timestamp } = decode(paymentRequest, network)
     return isInvoiceExpired({
       timeExpireDate,
       timestamp,
       nowSeconds,
-      firstSeenSeconds,
+      firstSeenSeconds: seenAt,
     })
   } catch {
     return false

--- a/app/screens/send-bitcoin-screen/payment-destination/lightning.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/lightning.ts
@@ -3,6 +3,7 @@ import {
   InvalidLightningDestinationReason,
   LightningPaymentDestination,
 } from "@galoymoney/client"
+import { noteInvoiceFirstSight } from "../invoice-expiry"
 import {
   createAmountLightningPaymentDetails,
   createNoAmountLightningPaymentDetails,
@@ -34,6 +35,26 @@ export const createLightningDestination = (
   parsedLightningDestination: LightningPaymentDestination & { valid: true },
 ): PaymentDestination => {
   const { paymentRequest, amount, memo } = parsedLightningDestination
+
+  // Start the expiry clock HERE — the first and only moment this device's own
+  // clock has certified the invoice alive. `parsePaymentDestination` rejects an
+  // already-expired bolt11, so reaching `valid === true` is proof the invoice
+  // was live one instant ago, by the same clock the guard later reads. That is
+  // exactly the property the elapsed-since-first-sight signal needs (see
+  // ../invoice-expiry.ts): from a reading taken at a certified-alive moment,
+  // "a whole lifetime has passed under this user" really does mean dead.
+  //
+  // The amount screen is one screen too late. Between here and there the user
+  // has to tap Next, and on the paste/blur path the destination screen has
+  // already flipped to Valid and may be holding them in ConfirmDestinationModal
+  // — an unbounded pause on a 60-second invoice that no later reading can see
+  // (ENG-555). A `lightning:` deep link pre-fills the field the same way.
+  //
+  // Registration is idempotent and keyed by the bolt11 itself, so the amount
+  // and confirm screens' identical calls collapse into no-ops and the reading
+  // they use is this one. Only `valid === true` destinations reach this
+  // function, so a half-typed invoice never registers.
+  noteInvoiceFirstSight(paymentRequest, Math.floor(Date.now() / 1000))
 
   let createPaymentDetail
 

--- a/app/screens/send-bitcoin-screen/payment-details/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/index.types.ts
@@ -97,6 +97,13 @@ export type SetInvoice<T extends WalletCurrency> = (params: {
 
 type BasePaymentDetail<T extends WalletCurrency> = {
   memo?: string
+  /**
+   * The bolt11 this payment will settle, when one has been minted already.
+   * Present on invoice-backed details; absent for destinations that mint the
+   * invoice later (an LNURL detail only gains one via setInvoice). Callers
+   * must treat it as perishable — see invoice-expiry.ts.
+   */
+  paymentRequest?: string
   paymentType:
     | typeof PaymentType.Intraledger
     | typeof PaymentType.Onchain

--- a/app/screens/send-bitcoin-screen/payment-details/lightning.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/lightning.ts
@@ -481,6 +481,12 @@ export const createLnurlPaymentDetails = <T extends WalletCurrency>(
     unitOfAccountAmount,
     paymentType: PaymentType.Lnurl,
     destination: lnurl,
+    // The bolt11 minted for this send, once setInvoice has attached one.
+    // Surfaced because it perishes: IBEX caps these at 60s, so the confirm
+    // screen has to be able to tell whether the one it is holding is still
+    // alive (ENG-555). `destination` is the lightning address here, not the
+    // invoice, so it cannot answer that question.
+    paymentRequest,
     settlementAmount,
     memo,
     settlementAmountIsEstimated: sendingWalletDescriptor.currency !== WalletCurrency.Btc,

--- a/app/screens/send-bitcoin-screen/payment-details/lightning.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/lightning.ts
@@ -199,6 +199,11 @@ export const createNoAmountLightningPaymentDetails = <T extends WalletCurrency>(
 
   return {
     destination: paymentRequest,
+    // Same string as `destination` here, but named for what it is. The
+    // confirm screen checks the invoice's expiry before sending (ENG-555)
+    // and must not have to know which detail type stores the bolt11 where —
+    // an LNURL detail's `destination` is an address, not an invoice.
+    paymentRequest,
     memo,
     convertMoneyAmount,
     setConvertMoneyAmount,
@@ -342,6 +347,11 @@ export const createAmountLightningPaymentDetails = <T extends WalletCurrency>(
 
   return {
     destination: paymentRequest,
+    // Same string as `destination` here, but named for what it is. The
+    // confirm screen checks the invoice's expiry before sending (ENG-555)
+    // and must not have to know which detail type stores the bolt11 where —
+    // an LNURL detail's `destination` is an address, not an invoice.
+    paymentRequest,
     destinationSpecifiedAmount: paymentRequestAmount,
     convertMoneyAmount,
     memo,

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -18,6 +18,8 @@ import { PrimaryBtn } from "@app/components/buttons"
 // hooks
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 import { useSendPayment } from "./use-send-payment"
+import { decodeInvoiceString, Network as NetworkLibGaloy } from "@galoymoney/client"
+import { isInvoiceExpired } from "./invoice-expiry"
 import { useActivityIndicator, useBreez } from "@app/hooks"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 
@@ -191,8 +193,42 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
     }
   }, [flashUserAddress, npubByUsernameQuery, promptForContactList, contactsEvent])
 
+  // Held invoices perish: IBEX caps Flash receive invoices at 60 seconds, so
+  // an invoice minted when the user left the amount screen can easily be dead
+  // by the time they confirm — or on a retry after a first failure. Sending it
+  // anyway spends a round trip to come back as the generic "Something went
+  // wrong", which sends the user (and support) after the wrong cause. Read the
+  // expiry off the invoice itself rather than timing it locally, so a clock
+  // skew or a backgrounded app cannot fool it.
+  const heldInvoiceHasExpired = useCallback((): boolean => {
+    const paymentRequest = paymentDetail.paymentRequest
+    if (!paymentRequest) return false
+
+    try {
+      const { timeExpireDate } = decodeInvoiceString(
+        paymentRequest,
+        "mainnet" as NetworkLibGaloy,
+      )
+      return isInvoiceExpired({
+        timeExpireDate,
+        nowSeconds: Math.floor(Date.now() / 1000),
+      })
+    } catch {
+      // Undecodable: let the backend be the judge rather than blocking a
+      // send on a parsing quirk.
+      return false
+    }
+  }, [paymentDetail.paymentRequest])
+
   const handleSendPayment = useCallback(async () => {
     if (sendPayment && sendingWalletDescriptor?.currency) {
+      if (heldInvoiceHasExpired()) {
+        setPaymentError(LL.SendBitcoinConfirmationScreen.invoiceExpired())
+        ReactNativeHapticFeedback.trigger("notificationError", {
+          ignoreAndroidSystemSettings: true,
+        })
+        return
+      }
       console.log("Starting animation and sending payment")
       try {
         logPaymentAttempt({
@@ -242,7 +278,13 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
     } else {
       return null
     }
-  }, [paymentType, sendPayment, sendingWalletDescriptor?.currency])
+  }, [
+    paymentType,
+    sendPayment,
+    sendingWalletDescriptor?.currency,
+    heldInvoiceHasExpired,
+    LL,
+  ])
 
   return (
     <Screen preset="scroll" style={styles.screenStyle} keyboardOffset="navigationHeader">

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -229,7 +229,8 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
   // the Breez BTC wallet re-mints at send time on the LNURL/intraledger paths,
   // where a stale held invoice is irrelevant. The lifetime is read off the
   // invoice, which removes any dependence on when we *recorded* minting it,
-  // and the elapsed-since-mount reading removes any dependence on the device
+  // and the elapsed-since-first-sight reading (registered when the destination is
+  // parsed — payment-destination/lightning.ts) removes any dependence on the device
   // clock agreeing with the issuer's.
   const heldInvoiceHasExpired = useCallback(
     () =>

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -19,7 +19,7 @@ import { PrimaryBtn } from "@app/components/buttons"
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 import { useSendPayment } from "./use-send-payment"
 import { decodeInvoiceString, Network as NetworkLibGaloy } from "@galoymoney/client"
-import { isInvoiceExpired } from "./invoice-expiry"
+import { isHeldInvoiceExpired } from "./invoice-expiry"
 import { useActivityIndicator, useBreez } from "@app/hooks"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 
@@ -200,25 +200,16 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
   // wrong", which sends the user (and support) after the wrong cause. Read the
   // expiry off the invoice itself rather than timing it locally, so a clock
   // skew or a backgrounded app cannot fool it.
-  const heldInvoiceHasExpired = useCallback((): boolean => {
-    const paymentRequest = paymentDetail.paymentRequest
-    if (!paymentRequest) return false
-
-    try {
-      const { timeExpireDate } = decodeInvoiceString(
-        paymentRequest,
-        "mainnet" as NetworkLibGaloy,
-      )
-      return isInvoiceExpired({
-        timeExpireDate,
+  const heldInvoiceHasExpired = useCallback(
+    () =>
+      isHeldInvoiceExpired({
+        paymentRequest: paymentDetail.paymentRequest,
         nowSeconds: Math.floor(Date.now() / 1000),
-      })
-    } catch {
-      // Undecodable: let the backend be the judge rather than blocking a
-      // send on a parsing quirk.
-      return false
-    }
-  }, [paymentDetail.paymentRequest])
+        decode: (paymentRequest, network) =>
+          decodeInvoiceString(paymentRequest, network as NetworkLibGaloy),
+      }),
+    [paymentDetail.paymentRequest],
+  )
 
   const handleSendPayment = useCallback(async () => {
     if (sendPayment && sendingWalletDescriptor?.currency) {
@@ -310,7 +301,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
         <PrimaryBtn
           loading={sendPaymentLoading}
           label={LL.SendBitcoinConfirmationScreen.title()}
-          disabled={!isValidAmount || hasAttemptedSend || !!paymentError}
+          disabled={!isValidAmount || hasAttemptedSend || Boolean(paymentError)}
           onPress={handleSendPayment}
         />
       </View>

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -18,8 +18,12 @@ import { PrimaryBtn } from "@app/components/buttons"
 // hooks
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 import { useSendPayment } from "./use-send-payment"
-import { decodeInvoiceString, Network as NetworkLibGaloy } from "@galoymoney/client"
-import { isHeldInvoiceExpired } from "./invoice-expiry"
+import {
+  decodeInvoiceString,
+  Network as NetworkLibGaloy,
+  PaymentType,
+} from "@galoymoney/client"
+import { isHeldInvoiceExpired, willTransmitHeldInvoice } from "./invoice-expiry"
 import { useActivityIndicator, useBreez } from "@app/hooks"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 
@@ -197,24 +201,47 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
   // an invoice minted when the user left the amount screen can easily be dead
   // by the time they confirm — or on a retry after a first failure. Sending it
   // anyway spends a round trip to come back as the generic "Something went
-  // wrong", which sends the user (and support) after the wrong cause. Read the
-  // expiry off the invoice itself rather than timing it locally, so a clock
-  // skew or a backgrounded app cannot fool it.
+  // wrong", which sends the user (and support) after the wrong cause.
+  //
+  // Only checked when the held bolt11 is the one that will actually go out:
+  // the Breez BTC wallet re-mints at send time on the LNURL/intraledger paths,
+  // where a stale held invoice is irrelevant. The expiry is read off the
+  // invoice, which removes any dependence on when we *recorded* minting it —
+  // but `nowSeconds` is still the device clock, so isInvoiceExpired carries a
+  // skew grace and a past-dated-invoice detector to stay fail-open.
   const heldInvoiceHasExpired = useCallback(
     () =>
+      willTransmitHeldInvoice({
+        sendingWalletCurrency: sendingWalletDescriptor?.currency,
+        paymentType: paymentDetail.paymentType,
+      }) &&
       isHeldInvoiceExpired({
         paymentRequest: paymentDetail.paymentRequest,
         nowSeconds: Math.floor(Date.now() / 1000),
         decode: (paymentRequest, network) =>
           decodeInvoiceString(paymentRequest, network as NetworkLibGaloy),
       }),
-    [paymentDetail.paymentRequest],
+    [
+      paymentDetail.paymentRequest,
+      paymentDetail.paymentType,
+      sendingWalletDescriptor?.currency,
+    ],
   )
 
   const handleSendPayment = useCallback(async () => {
     if (sendPayment && sendingWalletDescriptor?.currency) {
       if (heldInvoiceHasExpired()) {
-        setPaymentError(LL.SendBitcoinConfirmationScreen.invoiceExpired())
+        // Only an LNURL send can honour "go back and get a fresh one" — the
+        // details screen re-mints on the way forward. A payee-minted bolt11
+        // (scanned or pasted) is fixed: going back and re-entering the amount
+        // returns the *same* invoice, and an amount-carrying invoice has no
+        // amount field to re-enter at all. Those users need a new invoice from
+        // whoever they are paying.
+        setPaymentError(
+          paymentDetail.paymentType === PaymentType.Lnurl
+            ? LL.SendBitcoinConfirmationScreen.invoiceExpired()
+            : LL.SendBitcoinDestinationScreen.expiredInvoice(),
+        )
         ReactNativeHapticFeedback.trigger("notificationError", {
           ignoreAndroidSystemSettings: true,
         })

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -23,7 +23,11 @@ import {
   Network as NetworkLibGaloy,
   PaymentType,
 } from "@galoymoney/client"
-import { isHeldInvoiceExpired, willTransmitHeldInvoice } from "./invoice-expiry"
+import {
+  isHeldInvoiceExpired,
+  noteInvoiceFirstSight,
+  willTransmitHeldInvoice,
+} from "./invoice-expiry"
 import { useActivityIndicator, useBreez } from "@app/hooks"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 
@@ -204,10 +208,16 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
   // The device clock as it read on the way into this screen — before the user
   // could have paused on it. `Date.now()` inside the guard is read off the
   // same clock, so the difference between the two is an elapsed duration that
-  // no clock offset can inflate. This is the guard's primary signal; see
-  // invoice-expiry.ts. `useRef` so it survives re-renders (fee updates, wallet
-  // text) and is captured exactly once per mount.
-  const firstSeenSeconds = useRef(Math.floor(Date.now() / 1000)).current
+
+  // Start the clock on this invoice as soon as the screen shows it, not when
+  // Confirm is tapped. Registering on tap would miss the user who simply sits
+  // here past the 60s lifetime and taps once — their first reading would be
+  // the tap itself, so no time would appear to have elapsed.
+  useEffect(() => {
+    if (paymentDetail.paymentRequest) {
+      noteInvoiceFirstSight(paymentDetail.paymentRequest, Math.floor(Date.now() / 1000))
+    }
+  }, [paymentDetail.paymentRequest])
 
   // Held invoices perish: IBEX caps Flash receive invoices at 60 seconds, so
   // an invoice minted when the user left the amount screen can easily be dead
@@ -230,7 +240,6 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
       isHeldInvoiceExpired({
         paymentRequest: paymentDetail.paymentRequest,
         nowSeconds: Math.floor(Date.now() / 1000),
-        firstSeenSeconds,
         decode: (paymentRequest, network) =>
           decodeInvoiceString(paymentRequest, network as NetworkLibGaloy),
       }),
@@ -238,7 +247,6 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
       paymentDetail.paymentRequest,
       paymentDetail.paymentType,
       sendingWalletDescriptor?.currency,
-      firstSeenSeconds,
     ],
   )
 
@@ -352,7 +360,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
         <PrimaryBtn
           loading={sendPaymentLoading}
           label={LL.SendBitcoinConfirmationScreen.title()}
-          disabled={!isValidAmount || hasAttemptedSend || !!paymentError}
+          disabled={!isValidAmount || hasAttemptedSend || Boolean(paymentError)}
           onPress={handleSendPayment}
         />
       </View>

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react"
+import React, { useCallback, useEffect, useState } from "react"
 import { View } from "react-native"
 import { makeStyles } from "@rneui/themed"
 import { useI18nContext } from "@app/i18n/i18n-react"
@@ -205,14 +205,14 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
     }
   }, [flashUserAddress, npubByUsernameQuery, promptForContactList, contactsEvent])
 
-  // The device clock as it read on the way into this screen — before the user
-  // could have paused on it. `Date.now()` inside the guard is read off the
-  // same clock, so the difference between the two is an elapsed duration that
-
   // Start the clock on this invoice as soon as the screen shows it, not when
   // Confirm is tapped. Registering on tap would miss the user who simply sits
   // here past the 60s lifetime and taps once — their first reading would be
   // the tap itself, so no time would appear to have elapsed.
+  //
+  // A no-op for a bolt11 the amount screen already registered (the reading is
+  // keyed by the invoice, and the first one wins); it earns its keep for the
+  // freshly minted LNURL invoice, whose first sighting really is here.
   useEffect(() => {
     if (paymentDetail.paymentRequest) {
       noteInvoiceFirstSight(paymentDetail.paymentRequest, Math.floor(Date.now() / 1000))

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react"
+import React, { useCallback, useEffect, useRef, useState } from "react"
 import { View } from "react-native"
 import { makeStyles } from "@rneui/themed"
 import { useI18nContext } from "@app/i18n/i18n-react"
@@ -48,7 +48,11 @@ import { FeeType } from "./use-fee"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
 
 // utils
-import { logPaymentAttempt, logPaymentResult } from "@app/utils/analytics"
+import {
+  logPaymentAttempt,
+  logPaymentBlockedExpiredInvoice,
+  logPaymentResult,
+} from "@app/utils/analytics"
 import { getCashWallet } from "@app/graphql/wallets-utils"
 import { useChatContext } from "../chat/chatContext"
 import { addToContactList } from "@app/utils/nostr"
@@ -197,6 +201,14 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
     }
   }, [flashUserAddress, npubByUsernameQuery, promptForContactList, contactsEvent])
 
+  // The device clock as it read on the way into this screen — before the user
+  // could have paused on it. `Date.now()` inside the guard is read off the
+  // same clock, so the difference between the two is an elapsed duration that
+  // no clock offset can inflate. This is the guard's primary signal; see
+  // invoice-expiry.ts. `useRef` so it survives re-renders (fee updates, wallet
+  // text) and is captured exactly once per mount.
+  const firstSeenSeconds = useRef(Math.floor(Date.now() / 1000)).current
+
   // Held invoices perish: IBEX caps Flash receive invoices at 60 seconds, so
   // an invoice minted when the user left the amount screen can easily be dead
   // by the time they confirm — or on a retry after a first failure. Sending it
@@ -205,10 +217,10 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
   //
   // Only checked when the held bolt11 is the one that will actually go out:
   // the Breez BTC wallet re-mints at send time on the LNURL/intraledger paths,
-  // where a stale held invoice is irrelevant. The expiry is read off the
-  // invoice, which removes any dependence on when we *recorded* minting it —
-  // but `nowSeconds` is still the device clock, so isInvoiceExpired carries a
-  // skew grace and a past-dated-invoice detector to stay fail-open.
+  // where a stale held invoice is irrelevant. The lifetime is read off the
+  // invoice, which removes any dependence on when we *recorded* minting it,
+  // and the elapsed-since-mount reading removes any dependence on the device
+  // clock agreeing with the issuer's.
   const heldInvoiceHasExpired = useCallback(
     () =>
       willTransmitHeldInvoice({
@@ -218,6 +230,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
       isHeldInvoiceExpired({
         paymentRequest: paymentDetail.paymentRequest,
         nowSeconds: Math.floor(Date.now() / 1000),
+        firstSeenSeconds,
         decode: (paymentRequest, network) =>
           decodeInvoiceString(paymentRequest, network as NetworkLibGaloy),
       }),
@@ -225,21 +238,32 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
       paymentDetail.paymentRequest,
       paymentDetail.paymentType,
       sendingWalletDescriptor?.currency,
+      firstSeenSeconds,
     ],
   )
 
   const handleSendPayment = useCallback(async () => {
     if (sendPayment && sendingWalletDescriptor?.currency) {
       if (heldInvoiceHasExpired()) {
-        // Only an LNURL send can honour "go back and get a fresh one" — the
-        // details screen re-mints on the way forward. A payee-minted bolt11
-        // (scanned or pasted) is fixed: going back and re-entering the amount
-        // returns the *same* invoice, and an amount-carrying invoice has no
-        // amount field to re-enter at all. Those users need a new invoice from
-        // whoever they are paying.
+        // A refusal here is the whole point of ENG-555, so it has to be
+        // countable: without an event the failure just changes shape from
+        // "Something went wrong" to "Confirm did nothing", and support is
+        // back where it started. Logged before the copy so the event fires
+        // whichever remedy the user is shown.
+        logPaymentBlockedExpiredInvoice({
+          paymentType: paymentDetail.paymentType,
+          sendingWallet: sendingWalletDescriptor.currency,
+        })
+        // Only an LNURL send can honour "go back and confirm again" — the
+        // details screen re-mints on every pass forward, no edit required
+        // (which matters for a fixed-amount LNURL such as a flashcard reload,
+        // where the amount field is disabled and there is nothing to change).
+        // A payee-minted bolt11 (scanned or pasted) is fixed: going back and
+        // forward returns the *same* invoice. Those users need a new invoice
+        // from whoever they are paying.
         setPaymentError(
           paymentDetail.paymentType === PaymentType.Lnurl
-            ? LL.SendBitcoinConfirmationScreen.invoiceExpired()
+            ? LL.SendBitcoinConfirmationScreen.heldInvoiceExpired()
             : LL.SendBitcoinDestinationScreen.expiredInvoice(),
         )
         ReactNativeHapticFeedback.trigger("notificationError", {
@@ -328,7 +352,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
         <PrimaryBtn
           loading={sendPaymentLoading}
           label={LL.SendBitcoinConfirmationScreen.title()}
-          disabled={!isValidAmount || hasAttemptedSend || Boolean(paymentError)}
+          disabled={!isValidAmount || hasAttemptedSend || !!paymentError}
           onPress={handleSendPayment}
         />
       </View>

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -156,19 +156,22 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
     zeroDisplayAmount,
   ])
 
-  // Start the clock on a held bolt11 here, where it enters the flow, not on
-  // the confirm screen. A scanned or pasted `lightning` destination is carried
-  // through this screen unchanged — nothing re-mints it — and the time spent
-  // here picking a wallet and typing an amount is unbounded, so a 60-second
-  // Flash invoice can easily die before Next is ever tapped (ENG-555). The
-  // confirm screen's own reading would start at its mount and see zero elapsed
-  // time, waving the corpse through.
+  // Backstop reading of the expiry clock, not the primary one. A scanned or
+  // pasted bolt11 has already been registered at parse time, one instant after
+  // it was certified alive (payment-destination/lightning.ts) — and that is
+  // the reading that matters, since the pause on the destination screen and in
+  // ConfirmDestinationModal happens before this screen ever mounts (ENG-555).
   //
-  // Registration is idempotent and keyed by the bolt11 itself, so the confirm
-  // screen's identical call becomes a no-op and the elapsed reading it uses
-  // spans this screen's pause too. LNURL details have no invoice until Next
-  // mints one, so nothing is recorded for them here — which is correct: their
-  // first sighting really is on the confirm screen.
+  // This call exists for anything holding a bolt11 that did not arrive through
+  // that path, and because the time spent HERE picking a wallet and typing an
+  // amount is itself unbounded, while the confirm screen's own reading starts
+  // at its mount and would see zero elapsed time.
+  //
+  // Registration is idempotent and keyed by the bolt11 itself, so both the
+  // parse-time reading and the confirm screen's identical call resolve to the
+  // earliest sighting. LNURL details have no invoice until Next mints one, so
+  // nothing is recorded for them here — which is correct: their first sighting
+  // really is on the confirm screen.
   useEffect(() => {
     if (paymentDetail?.paymentRequest) {
       noteInvoiceFirstSight(paymentDetail.paymentRequest, Math.floor(Date.now() / 1000))

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -52,6 +52,7 @@ import {
   toUsdMoneyAmount,
 } from "@app/types/amounts"
 import { isValidAmount } from "./payment-details"
+import { noteInvoiceFirstSight } from "./invoice-expiry"
 import { buildMaxAmountButton } from "./max-amount-button"
 import { MaxAmountButton } from "@app/components/amount-input-screen"
 import { requestInvoice, utils } from "lnurl-pay"
@@ -154,6 +155,25 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ navigation, route }) => {
     defaultWallet,
     zeroDisplayAmount,
   ])
+
+  // Start the clock on a held bolt11 here, where it enters the flow, not on
+  // the confirm screen. A scanned or pasted `lightning` destination is carried
+  // through this screen unchanged — nothing re-mints it — and the time spent
+  // here picking a wallet and typing an amount is unbounded, so a 60-second
+  // Flash invoice can easily die before Next is ever tapped (ENG-555). The
+  // confirm screen's own reading would start at its mount and see zero elapsed
+  // time, waving the corpse through.
+  //
+  // Registration is idempotent and keyed by the bolt11 itself, so the confirm
+  // screen's identical call becomes a no-op and the elapsed reading it uses
+  // spans this screen's pause too. LNURL details have no invoice until Next
+  // mints one, so nothing is recorded for them here — which is correct: their
+  // first sighting really is on the confirm screen.
+  useEffect(() => {
+    if (paymentDetail?.paymentRequest) {
+      noteInvoiceFirstSight(paymentDetail.paymentRequest, Math.floor(Date.now() / 1000))
+    }
+  }, [paymentDetail?.paymentRequest])
 
   // Resolve the receiver's LNURL-pay limits once per destination so the
   // amount can be validated as the user types (BTC wallet pays Flash

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -98,6 +98,27 @@ export const logPaymentAttempt = (params: LogPaymentAttemptParams) => {
   })
 }
 
+type LogPaymentBlockedExpiredInvoiceParams = {
+  paymentType: ParsedPaymentType
+  sendingWallet: WalletCurrency
+}
+
+/**
+ * The send flow refused to transmit an invoice it could see had already
+ * expired (ENG-555). Distinct from `payment_attempt`, which is not logged in
+ * that case because nothing is attempted — without this event a blocked send
+ * leaves no client trace and, since no request goes out, no server trace
+ * either, which is exactly the diagnosis dead-end the guard exists to end.
+ */
+export const logPaymentBlockedExpiredInvoice = (
+  params: LogPaymentBlockedExpiredInvoiceParams,
+) => {
+  getAnalytics().logEvent("payment_blocked_expired_invoice", {
+    payment_type: params.paymentType,
+    sending_wallet: params.sendingWallet,
+  })
+}
+
 type LogPaymentResultParams = {
   paymentType: ParsedPaymentType
   sendingWallet: WalletCurrency


### PR DESCRIPTION
Fixes ENG-555.

## The bug

Flash IBEX receive invoices live **60 seconds** — IBEX caps non-msat accounts there (`IBEX_RECEIVE_MAX_EXPIRATION_SECONDS`, ENG-427). Decoding the invoice from the incident confirms it:

```
issued  1787243982  2026-08-20T16:39:42Z
expires 1787244042  2026-08-20T16:40:42Z   → exactly 60s
```

The confirmation screen holds whatever invoice was minted when the user left the amount screen, and resubmits it on every tap. In the reported case the **identical** `paymentRequest` was sent twice, 19 minutes apart:

```
16:40:04Z  attempt 1 — 38s before expiry → genuinely inside the window
16:58:52Z  attempt 2 — ~18 min past expiry → could never have succeeded
```

Both rendered as the same generic "Something went wrong". Because the user changed the amount between them, the amount looked like the variable under test when it was irrelevant — the investigation went after the wrong cause for a full round.

## The fix

Check the held invoice's expiry before spending a round trip on a doomed send, and name what happened.

Design notes:

- **The check is scoped to invoices that actually get transmitted.** Most sends put the held bolt11 on the wire, but the Breez/Spark BTC wallet's LNURL and intraledger paths do not: `useSendPayment` routes those to `payLnurlBreez`, which re-resolves the lightning address and mints a brand-new invoice at send time. Refusing on a stale held invoice there would kill a payment Breez would have completed. `willTransmitHeldInvoice` gates the guard; BTC + `lightning` still qualifies, because `payLightningBreez` is handed the detail's `destination`, which *is* the held bolt11.
- **The message depends on who minted the invoice.** Only an LNURL send can honour "go back and get a fresh one" — the details screen re-mints on the way forward. A scanned or pasted bolt11 is fixed: `setAmount` returns the same invoice, and an amount-carrying invoice has no amount field to re-enter at all. Those users get the existing `SendBitcoinDestinationScreen.expiredInvoice` ("This invoice has expired. Please generate a new invoice.") instead.
- **Expiry is read off the invoice, but `now` is still the device clock.** Reading `timeExpireDate` off the bolt11 removes any dependence on when the app *recorded* minting it — it does **not** make the check clock-independent, and an earlier draft of this PR wrongly claimed it did. `Date.now()` is the device wall clock, so a naive `now >= timeExpireDate` fails **closed** on skew: a handset running two minutes fast would mark every freshly minted 60-second invoice dead on arrival and lock that user out of sending entirely, where the backend (validating against server time) would have accepted the payment. So the guard carries a **120-second skew grace** and a skew detector — a `now` that precedes the invoice's own `timestamp` proves the clock is behind and fails open. The incident's 18-minute-late retry is still caught with wide margin.
- **Undecodable invoices are allowed through.** The backend still rejects a genuinely dead one, so a false negative costs nothing beyond today's behavior — while a false positive would block a perfectly good payment. Failing open is the right direction *here*, unlike the MAX case in #702.
- `paymentRequest` is now surfaced on the payment detail. An LNURL detail's `destination` is the lightning address, not the bolt11, so the confirm screen previously had no way to inspect the invoice it was about to send.

## Tests

`__tests__/utils/invoice-expiry.spec.ts` pins the real timestamps from the incident — attempt 1 must **not** be flagged (it wasn't an expiry failure), attempt 2 must be — plus the grace boundary, the full 60-second window, a fast clock, a past-dated invoice, `willTransmitHeldInvoice` across every wallet/type pair, and the fail-open paths.

The wiring is covered for real rather than by inspecting source text: the three existing `__tests__/payment-details/*-payment-details.spec.ts` now assert `paymentRequest` is surfaced (including that an LNURL detail gains it only via `setInvoice`), and `__tests__/screens/send-confirmation.spec.tsx` renders the actual confirm screen, presses Confirm, and asserts which copy appears and whether the send fired — including a BTC + LNURL case that must **not** be blocked. Reverting either behavioural fix turns two of those red.

## Also in this PR (not ENG-555)

- **`TopupDetails.allowanceExhausted` i18n source-drift repair.** The key already existed in `app/i18n/en/index.ts` and `i18n-types.ts` and was missing only from `raw-i18n/source/en.json`. It is top-up copy with nothing to do with ENG-555, flagged here so a later bisect of top-up copy knows where to look.
- **Locale propagation.** `allowanceExhausted` and the new `invoiceExpired` are carried into all 23 files under `raw-i18n/translations` as the English string (the convention for untranslated keys here), which is what `yarn check:translation-drift` requires. Isolated in its own commit.
- **Firebase test mocks.** `__mocks__/@react-native-firebase/{analytics,crashlytics}` exported only the legacy default factory, but the send flow uses the modular `getAnalytics` / `getCrashlytics` — so under jest every logged event threw and swallowed the call it wrapped. Added the named exports.

## Follow-up (deliberately not here)

For LNURL sends the app could re-mint the invoice automatically instead of asking the user to go back. That needs the `requestInvoice` logic lifted out of `send-bitcoin-details-screen.tsx`, which is a refactor rather than a fix, so it's left separate.

## Related

#702 (ENG-554) — the MAX fee-reserve bug found alongside this. They compound: MAX proposes an unsendable amount, the send fails, the user retries against a now-expired invoice, and both failures look identical on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016MsAGwtS4sNodzWu2VMTKR
