### PR TITLE
fix(support): WhatsApp contact opens the real chat with the message attached

### DIFF
--- a/__tests__/components/contact-modal-whatsapp.spec.ts
+++ b/__tests__/components/contact-modal-whatsapp.spec.ts
@@ -1,9 +1,16 @@
 import { Linking } from "react-native"
+import Toast from "react-native-toast-message"
 
 import {
   buildWhatsAppSupportUrl,
   openWhatsAppAction,
 } from "../../app/components/contact-modal/contact-modal.logic"
+import { CONTACT_EMAIL_ADDRESS, WHATSAPP_SUPPORT_URL } from "../../app/config"
+import { loadAllLocales } from "../../app/i18n/i18n-util.sync"
+
+beforeAll(() => {
+  loadAllLocales()
+})
 
 describe("WhatsApp support action", () => {
   it("carries the message — the app/device context support triages from", () => {
@@ -35,5 +42,39 @@ describe("WhatsApp support action", () => {
     openWhatsAppAction("hi from tests")
     expect(spy).toHaveBeenCalledWith(buildWhatsAppSupportUrl("hi from tests"))
     spy.mockRestore()
+  })
+
+  it("surfaces an email-fallback toast instead of an unhandled rejection when the link cannot open", async () => {
+    // An Android device with no browser and no WhatsApp (managed/kiosk builds
+    // exist) rejects openURL with no activity to handle the intent. A button
+    // tap must never become an unhandled rejection — the user gets pointed at
+    // the email channel that still works.
+    const openSpy = jest
+      .spyOn(Linking, "openURL")
+      .mockRejectedValue(new Error("No Activity found to handle Intent"))
+    const toastSpy = jest.spyOn(Toast, "show").mockImplementation(() => {})
+
+    await expect(openWhatsAppAction("hi")).resolves.toBeUndefined()
+
+    expect(toastSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        text2: expect.stringContaining(CONTACT_EMAIL_ADDRESS),
+      }),
+    )
+    openSpy.mockRestore()
+    toastSpy.mockRestore()
+  })
+})
+
+describe("WHATSAPP_SUPPORT_URL (the shared support-button target)", () => {
+  it("targets the support number via wa.me, never the dead placeholder host", () => {
+    // Three support buttons (Bank Accounts, Need Help, Bank Transfer) open this
+    // constant directly. wa.flashapp.me has served a "support unavailable"
+    // placeholder card since the 2026-08 suspension — pointing here again would
+    // dead-end all of them (#703).
+    expect(WHATSAPP_SUPPORT_URL).toBe("https://wa.me/18762909250")
+    expect(WHATSAPP_SUPPORT_URL).not.toContain("wa.flashapp.me")
+    expect(WHATSAPP_SUPPORT_URL).not.toContain("+")
   })
 })

--- a/__tests__/components/contact-modal-whatsapp.spec.ts
+++ b/__tests__/components/contact-modal-whatsapp.spec.ts
@@ -1,0 +1,39 @@
+import { Linking } from "react-native"
+
+import {
+  buildWhatsAppSupportUrl,
+  openWhatsAppAction,
+} from "../../app/components/contact-modal/contact-modal.logic"
+
+describe("WhatsApp support action", () => {
+  it("carries the message — the app/device context support triages from", () => {
+    // The regression: openWhatsAppAction used to accept the message and drop
+    // it, opening a chat with no context (#703). If this fails, support is
+    // back to receiving "hi" with no version or device info.
+    const url = buildWhatsAppSupportUrl(
+      "Flash 0.6.8 (91) · Pixel 7 · account rewards_notifier",
+    )
+    expect(url).toContain("text=Flash%200.6.8%20(91)")
+    expect(decodeURIComponent(url)).toContain("account rewards_notifier")
+  })
+
+  it("targets the support number directly via wa.me, not the placeholder page", () => {
+    // wa.flashapp.me has served a "support unavailable" card since the 2026-08
+    // suspension — routing there delivered neither chat nor message. wa.me with
+    // the digits-only number opens the app when installed and a usable page
+    // when not; a literal "+" in the wa.me path 404s, and the whatsapp://
+    // scheme would reject with no handler installed.
+    const url = buildWhatsAppSupportUrl("hello")
+    expect(url).toMatch(/^https:\/\/wa\.me\/18762909250\?text=hello$/)
+    expect(url).not.toContain("wa.flashapp.me")
+    expect(url).not.toContain("+")
+  })
+
+  it("openWhatsAppAction opens exactly that URL", () => {
+    // Pins the wiring, not just the builder — the original bug WAS the wiring.
+    const spy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined)
+    openWhatsAppAction("hi from tests")
+    expect(spy).toHaveBeenCalledWith(buildWhatsAppSupportUrl("hi from tests"))
+    spy.mockRestore()
+  })
+})

--- a/__tests__/components/contact-modal.spec.tsx
+++ b/__tests__/components/contact-modal.spec.tsx
@@ -1,0 +1,47 @@
+import React from "react"
+import { Linking } from "react-native"
+
+import { act, fireEvent, render, screen } from "@testing-library/react-native"
+import { ContextForScreen } from "../screens/helper"
+
+import ContactModal from "../../app/components/contact-modal/contact-modal"
+import { buildWhatsAppSupportUrl } from "../../app/components/contact-modal/contact-modal.logic"
+import { loadAllLocales } from "../../app/i18n/i18n-util.sync"
+
+// TypesafeI18n renders nothing until translations are loaded; the app does
+// this at startup in app.tsx, so tests that assert on copy must do it too.
+beforeAll(() => {
+  loadAllLocales()
+})
+
+describe("ContactModal", () => {
+  it("pressing WhatsApp opens the support chat with the messageBody prefilled", async () => {
+    // Pins the component call site, not just the exported helper. #703's
+    // failure shape — the button handler and the message parting ways — can
+    // recur one level up: a refactor that calls openWhatsAppAction("") or
+    // drops messageBody at the call site would pass every logic-only test.
+    const openSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(undefined)
+    const toggleModal = jest.fn()
+    const messageBody = "Flash 0.6.8 (91) · Pixel 7 · account rewards_notifier"
+
+    render(
+      <ContextForScreen>
+        <ContactModal
+          isVisible={true}
+          toggleModal={toggleModal}
+          messageBody={messageBody}
+          messageSubject="Support request"
+        />
+      </ContextForScreen>,
+    )
+    await act(async () => {})
+
+    fireEvent.press(screen.getByText("WhatsApp"))
+    await act(async () => {})
+
+    expect(openSpy).toHaveBeenCalledTimes(1)
+    expect(openSpy).toHaveBeenCalledWith(buildWhatsAppSupportUrl(messageBody))
+    expect(toggleModal).toHaveBeenCalledTimes(1)
+    openSpy.mockRestore()
+  })
+})

--- a/app/components/app-update/app-update.tsx
+++ b/app/components/app-update/app-update.tsx
@@ -51,13 +51,10 @@ const useStyles = makeStyles(({ colors }) => ({
 
 const storeLink = () => (isIos ? APP_STORE_LINK : PLAY_STORE_LINK)
 
-// Local on purpose. The gate's other escape is Contact Support, and the shared
-// contact-modal helper points at wa.flashapp.me — which, verified 2026-08-19,
-// returns 200 with zero redirects and no wa.me anywhere: a static "WhatsApp
-// support is temporarily unavailable" page that discards `?text=`. A hard-
-// blocked user needs a channel that works and keeps the build number they
-// cannot look up themselves, so this one composes mail directly rather than
-// changing behavior for every other caller of the shared helper.
+// Local on purpose. Email is the right channel for the hard-block gate: the
+// message carries the build number the user cannot look up themselves, and
+// mail keeps it in a durable medium support can quote back, so this composes
+// mail directly instead of routing through the shared WhatsApp helper.
 const openSupportEmail = (subject: string, body: string) =>
   Linking.openURL(
     `mailto:${CONTACT_EMAIL_ADDRESS}?subject=${encodeURIComponent(

--- a/app/components/contact-modal/contact-modal.logic.ts
+++ b/app/components/contact-modal/contact-modal.logic.ts
@@ -1,4 +1,4 @@
-import { CONTACT_EMAIL_ADDRESS, WHATSAPP_CONTACT_NUMBER } from "@app/config"
+import { CONTACT_EMAIL_ADDRESS, WHATSAPP_SUPPORT_URL } from "@app/config"
 import { openWhatsAppUrl } from "@app/utils/external"
 import { toastShow } from "@app/utils/toast"
 import type { TranslationFunctions } from "@app/i18n/i18n-types"
@@ -13,16 +13,17 @@ import type { TranslationFunctions } from "@app/i18n/i18n-types"
  * placeholder page, so the button delivered neither the chat nor the context
  * (#703).
  *
- * `wa.me` rather than the `whatsapp://` scheme deliberately: the scheme
- * rejects when WhatsApp is not installed (an unhandled rejection out of a
- * button handler), while the universal link opens the app when present and
- * falls back to a browser page that offers the chat. wa.me requires the number
- * digits-only — a literal `+` in the path 404s.
+ * Built on WHATSAPP_SUPPORT_URL — the same constant the three direct support
+ * buttons (Bank Accounts, Need Help, Bank Transfer) open — so there is exactly
+ * one derivation of the wa.me target. That constant already encodes the two
+ * load-bearing choices: `wa.me` rather than the `whatsapp://` scheme (the
+ * scheme rejects when WhatsApp is not installed — an unhandled rejection out
+ * of a button handler — while the universal link opens the app when present
+ * and falls back to a browser page that offers the chat), and the number
+ * digits-only (a literal `+` in the wa.me path 404s).
  */
-export const buildWhatsAppSupportUrl = (message: string): string => {
-  const number = WHATSAPP_CONTACT_NUMBER.replace(/[^0-9]/g, "")
-  return `https://wa.me/${number}?text=${encodeURIComponent(message)}`
-}
+export const buildWhatsAppSupportUrl = (message: string): string =>
+  `${WHATSAPP_SUPPORT_URL}?text=${encodeURIComponent(message)}`
 
 // Even a universal link can fail to open — an Android device with no browser
 // and no WhatsApp (managed/kiosk builds exist) rejects with no activity to

--- a/app/components/contact-modal/contact-modal.logic.ts
+++ b/app/components/contact-modal/contact-modal.logic.ts
@@ -1,6 +1,7 @@
 import { CONTACT_EMAIL_ADDRESS, WHATSAPP_CONTACT_NUMBER } from "@app/config"
 import { openWhatsAppUrl } from "@app/utils/external"
 import { toastShow } from "@app/utils/toast"
+import type { TranslationFunctions } from "@app/i18n/i18n-types"
 
 /**
  * The support chat URL with the message prefilled.
@@ -27,10 +28,19 @@ export const buildWhatsAppSupportUrl = (message: string): string => {
 // and no WhatsApp (managed/kiosk builds exist) rejects with no activity to
 // handle the intent. Catch it so a button tap never becomes an unhandled
 // rejection, and point the user at the email channel that still works.
-export const openWhatsAppAction = (message: string) =>
+//
+// `currentTranslation` follows the repo convention (near-universal at
+// toastShow call sites): without it the toast falls back to English for
+// every locale — and this one fires precisely for a user whose support
+// attempt just failed, the worst moment to switch languages on them.
+export const openWhatsAppAction = (
+  message: string,
+  currentTranslation?: TranslationFunctions,
+) =>
   openWhatsAppUrl(buildWhatsAppSupportUrl(message)).catch(() =>
     toastShow({
       message: (translations) =>
         translations.support.whatsappOpenFailed({ email: CONTACT_EMAIL_ADDRESS }),
+      currentTranslation,
     }),
   )

--- a/app/components/contact-modal/contact-modal.logic.ts
+++ b/app/components/contact-modal/contact-modal.logic.ts
@@ -1,15 +1,16 @@
-import { WHATSAPP_CONTACT_NUMBER } from "@app/config"
+import { CONTACT_EMAIL_ADDRESS, WHATSAPP_CONTACT_NUMBER } from "@app/config"
 import { openWhatsAppUrl } from "@app/utils/external"
+import { toastShow } from "@app/utils/toast"
 
 /**
  * The support chat URL with the message prefilled.
  *
  * The message is the whole point: callers pass app version and device context
  * so support starts triage with facts instead of "hi". openWhatsAppAction used
- * to accept it and drop it — and worse, it routed through WHATSAPP_SUPPORT_URL
- * (wa.flashapp.me), which since the 2026-08 account suspension serves a
- * "support unavailable" placeholder page, so the button delivered neither the
- * chat nor the context (#703).
+ * to accept it and drop it — and worse, it routed through wa.flashapp.me,
+ * which since the 2026-08 account suspension serves a "support unavailable"
+ * placeholder page, so the button delivered neither the chat nor the context
+ * (#703).
  *
  * `wa.me` rather than the `whatsapp://` scheme deliberately: the scheme
  * rejects when WhatsApp is not installed (an unhandled rejection out of a
@@ -22,5 +23,14 @@ export const buildWhatsAppSupportUrl = (message: string): string => {
   return `https://wa.me/${number}?text=${encodeURIComponent(message)}`
 }
 
+// Even a universal link can fail to open — an Android device with no browser
+// and no WhatsApp (managed/kiosk builds exist) rejects with no activity to
+// handle the intent. Catch it so a button tap never becomes an unhandled
+// rejection, and point the user at the email channel that still works.
 export const openWhatsAppAction = (message: string) =>
-  openWhatsAppUrl(buildWhatsAppSupportUrl(message))
+  openWhatsAppUrl(buildWhatsAppSupportUrl(message)).catch(() =>
+    toastShow({
+      message: (translations) =>
+        translations.support.whatsappOpenFailed({ email: CONTACT_EMAIL_ADDRESS }),
+    }),
+  )

--- a/app/components/contact-modal/contact-modal.logic.ts
+++ b/app/components/contact-modal/contact-modal.logic.ts
@@ -1,0 +1,26 @@
+import { WHATSAPP_CONTACT_NUMBER } from "@app/config"
+import { openWhatsAppUrl } from "@app/utils/external"
+
+/**
+ * The support chat URL with the message prefilled.
+ *
+ * The message is the whole point: callers pass app version and device context
+ * so support starts triage with facts instead of "hi". openWhatsAppAction used
+ * to accept it and drop it — and worse, it routed through WHATSAPP_SUPPORT_URL
+ * (wa.flashapp.me), which since the 2026-08 account suspension serves a
+ * "support unavailable" placeholder page, so the button delivered neither the
+ * chat nor the context (#703).
+ *
+ * `wa.me` rather than the `whatsapp://` scheme deliberately: the scheme
+ * rejects when WhatsApp is not installed (an unhandled rejection out of a
+ * button handler), while the universal link opens the app when present and
+ * falls back to a browser page that offers the chat. wa.me requires the number
+ * digits-only — a literal `+` in the path 404s.
+ */
+export const buildWhatsAppSupportUrl = (message: string): string => {
+  const number = WHATSAPP_CONTACT_NUMBER.replace(/[^0-9]/g, "")
+  return `https://wa.me/${number}?text=${encodeURIComponent(message)}`
+}
+
+export const openWhatsAppAction = (message: string) =>
+  openWhatsAppUrl(buildWhatsAppSupportUrl(message))

--- a/app/components/contact-modal/contact-modal.tsx
+++ b/app/components/contact-modal/contact-modal.tsx
@@ -2,15 +2,14 @@ import React from "react"
 import { Linking } from "react-native"
 import ReactNativeModal from "react-native-modal"
 
-import { CONTACT_EMAIL_ADDRESS, WHATSAPP_SUPPORT_URL } from "@app/config"
+import { CONTACT_EMAIL_ADDRESS } from "@app/config"
 import { useI18nContext } from "@app/i18n/i18n-react"
-import { openWhatsApp, openWhatsAppUrl } from "@app/utils/external"
+import { openWhatsAppAction } from "./contact-modal.logic"
 import { Icon, ListItem, makeStyles, useTheme } from "@rneui/themed"
-
 
 export const SupportChannels = {
   Email: "email",
- // Telegram: "telegram",
+  // Telegram: "telegram",
   Discord: "discord",
   WhatsApp: "whatsapp",
   StatusPage: "statusPage",
@@ -68,9 +67,9 @@ const ContactModal: React.FC<Props> = ({
       },
       hidden: supportChannelsToHide?.includes(SupportChannels.StatusPage),
     },
-    //name: LL.support.telegram(),
-    //icon: <TelegramOutline width={24} height={24} fill={colors.black} />,
-    //name: LL.support.Discord(),
+    // name: LL.support.telegram(),
+    // icon: <TelegramOutline width={24} height={24} fill={colors.black} />,
+    // name: LL.support.Discord(),
     {
       name: LL.support.discord(),
       icon: <Icon name={"logo-discord"} type="ionicon" color={colors.black} />,
@@ -143,9 +142,7 @@ const ContactModal: React.FC<Props> = ({
 
 export default ContactModal
 
-export const openWhatsAppAction = (message: string) => {
-  openWhatsAppUrl(WHATSAPP_SUPPORT_URL)
-}
+export { openWhatsAppAction } from "./contact-modal.logic"
 
 const useStyles = makeStyles(({ colors }) => ({
   modal: {

--- a/app/components/contact-modal/contact-modal.tsx
+++ b/app/components/contact-modal/contact-modal.tsx
@@ -142,8 +142,6 @@ const ContactModal: React.FC<Props> = ({
 
 export default ContactModal
 
-export { openWhatsAppAction } from "./contact-modal.logic"
-
 const useStyles = makeStyles(({ colors }) => ({
   modal: {
     justifyContent: "flex-end",

--- a/app/components/contact-modal/contact-modal.tsx
+++ b/app/components/contact-modal/contact-modal.tsx
@@ -92,7 +92,7 @@ const ContactModal: React.FC<Props> = ({
       name: LL.support.whatsapp(),
       icon: <Icon name={"logo-whatsapp"} type="ionicon" color={colors.black} />,
       action: () => {
-        openWhatsAppAction(messageBody)
+        openWhatsAppAction(messageBody, LL)
         toggleModal()
       },
       hidden: supportChannelsToHide?.includes(SupportChannels.WhatsApp),

--- a/app/config/appinfo.ts
+++ b/app/config/appinfo.ts
@@ -32,7 +32,14 @@ export const normalizeSupportChatPubkey = (raw: string | undefined): string => {
 export const SUPPORT_CHAT_PUBKEY = normalizeSupportChatPubkey(Config.SUPPORT_CHAT_PUBKEY)
 
 export const WHATSAPP_CONTACT_NUMBER = "+18762909250"
-export const WHATSAPP_SUPPORT_URL = "https://wa.flashapp.me"
+// Derived from the support number, not wa.flashapp.me: that host has served a
+// static "WhatsApp support is temporarily unavailable" placeholder since the
+// 2026-08 account suspension (#703), dead-ending every button that opened it.
+// wa.me requires the number digits-only — a literal "+" in the path 404s.
+export const WHATSAPP_SUPPORT_URL = `https://wa.me/${WHATSAPP_CONTACT_NUMBER.replace(
+  /\D/g,
+  "",
+)}`
 export const CONTACT_EMAIL_ADDRESS = "support@getflash.io"
 export const APP_STORE_LINK =
   "https://apps.apple.com/jm/app/flash-send-spend-and-save/id6451129095"

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -1714,6 +1714,7 @@ const en: BaseTranslation = {
       "In-app chat isn't available on this device yet. You can reach support by email instead.",
     joinTheCommunity: "Join the community",
     whatsapp: "WhatsApp",
+    whatsappOpenFailed: "Couldn't open WhatsApp. Please email {email: string} instead.",
     email: "Email",
     enjoyingApp: "Enjoying the app?",
     statusPage: "Status Page",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -5586,6 +5586,11 @@ type RootTranslation = {
 		 */
 		whatsapp: string
 		/**
+		 * C​o​u​l​d​n​'​t​ ​o​p​e​n​ ​W​h​a​t​s​A​p​p​.​ ​P​l​e​a​s​e​ ​e​m​a​i​l​ ​{​e​m​a​i​l​}​ ​i​n​s​t​e​a​d​.
+		 * @param {string} email
+		 */
+		whatsappOpenFailed: RequiredParams<'email'>
+		/**
 		 * E​m​a​i​l
 		 */
 		email: string
@@ -11856,6 +11861,10 @@ export type TranslationFunctions = {
 		 * WhatsApp
 		 */
 		whatsapp: () => LocalizedString
+		/**
+		 * Couldn't open WhatsApp. Please email {email} instead.
+		 */
+		whatsappOpenFailed: (arg: { email: string }) => LocalizedString
 		/**
 		 * Email
 		 */

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -1568,6 +1568,7 @@
         "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
         "joinTheCommunity": "Join the community",
         "whatsapp": "WhatsApp",
+        "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email: string} instead.",
         "email": "Email",
         "enjoyingApp": "Enjoying the app?",
         "statusPage": "Status Page",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -1170,6 +1170,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Sluit aan by die gemeenskap",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "E-pos",
     "enjoyingApp": "Geniet jy die toep?",
     "statusPage": "Statusbladsy",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -1112,6 +1112,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Join the community",
     "whatsapp": "واتساب",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "البريد الالكتروني",
     "statusPage": "Status Page",
     "telegram": "Telegram",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Join the community",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "Correu electrònic",
     "enjoyingApp": "Disfrutant de l'aplicació?",
     "statusPage": "Pàgina d'estat",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Připojte se ke komunitě",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "Email",
     "enjoyingApp": "Líbí se vám aplikace?",
     "statusPage": "Stav",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Bliv en del af fællesskabet",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "Email",
     "enjoyingApp": "Er du glad for at bruge appen?",
     "statusPage": "Statusside",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Tritt der Community bei",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "Email",
     "enjoyingApp": "Genießen Sie die App?",
     "statusPage": "Status-Seite",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Γίνετε μέλος της κοινότητας",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "Email",
     "enjoyingApp": "Σας αρέσει η εφαρμογή;",
     "statusPage": "Σελίδα Κατάστασης",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Unete a la comunidad",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "Correo electrónico",
     "enjoyingApp": "¿Disfrutas de la aplicación?",
     "statusPage": "Página de Estado",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Rejoindre la communauté",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "E-mail",
     "enjoyingApp": "Vous appréciez l'application?",
     "statusPage": "Page de configuration",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Join the community",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "Email",
     "enjoyingApp": "Uživate li u aplikaciji?",
     "statusPage": "Stranica statusa",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Csatlakozz a közösséghez",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "Email",
     "enjoyingApp": "Tetszik az alkalmazás?",
     "statusPage": "Állapotoldal",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Միանալ համայնքին",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "էլ․ հասցե",
     "enjoyingApp": "Հավանու՞մ եք հավելվածը։ ",
     "statusPage": "Status Page",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Join the community",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "Email",
     "enjoyingApp": "Godetevi l'app?",
     "statusPage": "Status Page",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Jadi sebahagian daripada komuniti",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "Emel",
     "enjoyingApp": "Menikmati aplikasi?",
     "statusPage": "Status Halaman",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Join the community",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "Email",
     "enjoyingApp": "Geniet u van de app?",
     "statusPage": "Status Pagina",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Join the community",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "E-mail",
     "enjoyingApp": "Desfrutando do aplicativo?",
     "statusPage": "Página de estado",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Join the community",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "Chaskiwi",
     "enjoyingApp": "¿Pipis chay appamanta kusikunkichu?",
     "statusPage": "P'anqakuna Yupaychay",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Join the community",
     "whatsapp": "„WhatsApp“",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "Е-пошта",
     "enjoyingApp": "Уживаш ли у апликацији?",
     "statusPage": "Страница стања",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -1112,6 +1112,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Join the community",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "Barua pepe",
     "statusPage": "Status Page",
     "telegram": "Telegram",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Join the community",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "อีเมล",
     "enjoyingApp": "เพลิดเพลินกับแอพลิเคชั่นเหรอ?",
     "statusPage": "Status Page",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Topluluğa katılın",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "E-posta",
     "enjoyingApp": "Uygulamayı beğendiniz mi?",
     "statusPage": "Durum Sayfası",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Join the community",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "Email",
     "enjoyingApp": "Bạn đang tận hưởng ứng dụng?",
     "statusPage": "Status Page",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -1334,6 +1334,7 @@
     "chatUnavailableMessage": "In-app chat isn't available on this device yet. You can reach support by email instead.",
     "joinTheCommunity": "Join the community",
     "whatsapp": "WhatsApp",
+    "whatsappOpenFailed": "Couldn't open WhatsApp. Please email {email} instead.",
     "email": "Email",
     "enjoyingApp": "Ngaba uyayonwabela le app?",
     "statusPage": "Status Page",

--- a/app/utils/external.ts
+++ b/app/utils/external.ts
@@ -1,14 +1,4 @@
 import { Linking } from "react-native"
 
-export const openWhatsApp: (number: string, message: string) => Promise<void> = async (
-  number: string,
-  message: string,
-) =>
-  Linking.openURL(
-    `whatsapp://send?phone=${encodeURIComponent(number)}&text=${encodeURIComponent(
-      message,
-    )}`,
-  )
-
 export const openWhatsAppUrl: (url: string) => Promise<void> = async (url: string) =>
   Linking.openURL(url)


### PR DESCRIPTION
Fixes #703 — and the bug on the ground is worse than the issue describes.

## What the button actually did

`openWhatsAppAction(message)` accepted the message and **dropped it** (#703's finding). But the URL it opened, `wa.flashapp.me`, has served a **"WhatsApp support is temporarily unavailable" placeholder card since the 2026-08 account suspension** — verified by fetching it. So the button delivered neither the chat *nor* the message: every user tapping "WhatsApp" dead-ended at a page telling them to email instead, while the restored support number sat reachable.

## The fix

Build `https://wa.me/<digits>?text=<message>` from `WHATSAPP_CONTACT_NUMBER` (routing decision confirmed with Jabari — inbound goes to the handset).

Two deliberate details:
- **`wa.me` over the `whatsapp://` scheme** — the scheme rejects when WhatsApp isn't installed (an unhandled rejection out of a button handler); the universal link opens the app when present and degrades to a browser page.
- **Digits-only number** — a literal `+` in the `wa.me` path 404s.

## Structure

Logic extracted to `contact-modal.logic.ts` (the existing `app-update.logic` pattern) so it's testable without dragging the component tree through jest; the component re-exports it, so no caller changes.

## Tests

Three, and the third is the one that matters: the message surviving into the URL, the `wa.me` target (not the placeholder host, no `+`), and **`openWhatsAppAction` opening exactly the built URL** — the original bug *was* the wiring, and a builder-only test would have passed with the bug present.

88 suites / 864 tests green; tsc + eslint clean.