### PR TITLE
fix(send): disclose when the network fee is deducted from the amount

### DIFF
--- a/__tests__/components/fee-from-amount.spec.ts
+++ b/__tests__/components/fee-from-amount.spec.ts
@@ -1,0 +1,56 @@
+import { WalletCurrency } from "../../app/graphql/generated"
+import { shouldDiscloseFeeFromAmount } from "../../app/components/send-flow/fee-from-amount.logic"
+
+const base = {
+  paymentType: "lightning",
+  sendingWalletCurrency: WalletCurrency.Usd,
+  feeStatus: "set" as const,
+  feeAmount: 0,
+}
+
+describe("shouldDiscloseFeeFromAmount", () => {
+  it("discloses on the repro: external USD send, probed fee of zero", () => {
+    // #694: $1.10 sent, "$0.00" fee displayed, $1.07 delivered. The probed
+    // zero is the untrustworthy case — IBEX deducts the real routing fee from
+    // the amount on these routes and its pre-send estimate says nothing.
+    expect(shouldDiscloseFeeFromAmount(base)).toBe(true)
+    expect(
+      shouldDiscloseFeeFromAmount({
+        ...base,
+        sendingWalletCurrency: WalletCurrency.Usdt,
+      }),
+    ).toBe(true)
+  })
+
+  it("stays silent when the probe returned a real nonzero fee", () => {
+    // A priced fee is already on screen; the caveat would dilute it.
+    expect(shouldDiscloseFeeFromAmount({ ...base, feeAmount: 3 })).toBe(false)
+  })
+
+  it("stays silent on intraledger — free is TRUE there, and crying wolf teaches users to ignore the caveat", () => {
+    expect(shouldDiscloseFeeFromAmount({ ...base, paymentType: "intraledger" })).toBe(
+      false,
+    )
+  })
+
+  it("stays silent for BTC-wallet sends — their probes price the actual route", () => {
+    // A zero from the BTC fee probe means a genuinely free route (e.g. direct
+    // channel), not an IBEX shrug.
+    expect(
+      shouldDiscloseFeeFromAmount({
+        ...base,
+        sendingWalletCurrency: WalletCurrency.Btc,
+      }),
+    ).toBe(false)
+  })
+
+  it("stays silent while loading/error/unset — those states carry their own caveats", () => {
+    for (const feeStatus of ["loading", "error", "unset"] as const) {
+      expect(shouldDiscloseFeeFromAmount({ ...base, feeStatus })).toBe(false)
+    }
+  })
+
+  it("stays silent when the amount is undefined — that is the error path, not a probed zero", () => {
+    expect(shouldDiscloseFeeFromAmount({ ...base, feeAmount: undefined })).toBe(false)
+  })
+})

--- a/__tests__/components/fee-from-amount.spec.ts
+++ b/__tests__/components/fee-from-amount.spec.ts
@@ -1,5 +1,6 @@
 import { PaymentType } from "@galoymoney/client"
 
+import { GALOY_INSTANCES } from "@app/config"
 import { WalletCurrency } from "../../app/graphql/generated"
 import {
   payeeNodePubkey,
@@ -13,6 +14,15 @@ const FLASH_TEST_INVOICE =
   "lnbc14060n1p4gclcjpp555k59jc4xn0x3mej3gzmuj7lg66u0rtkq73vtvwqtrmd8luemprqdpvvejk2ttswfhkyefqwejhy6txd93kzarfdahzqgek8y6qcqzzsxqzpusp5rprrqnqhclwmc7au9vqf306mg6wndelar076yu6f8nr7md6kzv9q9qxpqysgqnpc09nfh90rew3z7d06pu3056nu24e809j5sj6qn0ytquu252h0sp2dkd6gc3qudwduecfvxw7m6vlt6mc0s3seqv0nvet4u9xpq6wsqfhuttw"
 const FLASH_TEST_NODE_PUBKEY =
   "02004d8933df4f002fa95d8c37ca43eb9c175d310aad55cc6d442e4accc3740029"
+
+// A real bolt11 minted live on PROD (Main) 2026-08-24 via the LNURL-pay
+// callback (21-sat receive invoice, long expired — expiry is irrelevant to
+// decoding). Its payee is IBEX_Ops1, the node prod mints from. Five prod
+// invoices across two accounts and four amounts all decoded to this one node.
+const FLASH_MAIN_INVOICE =
+  "lnbc210n1p4gepdqpp55t3rkvgg6ng47c0dn0qkfscld09y36fa5khnmntclu227t542u4shp5lg2dp2w8957pyf6p38kufsyjxclwzc9kyg5ysp68er2fc4rpmpwqcqzzsxqzpusp5958p7zlqhexkeh0326fr3rjtahg5a3ffzeszk93yku6x6smq6r0s9qxpqysgq89pkzd8c94jv9sckdwjce78q0qzdlgnukljkpq8pptruexhhwl8ndypwde5k87zummne4ze7pcvug2ampawzzpajsmsdhsw5t0ztnyspvlk2w2"
+const FLASH_MAIN_NODE_PUBKEY =
+  "03501a74753e0f6ae270a1e4e2ffbbc37f7a796360e650c1121c18e116b22ac106"
 
 const base = {
   paymentType: PaymentType.Lightning,
@@ -90,12 +100,11 @@ describe("shouldDiscloseFeeFromAmount", () => {
     ).toBe(false)
   })
 
-  it("still discloses when the payee is some other node", () => {
+  it("still discloses when the payee is some other node (another instance's, even)", () => {
     expect(
       shouldDiscloseFeeFromAmount({
         ...base,
-        destinationPayeePubkey:
-          "03501a74753e0f6ae270a1e4e2ffbbc37f7a796360e650c1121c18e116b22ac106",
+        destinationPayeePubkey: FLASH_MAIN_NODE_PUBKEY,
         flashNodePubkeys: [FLASH_TEST_NODE_PUBKEY],
       }),
     ).toBe(true)
@@ -125,6 +134,36 @@ describe("shouldDiscloseFeeFromAmount", () => {
         flashNodePubkeys: undefined,
       }),
     ).toBe(true)
+  })
+})
+
+describe("Main instance suppression — live on prod, not just in test config", () => {
+  // Round-2 review finding: Main shipped with lnNodePubkeys: [], which made
+  // the Flash-to-Flash suppression inert on the only instance users run —
+  // every prod Flash-to-Flash payment showed the caveat on a full-amount
+  // transfer. This suite fails if Main's pin ever regresses to empty or
+  // drifts from what prod invoices actually decode to.
+  const mainInstance = GALOY_INSTANCES.find((instance) => instance.id === "Main")
+
+  it("decodes the real prod invoice to the pinned Main node", () => {
+    expect(payeeNodePubkey(FLASH_MAIN_INVOICE)).toBe(FLASH_MAIN_NODE_PUBKEY)
+  })
+
+  it("Main pins a non-empty lnNodePubkeys list containing the prod node", () => {
+    expect(mainInstance?.lnNodePubkeys).toContain(FLASH_MAIN_NODE_PUBKEY)
+    mainInstance?.lnNodePubkeys?.forEach((pubkey) =>
+      expect(pubkey).toMatch(/^0[23][0-9a-f]{64}$/),
+    )
+  })
+
+  it("suppresses the caveat for a prod Flash-to-Flash invoice end to end", () => {
+    expect(
+      shouldDiscloseFeeFromAmount({
+        ...base,
+        destinationPayeePubkey: payeeNodePubkey(FLASH_MAIN_INVOICE),
+        flashNodePubkeys: mainInstance?.lnNodePubkeys,
+      }),
+    ).toBe(false)
   })
 })
 

--- a/__tests__/components/fee-from-amount.spec.ts
+++ b/__tests__/components/fee-from-amount.spec.ts
@@ -1,8 +1,21 @@
+import { PaymentType } from "@galoymoney/client"
+
 import { WalletCurrency } from "../../app/graphql/generated"
-import { shouldDiscloseFeeFromAmount } from "../../app/components/send-flow/fee-from-amount.logic"
+import {
+  payeeNodePubkey,
+  shouldDiscloseFeeFromAmount,
+} from "../../app/components/send-flow/fee-from-amount.logic"
+
+// A real bolt11 minted by the Test instance (2026-08-24, $1.10 USD receive
+// invoice, long expired — expiry is irrelevant to decoding). Its payee is the
+// instance's node (IBEX_SB), the pubkey pinned in galoy-instances.ts.
+const FLASH_TEST_INVOICE =
+  "lnbc14060n1p4gclcjpp555k59jc4xn0x3mej3gzmuj7lg66u0rtkq73vtvwqtrmd8luemprqdpvvejk2ttswfhkyefqwejhy6txd93kzarfdahzqgek8y6qcqzzsxqzpusp5rprrqnqhclwmc7au9vqf306mg6wndelar076yu6f8nr7md6kzv9q9qxpqysgqnpc09nfh90rew3z7d06pu3056nu24e809j5sj6qn0ytquu252h0sp2dkd6gc3qudwduecfvxw7m6vlt6mc0s3seqv0nvet4u9xpq6wsqfhuttw"
+const FLASH_TEST_NODE_PUBKEY =
+  "02004d8933df4f002fa95d8c37ca43eb9c175d310aad55cc6d442e4accc3740029"
 
 const base = {
-  paymentType: "lightning",
+  paymentType: PaymentType.Lightning,
   sendingWalletCurrency: WalletCurrency.Usd,
   feeStatus: "set" as const,
   feeAmount: 0,
@@ -28,9 +41,9 @@ describe("shouldDiscloseFeeFromAmount", () => {
   })
 
   it("stays silent on intraledger — free is TRUE there, and crying wolf teaches users to ignore the caveat", () => {
-    expect(shouldDiscloseFeeFromAmount({ ...base, paymentType: "intraledger" })).toBe(
-      false,
-    )
+    expect(
+      shouldDiscloseFeeFromAmount({ ...base, paymentType: PaymentType.Intraledger }),
+    ).toBe(false)
   })
 
   it("stays silent for BTC-wallet sends — their probes price the actual route", () => {
@@ -52,5 +65,78 @@ describe("shouldDiscloseFeeFromAmount", () => {
 
   it("stays silent when the amount is undefined — that is the error path, not a probed zero", () => {
     expect(shouldDiscloseFeeFromAmount({ ...base, feeAmount: undefined })).toBe(false)
+  })
+
+  it("stays silent when the invoice pays this instance's own node — Flash-to-Flash delivery is full-amount", () => {
+    // Verified 2026-08-24: probing a Flash-internal invoice returns a SET
+    // zero, so without this exclusion the caveat would fire on every
+    // Flash-to-Flash invoice payment — crying wolf on the most common send.
+    expect(
+      shouldDiscloseFeeFromAmount({
+        ...base,
+        destinationPayeePubkey: FLASH_TEST_NODE_PUBKEY,
+        flashNodePubkeys: [FLASH_TEST_NODE_PUBKEY],
+      }),
+    ).toBe(false)
+  })
+
+  it("matches node pubkeys case-insensitively", () => {
+    expect(
+      shouldDiscloseFeeFromAmount({
+        ...base,
+        destinationPayeePubkey: FLASH_TEST_NODE_PUBKEY.toUpperCase(),
+        flashNodePubkeys: [FLASH_TEST_NODE_PUBKEY],
+      }),
+    ).toBe(false)
+  })
+
+  it("still discloses when the payee is some other node", () => {
+    expect(
+      shouldDiscloseFeeFromAmount({
+        ...base,
+        destinationPayeePubkey:
+          "03501a74753e0f6ae270a1e4e2ffbbc37f7a796360e650c1121c18e116b22ac106",
+        flashNodePubkeys: [FLASH_TEST_NODE_PUBKEY],
+      }),
+    ).toBe(true)
+  })
+
+  it("still discloses when the payee is unknown or the node list is empty — suppression must fail open", () => {
+    // No decoded payee (onchain, undecodable invoice) or an unpopulated
+    // lnNodePubkeys (prod today) must never swallow the #694 warning.
+    expect(
+      shouldDiscloseFeeFromAmount({
+        ...base,
+        destinationPayeePubkey: undefined,
+        flashNodePubkeys: [FLASH_TEST_NODE_PUBKEY],
+      }),
+    ).toBe(true)
+    expect(
+      shouldDiscloseFeeFromAmount({
+        ...base,
+        destinationPayeePubkey: FLASH_TEST_NODE_PUBKEY,
+        flashNodePubkeys: [],
+      }),
+    ).toBe(true)
+    expect(
+      shouldDiscloseFeeFromAmount({
+        ...base,
+        destinationPayeePubkey: FLASH_TEST_NODE_PUBKEY,
+        flashNodePubkeys: undefined,
+      }),
+    ).toBe(true)
+  })
+})
+
+describe("payeeNodePubkey", () => {
+  it("decodes the payee node from a real Flash invoice", () => {
+    expect(payeeNodePubkey(FLASH_TEST_INVOICE)).toBe(FLASH_TEST_NODE_PUBKEY)
+  })
+
+  it("returns undefined when there is no invoice or it cannot be decoded", () => {
+    expect(payeeNodePubkey(undefined)).toBeUndefined()
+    expect(payeeNodePubkey("")).toBeUndefined()
+    expect(payeeNodePubkey("bc1qexampledestination")).toBeUndefined()
+    expect(payeeNodePubkey("lnbc-not-an-invoice")).toBeUndefined()
   })
 })

--- a/app/components/send-flow/ConfirmationWalletFee.tsx
+++ b/app/components/send-flow/ConfirmationWalletFee.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react"
+import React, { useEffect, useMemo, useRef } from "react"
 import { ActivityIndicator, View } from "react-native"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { makeStyles, Text } from "@rneui/themed"
@@ -129,6 +129,15 @@ const ConfirmationWalletFee: React.FC<Props> = ({
     selectedFeeType,
   ])
 
+  // decodeInvoiceString performs sync ECDSA pubkey recovery when the invoice
+  // carries no `n` tag — milliseconds of crypto that must not re-run on every
+  // fee/quote state transition of this frequently re-rendering screen. The
+  // invoice is immutable for a given paymentRequest, so decode it once.
+  const destinationPayeePubkey = useMemo(
+    () => payeeNodePubkey(paymentDetail.paymentRequest),
+    [paymentDetail.paymentRequest],
+  )
+
   let feeDisplayText = ""
   if (fee.amount) {
     const feeDisplayAmount = paymentDetail.convertMoneyAmount(fee.amount, DisplayCurrency)
@@ -198,7 +207,7 @@ const ConfirmationWalletFee: React.FC<Props> = ({
           sendingWalletCurrency: sendingWalletDescriptor.currency,
           feeStatus: fee.status,
           feeAmount: fee.amount?.amount,
-          destinationPayeePubkey: payeeNodePubkey(paymentDetail.paymentRequest),
+          destinationPayeePubkey,
           flashNodePubkeys: galoyInstance.lnNodePubkeys,
         }) && (
           <Text

--- a/app/components/send-flow/ConfirmationWalletFee.tsx
+++ b/app/components/send-flow/ConfirmationWalletFee.tsx
@@ -5,6 +5,8 @@ import { makeStyles, Text } from "@rneui/themed"
 
 // hooks
 import useFee, { FeeType } from "@app/screens/send-bitcoin-screen/use-fee"
+
+import { shouldDiscloseFeeFromAmount } from "./fee-from-amount.logic"
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 import { useFormatSats } from "@app/hooks/use-format-sats"
 
@@ -185,6 +187,19 @@ const ConfirmationWalletFee: React.FC<Props> = ({
         {fee.status === "error" && Boolean(fee.amount) && (
           <Text style={styles.maxFeeWarningText}>
             {"*" + LL.SendBitcoinConfirmationScreen.maxFeeSelected()}
+          </Text>
+        )}
+        {shouldDiscloseFeeFromAmount({
+          paymentType,
+          sendingWalletCurrency: sendingWalletDescriptor.currency,
+          feeStatus: fee.status,
+          feeAmount: fee.amount?.amount,
+        }) && (
+          <Text
+            {...testProps("Fee From Amount Disclosure")}
+            style={styles.maxFeeWarningText}
+          >
+            {LL.SendBitcoinConfirmationScreen.feeDeductedFromAmount()}
           </Text>
         )}
       </View>

--- a/app/components/send-flow/ConfirmationWalletFee.tsx
+++ b/app/components/send-flow/ConfirmationWalletFee.tsx
@@ -6,7 +6,8 @@ import { makeStyles, Text } from "@rneui/themed"
 // hooks
 import useFee, { FeeType } from "@app/screens/send-bitcoin-screen/use-fee"
 
-import { shouldDiscloseFeeFromAmount } from "./fee-from-amount.logic"
+import { payeeNodePubkey, shouldDiscloseFeeFromAmount } from "./fee-from-amount.logic"
+import { useAppConfig } from "@app/hooks/use-app-config"
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 import { useFormatSats } from "@app/hooks/use-format-sats"
 
@@ -57,6 +58,9 @@ const ConfirmationWalletFee: React.FC<Props> = ({
   // overlapping fetches whose transient failure left a stale, sticky
   // paymentError that kept Confirm disabled under a successfully loaded fee.
   const getLightningFee = useFee(isGaloyWalletSend && getFee ? getFee : null)
+  const {
+    appConfig: { galoyInstance },
+  } = useAppConfig()
   const { formatDisplayAndWalletAmount } = useDisplayCurrency()
   const formatSats = useFormatSats()
   const breezFeeRequestId = useRef(0)
@@ -194,6 +198,8 @@ const ConfirmationWalletFee: React.FC<Props> = ({
           sendingWalletCurrency: sendingWalletDescriptor.currency,
           feeStatus: fee.status,
           feeAmount: fee.amount?.amount,
+          destinationPayeePubkey: payeeNodePubkey(paymentDetail.paymentRequest),
+          flashNodePubkeys: galoyInstance.lnNodePubkeys,
         }) && (
           <Text
             {...testProps("Fee From Amount Disclosure")}

--- a/app/components/send-flow/__tests__/ConfirmationWalletFee.test.tsx
+++ b/app/components/send-flow/__tests__/ConfirmationWalletFee.test.tsx
@@ -24,6 +24,16 @@ jest.mock("@app/screens/send-bitcoin-screen/use-fee", () => ({
   default: (...args: unknown[]) => mockUseFee(...args),
 }))
 
+// The instance's own lightning node ids consumed by the fee-from-amount
+// disclosure. Mutable so individual cases can pin a node and exercise the
+// Flash-to-Flash suppression; reset in beforeEach.
+let mockLnNodePubkeys: string[] = []
+jest.mock("@app/hooks/use-app-config", () => ({
+  useAppConfig: () => ({
+    appConfig: { galoyInstance: { lnNodePubkeys: mockLnNodePubkeys } },
+  }),
+}))
+
 jest.mock("@app/hooks/use-display-currency", () => ({
   useDisplayCurrency: () => ({
     formatDisplayAndWalletAmount: ({
@@ -95,6 +105,7 @@ const renderFee = (overrides: Overrides = {}) => {
 
 beforeEach(() => {
   jest.clearAllMocks()
+  mockLnNodePubkeys = []
   mockUseFee.mockReturnValue({ status: "unset" })
 })
 
@@ -223,5 +234,57 @@ describe("ConfirmationWalletFee — galoy USD sends", () => {
     await waitFor(() => expect(setFee).toHaveBeenCalledWith(probeFee))
     expect(mockFetchBreezFee).not.toHaveBeenCalled()
     expect(mockUseFee).toHaveBeenCalledWith(basePaymentDetail.getFee)
+  })
+
+  // Render-level coverage for the fee-from-amount disclosure (#694). The
+  // predicate is unit-tested in __tests__/components/fee-from-amount.spec.ts;
+  // these cases pin the component wiring — e.g. passing `fee.amount` (the
+  // object) instead of `fee.amount?.amount` would make `feeAmount === 0`
+  // always false, silently killing the feature while the predicate's own
+  // tests stay green.
+  const usdLightningDetail = {
+    ...basePaymentDetail,
+    sendingWalletDescriptor: { currency: "USD" },
+    paymentType: "lightning",
+  }
+  const probedZeroFee = {
+    status: "set",
+    amount: { amount: 0, currency: "USD", currencyCode: "USD" },
+  } as const
+
+  it("renders the fee-from-amount disclosure under a probed-zero fee", () => {
+    const { getByTestId } = renderFee({
+      paymentDetail: usdLightningDetail,
+      fee: probedZeroFee,
+    })
+    expect(getByTestId("Fee From Amount Disclosure")).toBeTruthy()
+  })
+
+  it("keeps the disclosure absent when the probe priced a real fee", () => {
+    const { queryByTestId } = renderFee({
+      paymentDetail: usdLightningDetail,
+      fee: {
+        status: "set",
+        amount: { amount: 5, currency: "USD", currencyCode: "USD" },
+      } as const,
+    })
+    expect(queryByTestId("Fee From Amount Disclosure")).toBeNull()
+  })
+
+  it("suppresses the disclosure when the held invoice pays the instance's own node", () => {
+    // A real bolt11 minted by the Test instance (2026-08-24, long expired —
+    // expiry is irrelevant to decoding); its payee is the pinned Test node.
+    // Exercises the full wiring: paymentRequest → payeeNodePubkey →
+    // lnNodePubkeys from useAppConfig → predicate suppression.
+    const flashTestInvoice =
+      "lnbc14060n1p4gclcjpp555k59jc4xn0x3mej3gzmuj7lg66u0rtkq73vtvwqtrmd8luemprqdpvvejk2ttswfhkyefqwejhy6txd93kzarfdahzqgek8y6qcqzzsxqzpusp5rprrqnqhclwmc7au9vqf306mg6wndelar076yu6f8nr7md6kzv9q9qxpqysgqnpc09nfh90rew3z7d06pu3056nu24e809j5sj6qn0ytquu252h0sp2dkd6gc3qudwduecfvxw7m6vlt6mc0s3seqv0nvet4u9xpq6wsqfhuttw"
+    mockLnNodePubkeys = [
+      "02004d8933df4f002fa95d8c37ca43eb9c175d310aad55cc6d442e4accc3740029",
+    ]
+    const { queryByTestId } = renderFee({
+      paymentDetail: { ...usdLightningDetail, paymentRequest: flashTestInvoice },
+      fee: probedZeroFee,
+    })
+    expect(queryByTestId("Fee From Amount Disclosure")).toBeNull()
   })
 })

--- a/app/components/send-flow/__tests__/ConfirmationWalletFee.test.tsx
+++ b/app/components/send-flow/__tests__/ConfirmationWalletFee.test.tsx
@@ -34,6 +34,18 @@ jest.mock("@app/hooks/use-app-config", () => ({
   }),
 }))
 
+// Spy on the invoice decode so the memoization test below can count calls.
+// It delegates to the real implementation, so the suppression test still
+// exercises genuine bolt11 decoding end to end.
+const mockPayeeNodePubkey = jest.fn((paymentRequest: string | undefined) =>
+  jest.requireActual("../fee-from-amount.logic").payeeNodePubkey(paymentRequest),
+)
+jest.mock("../fee-from-amount.logic", () => ({
+  ...jest.requireActual("../fee-from-amount.logic"),
+  payeeNodePubkey: (paymentRequest: string | undefined) =>
+    mockPayeeNodePubkey(paymentRequest),
+}))
+
 jest.mock("@app/hooks/use-display-currency", () => ({
   useDisplayCurrency: () => ({
     formatDisplayAndWalletAmount: ({
@@ -251,6 +263,10 @@ describe("ConfirmationWalletFee — galoy USD sends", () => {
     status: "set",
     amount: { amount: 0, currency: "USD", currencyCode: "USD" },
   } as const
+  // A real bolt11 minted by the Test instance (2026-08-24, long expired —
+  // expiry is irrelevant to decoding); its payee is the pinned Test node.
+  const flashTestInvoice =
+    "lnbc14060n1p4gclcjpp555k59jc4xn0x3mej3gzmuj7lg66u0rtkq73vtvwqtrmd8luemprqdpvvejk2ttswfhkyefqwejhy6txd93kzarfdahzqgek8y6qcqzzsxqzpusp5rprrqnqhclwmc7au9vqf306mg6wndelar076yu6f8nr7md6kzv9q9qxpqysgqnpc09nfh90rew3z7d06pu3056nu24e809j5sj6qn0ytquu252h0sp2dkd6gc3qudwduecfvxw7m6vlt6mc0s3seqv0nvet4u9xpq6wsqfhuttw"
 
   it("renders the fee-from-amount disclosure under a probed-zero fee", () => {
     const { getByTestId } = renderFee({
@@ -272,12 +288,8 @@ describe("ConfirmationWalletFee — galoy USD sends", () => {
   })
 
   it("suppresses the disclosure when the held invoice pays the instance's own node", () => {
-    // A real bolt11 minted by the Test instance (2026-08-24, long expired —
-    // expiry is irrelevant to decoding); its payee is the pinned Test node.
     // Exercises the full wiring: paymentRequest → payeeNodePubkey →
     // lnNodePubkeys from useAppConfig → predicate suppression.
-    const flashTestInvoice =
-      "lnbc14060n1p4gclcjpp555k59jc4xn0x3mej3gzmuj7lg66u0rtkq73vtvwqtrmd8luemprqdpvvejk2ttswfhkyefqwejhy6txd93kzarfdahzqgek8y6qcqzzsxqzpusp5rprrqnqhclwmc7au9vqf306mg6wndelar076yu6f8nr7md6kzv9q9qxpqysgqnpc09nfh90rew3z7d06pu3056nu24e809j5sj6qn0ytquu252h0sp2dkd6gc3qudwduecfvxw7m6vlt6mc0s3seqv0nvet4u9xpq6wsqfhuttw"
     mockLnNodePubkeys = [
       "02004d8933df4f002fa95d8c37ca43eb9c175d310aad55cc6d442e4accc3740029",
     ]
@@ -286,5 +298,29 @@ describe("ConfirmationWalletFee — galoy USD sends", () => {
       fee: probedZeroFee,
     })
     expect(queryByTestId("Fee From Amount Disclosure")).toBeNull()
+  })
+
+  it("decodes the held invoice once, not on every render", () => {
+    // decodeInvoiceString does sync ECDSA pubkey recovery for invoices
+    // without an `n` tag, and this screen re-renders several times per fee
+    // fetch. Round-2 review finding: the decode ran eagerly on every render.
+    const { rerenderWith } = renderFee({
+      paymentDetail: { ...usdLightningDetail, paymentRequest: flashTestInvoice },
+      fee: { status: "loading" },
+    })
+    expect(mockPayeeNodePubkey).toHaveBeenCalledTimes(1)
+
+    // Fee state transitions (loading → set) re-render with the same invoice;
+    // the memoized decode must not re-run — even though each rerender passes
+    // a fresh paymentDetail object, the paymentRequest string is unchanged.
+    rerenderWith({
+      paymentDetail: { ...usdLightningDetail, paymentRequest: flashTestInvoice },
+      fee: probedZeroFee,
+    })
+    rerenderWith({
+      paymentDetail: { ...usdLightningDetail, paymentRequest: flashTestInvoice },
+      fee: { status: "loading" },
+    })
+    expect(mockPayeeNodePubkey).toHaveBeenCalledTimes(1)
   })
 })

--- a/app/components/send-flow/fee-from-amount.logic.ts
+++ b/app/components/send-flow/fee-from-amount.logic.ts
@@ -1,0 +1,42 @@
+import { WalletCurrency } from "@app/graphql/generated"
+
+/**
+ * Whether the confirmation screen owes the customer the fee-from-amount
+ * disclosure (#694).
+ *
+ * On external sends from cash wallets, the IBEX pre-send estimate for some
+ * routes is 0 while settlement deducts the real routing fee FROM THE AMOUNT:
+ * the repro was a $1.10 send that displayed "$0.00" fee, debited $1.10, and
+ * delivered $1.07. The app cannot conjure the true fee pre-send — IBEX does
+ * not provide it on those routes — so the honest move is to stop presenting
+ * the 0 as a promise. Showing "$0.00" unqualified is a claim; this predicate
+ * decides when that claim must carry the "deducted from the amount" caveat.
+ *
+ * The conditions, and why each is there:
+ * - `status === "set"` with amount 0: a PROBED zero, the untrustworthy case.
+ *   Errors and unset already render their own caveats.
+ * - cash wallets only (USD/USDT): BTC-wallet fee probes price the actual
+ *   route and a zero there is real (e.g. direct channel).
+ * - external only: intraledger transfers genuinely cost nothing, and the
+ *   caveat on them would teach users to ignore it exactly where it matters.
+ *
+ * A rare genuinely-free external route reads the soft copy ("may receive
+ * slightly less") — a mild false positive, priced against the current false
+ * NEGATIVE, which is a customer discovering the fee on the recipient side.
+ */
+export const shouldDiscloseFeeFromAmount = ({
+  paymentType,
+  sendingWalletCurrency,
+  feeStatus,
+  feeAmount,
+}: {
+  paymentType: string
+  sendingWalletCurrency: WalletCurrency
+  feeStatus: "loading" | "error" | "unset" | "set"
+  feeAmount: number | undefined
+}): boolean =>
+  feeStatus === "set" &&
+  feeAmount === 0 &&
+  paymentType !== "intraledger" &&
+  (sendingWalletCurrency === WalletCurrency.Usd ||
+    sendingWalletCurrency === WalletCurrency.Usdt)

--- a/app/components/send-flow/fee-from-amount.logic.ts
+++ b/app/components/send-flow/fee-from-amount.logic.ts
@@ -1,4 +1,59 @@
+import {
+  decodeInvoiceString,
+  Network as NetworkLibGaloy,
+  PaymentType,
+} from "@galoymoney/client"
+
 import { WalletCurrency } from "@app/graphql/generated"
+import { networkForPaymentRequest } from "@app/screens/send-bitcoin-screen/invoice-expiry"
+
+/**
+ * The payment types a send-flow detail can carry — the same union
+ * BasePaymentDetail uses. Typed against the @galoymoney/client constants so
+ * the intraledger exclusion below is compiler-checked: a typo'd literal or a
+ * renamed PaymentType member fails the build instead of silently re-enabling
+ * the caveat on intraledger sends.
+ */
+type SendPaymentType =
+  | typeof PaymentType.Intraledger
+  | typeof PaymentType.Onchain
+  | typeof PaymentType.Lightning
+  | typeof PaymentType.Lnurl
+
+/**
+ * The payee node pubkey of a held bolt11, or undefined when there is no
+ * invoice or it cannot be decoded.
+ *
+ * Fails closed for the disclosure's purposes: an undecodable invoice yields
+ * undefined, which never matches a Flash node id, so the caveat still shows.
+ * A decode quirk must not suppress the warning the #694 repro exists for.
+ */
+export const payeeNodePubkey = (
+  paymentRequest: string | undefined,
+): string | undefined => {
+  if (!paymentRequest) return undefined
+  const network = networkForPaymentRequest(paymentRequest)
+  if (!network) return undefined
+  try {
+    return (
+      decodeInvoiceString(paymentRequest, network as NetworkLibGaloy).payeeNodeKey ??
+      undefined
+    )
+  } catch {
+    return undefined
+  }
+}
+
+const isFlashNodePayee = (
+  destinationPayeePubkey: string | undefined,
+  flashNodePubkeys: readonly string[] | undefined,
+): boolean =>
+  Boolean(
+    destinationPayeePubkey &&
+      flashNodePubkeys?.some(
+        (pubkey) => pubkey.toLowerCase() === destinationPayeePubkey.toLowerCase(),
+      ),
+  )
 
 /**
  * Whether the confirmation screen owes the customer the fee-from-amount
@@ -19,6 +74,28 @@ import { WalletCurrency } from "@app/graphql/generated"
  *   route and a zero there is real (e.g. direct channel).
  * - external only: intraledger transfers genuinely cost nothing, and the
  *   caveat on them would teach users to ignore it exactly where it matters.
+ * - not a Flash-node invoice: a bolt11 minted by this instance's own
+ *   lightning node settles inside the custodian — delivery is full-amount
+ *   and the probed 0 is TRUE, so the caveat must stay silent (see below).
+ *
+ * Flash-to-Flash invoices — VERIFIED, not assumed (2026-08-24):
+ * A Flash user paying another Flash user's (or a flash-pos merchant's)
+ * pasted/scanned invoice is paymentType "lightning", not "intraledger", and
+ * the backend probe is a blind pass-through to IBEX's estimate-fee (flash
+ * `ln-usd-invoice-fee-probe.ts` → `Ibex.getLnFeeEstimation`, no
+ * internal-invoice special-casing). Probing a freshly minted Flash-internal
+ * invoice on the Test instance returned `{ amount: 0 }` with no errors — a
+ * probed "set" zero. Without the payee check, the caveat would therefore
+ * fire on every Flash-to-Flash invoice payment, teaching users to ignore it
+ * exactly where the disclosure matters.
+ *
+ * The payee check compares the invoice's payee node pubkey against the
+ * instance's `lnNodePubkeys` (galoy-instances.ts). `globals.nodesIds` was
+ * the natural source, but it is empty on prod and test (verified live), so
+ * the ids ship as per-instance config. The Test entry is verified; Main's
+ * list is still empty, which means prod keeps the false positive on
+ * Flash-to-Flash sends until someone with a prod account pins the prod node
+ * id — the recipe is in galoy-instances.ts next to the field.
  *
  * A rare genuinely-free external route reads the soft copy ("may receive
  * slightly less") — a mild false positive, priced against the current false
@@ -29,14 +106,21 @@ export const shouldDiscloseFeeFromAmount = ({
   sendingWalletCurrency,
   feeStatus,
   feeAmount,
+  destinationPayeePubkey,
+  flashNodePubkeys,
 }: {
-  paymentType: string
+  paymentType: SendPaymentType
   sendingWalletCurrency: WalletCurrency
   feeStatus: "loading" | "error" | "unset" | "set"
   feeAmount: number | undefined
+  /** Payee node pubkey decoded from the held bolt11, when there is one. */
+  destinationPayeePubkey?: string
+  /** This instance's own lightning node ids (`lnNodePubkeys` in galoy-instances.ts). */
+  flashNodePubkeys?: readonly string[]
 }): boolean =>
   feeStatus === "set" &&
   feeAmount === 0 &&
-  paymentType !== "intraledger" &&
+  paymentType !== PaymentType.Intraledger &&
   (sendingWalletCurrency === WalletCurrency.Usd ||
-    sendingWalletCurrency === WalletCurrency.Usdt)
+    sendingWalletCurrency === WalletCurrency.Usdt) &&
+  !isFlashNodePayee(destinationPayeePubkey, flashNodePubkeys)

--- a/app/components/send-flow/fee-from-amount.logic.ts
+++ b/app/components/send-flow/fee-from-amount.logic.ts
@@ -92,10 +92,10 @@ const isFlashNodePayee = (
  * The payee check compares the invoice's payee node pubkey against the
  * instance's `lnNodePubkeys` (galoy-instances.ts). `globals.nodesIds` was
  * the natural source, but it is empty on prod and test (verified live), so
- * the ids ship as per-instance config. The Test entry is verified; Main's
- * list is still empty, which means prod keeps the false positive on
- * Flash-to-Flash sends until someone with a prod account pins the prod node
- * id — the recipe is in galoy-instances.ts next to the field.
+ * the ids ship as per-instance config. Both the Test and Main entries are
+ * pinned from freshly minted invoices decoded live (Main: five prod invoices
+ * across two accounts, 2026-08-24, all paying IBEX_Ops1) — the re-verify
+ * recipe is in galoy-instances.ts next to the field.
  *
  * A rare genuinely-free external route reads the soft copy ("may receive
  * slightly less") — a mild false positive, priced against the current false

--- a/app/config/galoy-instances.ts
+++ b/app/config/galoy-instances.ts
@@ -115,11 +115,14 @@ export const GALOY_INSTANCES: readonly GaloyInstance[] = [
     lnAddressHostname: "flashapp.me",
     relayUrl: "wss://relay.flashapp.me",
     blockExplorer: "https://mempool.space/tx/",
-    // UNVERIFIED as of 2026-08-24 — deliberately empty. Until someone with a
-    // prod account decodes a prod receive invoice (recipe on the type field)
-    // and pins the pubkey here, Flash-to-Flash invoice payments on prod show
-    // the fee-from-amount caveat even though delivery is full-amount there.
-    lnNodePubkeys: [],
+    // Verified 2026-08-24: five receive invoices minted live on prod via the
+    // LNURL-pay callback (`https://ibex.flashapp.me/pay/lnurl/<user>`) across
+    // two different accounts and amounts from 1 to 50,000 sats ALL decode to
+    // this payee — alias IBEX_Ops1 on mempool.space. If IBEX ever mints prod
+    // invoices from an additional node, append it here (recipe on the type
+    // field); a missing node only re-shows the caveat on Flash-to-Flash
+    // sends, it never hides a real fee.
+    lnNodePubkeys: ["03501a74753e0f6ae270a1e4e2ffbbc37f7a796360e650c1121c18e116b22ac106"],
   },
   {
     id: "Staging",

--- a/app/config/galoy-instances.ts
+++ b/app/config/galoy-instances.ts
@@ -68,6 +68,22 @@ export type GaloyInstance = {
   lnAddressHostname: string
   blockExplorer: string
   relayUrl: string
+  /**
+   * The lightning node pubkeys this instance mints bolt11 invoices from.
+   *
+   * Consumed by the fee-from-amount disclosure (#694): an invoice whose payee
+   * is one of these nodes settles inside the custodian, so a probed $0.00 fee
+   * is genuine and the "deducted from the amount" caveat must stay silent.
+   * `globals.nodesIds` would be the natural source, but it is empty on prod
+   * and test (verified live 2026-08-24), so the ids live here.
+   *
+   * To populate or verify an entry: mint any receive invoice on the instance
+   * (the app's receive screen works), then decode it —
+   *   `require("bolt11").decode(paymentRequest).payeeNodeKey`
+   * — and pin that pubkey. An empty list only disables the suppression; the
+   * disclosure itself still shows.
+   */
+  lnNodePubkeys?: readonly string[]
 }
 
 export const resolveGaloyInstanceOrDefault = (
@@ -99,6 +115,11 @@ export const GALOY_INSTANCES: readonly GaloyInstance[] = [
     lnAddressHostname: "flashapp.me",
     relayUrl: "wss://relay.flashapp.me",
     blockExplorer: "https://mempool.space/tx/",
+    // UNVERIFIED as of 2026-08-24 — deliberately empty. Until someone with a
+    // prod account decodes a prod receive invoice (recipe on the type field)
+    // and pins the pubkey here, Flash-to-Flash invoice payments on prod show
+    // the fee-from-amount caveat even though delivery is full-amount there.
+    lnNodePubkeys: [],
   },
   {
     id: "Staging",
@@ -121,6 +142,10 @@ export const GALOY_INSTANCES: readonly GaloyInstance[] = [
     lnAddressHostname: "test.flashapp.me",
     blockExplorer: "https://mempool.space/signet/tx/",
     relayUrl: "wss://relay.test.flashapp.me",
+    // Verified 2026-08-24: a freshly minted Test-instance USD invoice decodes
+    // to this payee (IBEX_SB on mempool.space), and probing it via
+    // lnUsdInvoiceFeeProbe returned a set fee of 0.
+    lnNodePubkeys: ["02004d8933df4f002fa95d8c37ca43eb9c175d310aad55cc6d442e4accc3740029"],
   },
   {
     id: "Sandbox",

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -983,6 +983,8 @@ const en: BaseTranslation = {
     confirmPaymentQuestion: "Do you want to confirm this payment?",
     destinationLabel: "To:",
     feeLabel: "Fee",
+    feeDeductedFromAmount:
+      "The network fee is deducted from the amount — the recipient may receive slightly less.",
     memoLabel: "Note:",
     paymentFinal: "Payments are final.",
     stalePrice:

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -3120,6 +3120,10 @@ type RootTranslation = {
 		 */
 		feeLabel: string
 		/**
+		 * T​h​e​ ​n​e​t​w​o​r​k​ ​f​e​e​ ​i​s​ ​d​e​d​u​c​t​e​d​ ​f​r​o​m​ ​t​h​e​ ​a​m​o​u​n​t​ ​—​ ​t​h​e​ ​r​e​c​i​p​i​e​n​t​ ​m​a​y​ ​r​e​c​e​i​v​e​ ​s​l​i​g​h​t​l​y​ ​l​e​s​s​.
+		 */
+		feeDeductedFromAmount: string
+		/**
 		 * N​o​t​e​:
 		 */
 		memoLabel: string
@@ -9447,6 +9451,10 @@ export type TranslationFunctions = {
 		 * Fee
 		 */
 		feeLabel: () => LocalizedString
+		/**
+		 * The network fee is deducted from the amount — the recipient may receive slightly less.
+		 */
+		feeDeductedFromAmount: () => LocalizedString
 		/**
 		 * Note:
 		 */

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -885,6 +885,7 @@
         "confirmPaymentQuestion": "Do you want to confirm this payment?",
         "destinationLabel": "To:",
         "feeLabel": "Fee",
+        "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
         "memoLabel": "Note:",
         "paymentFinal": "Payments are final.",
         "stalePrice": "Your bitcoin price is old and was last updated {timePeriod} ago. Please restart the app before making a payment.",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -643,7 +643,8 @@
     "maxFeeSelected": "Hierdie is die maksimum fooi wat jy sal betaal vir hierdie transaksie. Dit mag dalk minder wees as die betaling voltooi is.",
     "feeError": "Kon nie fooi bereken nie",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} gebruikersname is nou {bankName: string} adresse. ",
@@ -1596,8 +1597,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD-rekening",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -629,6 +629,7 @@
     "backupDescription": "To set a PIN code, please back up your account by adding a phone number."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Bedrag:",
     "confirmPayment": "Bevestig betaling",
     "confirmPaymentQuestion": "Wil jy hierdie betaling bevestig?",
@@ -643,8 +644,7 @@
     "maxFeeSelected": "Hierdie is die maksimum fooi wat jy sal betaal vir hierdie transaksie. Dit mag dalk minder wees as die betaling voltooi is.",
     "feeError": "Kon nie fooi bereken nie",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} gebruikersname is nou {bankName: string} adresse. ",
@@ -1597,7 +1597,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "USD-rekening",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -635,7 +635,8 @@
     "maxFeeSelected": "هذا هو الحد الأقصى للرسوم التي ستُقتضى منك لهذه المعاملة. قد تكون أقل من ذلك عند إتمام الدفع.",
     "feeError": "فشل في حساب العمولة",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "أسماء المستخدمين في {bankName} أصبحت عناوين في {bankName}",
@@ -1601,8 +1602,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "حساب بالدولار",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -621,6 +621,7 @@
     "backupDescription": "To set a PIN code, please back up your account by adding a phone number."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "كمية:",
     "confirmPayment": "تأكيد الدفع",
     "confirmPaymentQuestion": "هل تريد تأكيد هذا الدفع؟",
@@ -635,8 +636,7 @@
     "maxFeeSelected": "هذا هو الحد الأقصى للرسوم التي ستُقتضى منك لهذه المعاملة. قد تكون أقل من ذلك عند إتمام الدفع.",
     "feeError": "فشل في حساب العمولة",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "أسماء المستخدمين في {bankName} أصبحت عناوين في {bankName}",
@@ -1602,7 +1602,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "حساب بالدولار",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Aquesta és la comissió màxima que se't cobrarà per aquesta transacció. Pot acabar sent inferior un cop s'hagi realitzat el pagament.",
     "feeError": "No s'ha pogut calcular la comissió",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName} nom d'usuari és ara la adreça {bankName}.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Compte en USD",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -671,6 +671,7 @@
     "backupDescription": "Per a configurar un codi PIN, si us plau, fer una copia de seguretat del vostre compte afegint un número de telèfon."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Import:",
     "confirmPayment": "Confirma el pagament",
     "confirmPaymentQuestion": "Vols confirmar aquest pagament?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Aquesta és la comissió màxima que se't cobrarà per aquesta transacció. Pot acabar sent inferior un cop s'hagi realitzat el pagament.",
     "feeError": "No s'ha pogut calcular la comissió",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName} nom d'usuari és ara la adreça {bankName}.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "Compte en USD",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Jedná se o maximální poplatek, který vám bude za tuto transakci účtován. Po provedení platby může být nakonec nižší.",
     "feeError": "Nepodařilo se vypočítat poplatek",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Uživatelská jména {bankName} jsou nyní adresy {bankName}.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD účet",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -671,6 +671,7 @@
     "backupDescription": "Pokud chcete nastavit kód PIN, zálohte si svůj účet přidáním telefonního čísla."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Částka:",
     "confirmPayment": "Potvrďte platbu",
     "confirmPaymentQuestion": "Chcete tuto platbu potvrdit?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Jedná se o maximální poplatek, který vám bude za tuto transakci účtován. Po provedení platby může být nakonec nižší.",
     "feeError": "Nepodařilo se vypočítat poplatek",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Uživatelská jména {bankName} jsou nyní adresy {bankName}.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "USD účet",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Dette er det maksimale gebyr, du vil blive opkrævet for denne transaktion. Det kan ende med at være mindre, når betalingen er foretaget.",
     "feeError": "Kunne ikke beregne gebyr",
     "breezFeeText": "Der kan være et lille gebyr for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} brugernavne er nu {bankName: string} adresser.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD-konto",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -671,6 +671,7 @@
     "backupDescription": "Til at indstille en PIN-kode, skal du sikkerhedskopiere din konto ved at tilføje et telefonnummer."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Beløb:",
     "confirmPayment": "Bekræft betaling",
     "confirmPaymentQuestion": "Vil du bekræfte denne betaling?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Dette er det maksimale gebyr, du vil blive opkrævet for denne transaktion. Det kan ende med at være mindre, når betalingen er foretaget.",
     "feeError": "Kunne ikke beregne gebyr",
     "breezFeeText": "Der kan være et lille gebyr for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} brugernavne er nu {bankName: string} adresser.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "USD-konto",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -671,6 +671,7 @@
     "backupDescription": "Um einen PIN-Code einzurichten, unterstützen Sie bitte Ihr Konto, indem Sie eine Telefonnummer hinzufügen."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Betrag:",
     "confirmPayment": "Zahlung bestätigen",
     "confirmPaymentQuestion": "Möchtest Du diese Zahlung bestätigen?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Dies ist die maximale Transaktionsgebühr. Die tatsächlich gezahlte Gebühr kann weniger betragen.",
     "feeError": "Gebühr konnte nicht berechnet werden",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName} Benutzernamen sind nun {bankName} Adressen.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "USD-Konto",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Dies ist die maximale Transaktionsgebühr. Die tatsächlich gezahlte Gebühr kann weniger betragen.",
     "feeError": "Gebühr konnte nicht berechnet werden",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName} Benutzernamen sind nun {bankName} Adressen.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD-Konto",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Αυτή είναι τα περισσότερα τέλη που θα χρεωθείτε για αυτή τη συναλλαγή. Μπορεί να είναι λιγότερα όταν πραγματοποιηθεί η πληρωμή.",
     "feeError": "Απέτυχε ο υπολογισμός των τελών",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Τα ονόματα χρηστών {bankName: string} είναι τώρα διευθύνσεις {bankName: string}.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Λογαριασμός USD",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -671,6 +671,7 @@
     "backupDescription": "Για να ορίσετε έναν κωδικό PIN, παρακαλούμε κάντε αντίγραφο ασφαλείας του λογαριασμού σας προσθέτοντας έναν αριθμό τηλεφώνου."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Ποσό:",
     "confirmPayment": "Επιβεβαίωση πληρωμής",
     "confirmPaymentQuestion": "Θέλετε να επιβεβαιώσετε αυτή την πληρωμή;",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Αυτή είναι τα περισσότερα τέλη που θα χρεωθείτε για αυτή τη συναλλαγή. Μπορεί να είναι λιγότερα όταν πραγματοποιηθεί η πληρωμή.",
     "feeError": "Απέτυχε ο υπολογισμός των τελών",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Τα ονόματα χρηστών {bankName: string} είναι τώρα διευθύνσεις {bankName: string}.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "Λογαριασμός USD",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -671,6 +671,7 @@
     "backupDescription": "Para configurar un código PIN, haga una copia de seguridad de su cuenta añadiendo un número de teléfono."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "La comisión de red se deduce del monto — el destinatario puede recibir un poco menos.",
     "amountLabel": "Cantidad:",
     "confirmPayment": "Confirmar y pagar",
     "confirmPaymentQuestion": "¿Desea confirmar este pago?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Tarifa máxima que se cobrará por esta transacción. Podría ser menor una vez se realice el pago.",
     "feeError": "Error al calcular la tarifa",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "La comisión de red se deduce del monto — el destinatario puede recibir un poco menos."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Los nombres de usuario de {bankName} ahora son direcciones de {bankName}.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "Cuenta en USD",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Tarifa máxima que se cobrará por esta transacción. Podría ser menor una vez se realice el pago.",
     "feeError": "Error al calcular la tarifa",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "La comisión de red se deduce del monto — el destinatario puede recibir un poco menos."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Los nombres de usuario de {bankName} ahora son direcciones de {bankName}.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Cuenta en USD",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -671,6 +671,7 @@
     "backupDescription": "Pour définir un code PIN, veuillez sauvegarder votre compte en ajoutant un numéro de téléphone."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Montant :",
     "confirmPayment": "Confirmer le paiement",
     "confirmPaymentQuestion": "Voulez-vous confirmer le paiement ?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Il s’agit des frais maximums qui vous seront facturés pour cette transaction. Il peut s’avérer inférieur une fois le paiement effectué.",
     "feeError": "Échec du calcul des frais",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Les identifiants {bankName: string} sont maintenant les adresses {bankName: string}.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "Compte en USD",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Il s’agit des frais maximums qui vous seront facturés pour cette transaction. Il peut s’avérer inférieur une fois le paiement effectué.",
     "feeError": "Échec du calcul des frais",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Les identifiants {bankName: string} sont maintenant les adresses {bankName: string}.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Compte en USD",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Ovo je najveća naknada koja će vam biti naplaćena za ovu transakciju. Nakon izvršenja plaćanja može ispasti manje.",
     "feeError": "Neuspješno izračunavanje naknade",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} korisnička imena sada su {bankName: string} adrese.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD račun",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -671,6 +671,7 @@
     "backupDescription": "Za postavljanje PIN koda, molimo vas da se zauzmete pomoću dodavanja telefonskog broja."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Iznos:",
     "confirmPayment": "Potvrdi plaćanje",
     "confirmPaymentQuestion": "Želite li potvrditi ovo plaćanje?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Ovo je najveća naknada koja će vam biti naplaćena za ovu transakciju. Nakon izvršenja plaćanja može ispasti manje.",
     "feeError": "Neuspješno izračunavanje naknade",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} korisnička imena sada su {bankName: string} adrese.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "USD račun",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -671,6 +671,7 @@
     "backupDescription": "Ha egy PIN kódot állítanak be, kérjük, biztonsági mentse a fiókját egy telefonszám hozzáadásával."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Összeg:",
     "confirmPayment": "Fizetés megerősítése",
     "confirmPaymentQuestion": "Megerősíted ezt a fizetést?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Ez a maximális díj, amit ezen tranzakcióért felszámíthatunk. Lehet, hogy kevesebb lesz, miután a fizetés megtörtént.",
     "feeError": "Nem sikerült kiszámítani a díjat",
     "breezFeeText": "Lehet, hogy egy kis díj van a útvonalért",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Mostantól a {bankName: string} felhasználónevek {bankName: string} címek is.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "USD-számla",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Ez a maximális díj, amit ezen tranzakcióért felszámíthatunk. Lehet, hogy kevesebb lesz, miután a fizetés megtörtént.",
     "feeError": "Nem sikerült kiszámítani a díjat",
     "breezFeeText": "Lehet, hogy egy kis díj van a útvonalért",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Mostantól a {bankName: string} felhasználónevek {bankName: string} címek is.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD-számla",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -671,6 +671,7 @@
     "backupDescription": "PIN կոդը սահմանելու համար խնդրում ենք պահեստավորել ձեր հաշիվը' ավելացնելով հեռախոսահամար:"
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Չափը․",
     "confirmPayment": "Հաստատել վճարումը",
     "confirmPaymentQuestion": "Դուք ցանկանու՞մ եք հաստատել այս վճարումը։ ",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Սա առավելագույն վճարն է, որը Ձեզանից կգանձվի այս գործառնության համար: Վճարումը կատարելուց հետո այն կարող է նվազել։ ",
     "feeError": "Չհաջողվեց հաշվել վճարը",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} օգտանունները հիմա {bankName: string} հասցեներն են։ ",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "USD հաշիվ",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Սա առավելագույն վճարն է, որը Ձեզանից կգանձվի այս գործառնության համար: Վճարումը կատարելուց հետո այն կարող է նվազել։ ",
     "feeError": "Չհաջողվեց հաշվել վճարը",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} օգտանունները հիմա {bankName: string} հասցեներն են։ ",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD հաշիվ",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -671,6 +671,7 @@
     "backupDescription": "Per impostare un codice PIN, si prega di fare un backup dell'account aggiungendo un numero di telefono."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Importo:",
     "confirmPayment": "Conferma pagamento",
     "confirmPaymentQuestion": "Vuoi confermare questo pagamento?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Questa è la commissione massima che ti verrà addebitata per questa transazione. Una volta effettuato il pagamento, il costo potrebbe risultare inferiore.",
     "feeError": "Impossibile calcolare la fee",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Gli username {bankName: string} sono ora indirizzi {bankName: string}.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "Conto in USD",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Questa è la commissione massima che ti verrà addebitata per questa transazione. Una volta effettuato il pagamento, il costo potrebbe risultare inferiore.",
     "feeError": "Impossibile calcolare la fee",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Gli username {bankName: string} sono ora indirizzi {bankName: string}.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Conto in USD",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -671,6 +671,7 @@
     "backupDescription": "Untuk menetapkan kod PIN, sila sandarkan akaun anda dengan menambah nombor telefon."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Jumlah:",
     "confirmPayment": "Bayar dengan pasti ",
     "confirmPaymentQuestion": "Anda pasti nak buat pembayaran ini?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Ini adalah cas bayaran maksimum yang akan dikenakan untuk transaksi ini. Tapi cas ni mungkin akan lagi rendah bila bayaran telah dibuat.",
     "feeError": "Gagal untuk kira berapa cas dikenakan",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{NamaBank: string} id pengguna sekarang adalah {NamaBank: string} alamatnya.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "Akaun USD",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Ini adalah cas bayaran maksimum yang akan dikenakan untuk transaksi ini. Tapi cas ni mungkin akan lagi rendah bila bayaran telah dibuat.",
     "feeError": "Gagal untuk kira berapa cas dikenakan",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{NamaBank: string} id pengguna sekarang adalah {NamaBank: string} alamatnya.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Akaun USD",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -671,6 +671,7 @@
     "backupDescription": "Als u een PIN-code hebt ingesteld, moet u uw account back-up maken door een telefoonnummer toe te voegen."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Bedrag:",
     "confirmPayment": "Bevestig betaling",
     "confirmPaymentQuestion": "Wil je deze betaling bevestigen?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Dit zijn de maximale kosten die voor deze transactie in rekening worden gebracht. Het kan uiteindelijk minder zijn zodra de betaling is gedaan.",
     "feeError": "Het berekenen van de kosten is mislukt",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} gebruikersnamen zijn nu {bankName: string} adressen.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "USD-rekening",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Dit zijn de maximale kosten die voor deze transactie in rekening worden gebracht. Het kan uiteindelijk minder zijn zodra de betaling is gedaan.",
     "feeError": "Het berekenen van de kosten is mislukt",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} gebruikersnamen zijn nu {bankName: string} adressen.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD-rekening",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -671,6 +671,7 @@
     "backupDescription": "Para definir um código PIN, faça backup da sua conta adicionando um número de telefone."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Quantidade:",
     "confirmPayment": "Confirmar pagamento",
     "confirmPaymentQuestion": "Deseja confirmar este pagamento?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Esta é a taxa máxima que será cobrada por esta transação. Pode acabar sendo menor uma vez que o pagamento foi feito.",
     "feeError": "Falha ao calcular a taxa",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Nomes de usuário {bankName: string} agora são endereços {bankName: string}.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "Conta em USD",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Esta é a taxa máxima que será cobrada por esta transação. Pode acabar sendo menor uma vez que o pagamento foi feito.",
     "feeError": "Falha ao calcular a taxa",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Nomes de usuário {bankName: string} agora são endereços {bankName: string}.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Conta em USD",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Chaynamanta kaniyta rikuyta munanpi, kaniyta rikuyta munanpi ch'usaq kayniyta rikuy munanpi kawsayniyta qillqata sutichinaqinmi. Kaniytaikuyta munanpi kawsayniyta qillqata sutichinaqinmi chaypi ch'usaq kayniyta rikuy munanpi ch'usaqta munanpi kawsayniyta qillqata sutichinaqinmi.",
     "feeError": "Chaynamanta kaniyta rikuyta munanpi, ch'usaq kayniyta rikuyta munanpi ch'usaqta munanpi kawsayniyta qillqata sutichinaqin.",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} kaniyta yachanakuyta sutichinaqinmi, {bankName: string} kawsayniyta qillqata sutichinaqinmi kaniyta rikuyta munanpi.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD cuenta",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -671,6 +671,7 @@
     "backupDescription": "PIN kodonpi qhawariyta munaspaqa, huk telefonata qoykuspa cuentaykita saqerunchis."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Suma:",
     "confirmPayment": "Kawsayniyta qillqata sutichinaqinmi",
     "confirmPaymentQuestion": "Kawsayniyta qillqata sutichinaqinmi kaniy rikuyta munanpi yachanakuyta sutichaqmi?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Chaynamanta kaniyta rikuyta munanpi, kaniyta rikuyta munanpi ch'usaq kayniyta rikuy munanpi kawsayniyta qillqata sutichinaqinmi. Kaniytaikuyta munanpi kawsayniyta qillqata sutichinaqinmi chaypi ch'usaq kayniyta rikuy munanpi ch'usaqta munanpi kawsayniyta qillqata sutichinaqinmi.",
     "feeError": "Chaynamanta kaniyta rikuyta munanpi, ch'usaq kayniyta rikuyta munanpi ch'usaqta munanpi kawsayniyta qillqata sutichinaqin.",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} kaniyta yachanakuyta sutichinaqinmi, {bankName: string} kawsayniyta qillqata sutichinaqinmi kaniyta rikuyta munanpi.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "USD cuenta",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Ово је максимална накнада која ће вам бити наплаћена за ову трансакцију. Може се испоставити да је мања након што је плаћање извршено.",
     "feeError": "Неуспешно рачунање накнаде",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} корисничка имена су сада {bankName: string} адресе.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD рачун",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -671,6 +671,7 @@
     "backupDescription": "Да бисте поставили PIN код, молимо вас да резервирате свој рачун додавањем телефонског броја."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Износ:",
     "confirmPayment": "Потврди плаћање",
     "confirmPaymentQuestion": "Да ли желите да потврдите ово плаћање?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Ово је максимална накнада која ће вам бити наплаћена за ову трансакцију. Може се испоставити да је мања након што је плаћање извршено.",
     "feeError": "Неуспешно рачунање накнаде",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} корисничка имена су сада {bankName: string} адресе.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "USD рачун",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -621,6 +621,7 @@
     "backupDescription": "To set a PIN code, please back up your account by adding a phone number."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Kiasi",
     "confirmPayment": "Thibithisha malipo",
     "confirmPaymentQuestion": "Je, unataka kuthibitisha malipo haya?",
@@ -635,8 +636,7 @@
     "maxFeeSelected": "Hii ndio ada ya juu zaidi ambayo unawezalipishwa kwa malipo haya. Inaweza kuishia kuwa kidogo malipo yatakapofanyika.",
     "feeError": "Imeshindwa kuhesabu ada",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} majina ya watumiaji sasa ni anwani za {bankName: string} ",
@@ -1602,7 +1602,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "Akaunti ya USD",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -635,7 +635,8 @@
     "maxFeeSelected": "Hii ndio ada ya juu zaidi ambayo unawezalipishwa kwa malipo haya. Inaweza kuishia kuwa kidogo malipo yatakapofanyika.",
     "feeError": "Imeshindwa kuhesabu ada",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} majina ya watumiaji sasa ni anwani za {bankName: string} ",
@@ -1601,8 +1602,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Akaunti ya USD",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "นี่คือค่าธรรมเนียมสูงสุดที่จะถูกเรียกเก็บในธุรกรรมนี้ได้ มันอาจน้อยกว่านี้เมื่อมีการทำธุรกรรมกันจริงๆ",
     "feeError": "การคำนวณค่าธรรมเนียมล้มเหลว",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "ชื่อผู้ใช้{bankName: string} เป็นแอดเดรส{bankName: string}ของคุณในขณะนี้",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "บัญชี USD",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -671,6 +671,7 @@
     "backupDescription": "สําหรับการตั้งรหัส PIN กรุณาทําสํารองบัญชีของคุณโดยการเพิ่มเบอร์โทรศัพท์"
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "จำนวน:",
     "confirmPayment": "ยืนยันการชำระเงิน",
     "confirmPaymentQuestion": "ยืนยันการทำธุรกรรมนี้หรือไม่?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "นี่คือค่าธรรมเนียมสูงสุดที่จะถูกเรียกเก็บในธุรกรรมนี้ได้ มันอาจน้อยกว่านี้เมื่อมีการทำธุรกรรมกันจริงๆ",
     "feeError": "การคำนวณค่าธรรมเนียมล้มเหลว",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "ชื่อผู้ใช้{bankName: string} เป็นแอดเดรส{bankName: string}ของคุณในขณะนี้",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "บัญชี USD",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -671,6 +671,7 @@
     "backupDescription": "Bir PIN kodu ayarlamak için, lütfen bir telefon numarası ekleyerek hesabınızı yedekleyin."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Miktar:",
     "confirmPayment": "Ödemeyi onayla",
     "confirmPaymentQuestion": "Bu ödemeyi onaylıyor musunuz?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Bu, bu işlem için sizden tahsil edilecek maksimum ücrettir. Ödeme yapıldıktan sonra daha az olabilir.",
     "feeError": "Gönderi ücreti hesaplanamadı",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{BankName: string} kullanıcı adları artık {bankName: string} adresleridir.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "USD hesabı",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Bu, bu işlem için sizden tahsil edilecek maksimum ücrettir. Ödeme yapıldıktan sonra daha az olabilir.",
     "feeError": "Gönderi ücreti hesaplanamadı",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{BankName: string} kullanıcı adları artık {bankName: string} adresleridir.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD hesabı",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -671,6 +671,7 @@
     "backupDescription": "Để đặt mã PIN, vui lòng sao lưu tài khoản của bạn bằng cách thêm một số điện thoại."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Số tiền",
     "confirmPayment": "Xác nhận thanh toán",
     "confirmPaymentQuestion": "Bạn có muốn xác nhận thanh toán này?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Đây là mức phí tối đa bạn sẽ phải trả cho giao dịch này. Nó có thể sẽ ít hơn sau khi thanh toán được thực hiện.",
     "feeError": "Không thể tính phí",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Tên người dùng {bankName: string} hiện là địa chỉ {bankName: string}.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "Tài khoản USD",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Đây là mức phí tối đa bạn sẽ phải trả cho giao dịch này. Nó có thể sẽ ít hơn sau khi thanh toán được thực hiện.",
     "feeError": "Không thể tính phí",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Tên người dùng {bankName: string} hiện là địa chỉ {bankName: string}.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Tài khoản USD",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -671,6 +671,7 @@
     "backupDescription": "Ukuseta ikhowudi ye-PIN, nceda wenze isipele kwiakhawunti yakho ngokongeza inombolo yefowuni."
   },
   "SendBitcoinConfirmationScreen": {
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Isixa",
     "confirmPayment": "Qinisekisa intlawulo",
     "confirmPaymentQuestion": "Ngaba uyafuna ukuqinisekisa le ntlawulo?",
@@ -685,8 +686,7 @@
     "maxFeeSelected": "Lo ngowona mrhumo uphezulu oza kubizwa ngawo kule ntengiselwano. Inokuphela incinci xa intlawulo yenziwe.",
     "feeError": "Ayiphumelelanga ukubala umrhumo",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
-    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "bankName:} amagama abasebenzisi ngoku {bankName: string} iidilesi.",
@@ -1596,7 +1596,8 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again."
+    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
+    "allowanceExhausted": "You've used today's {limit} top-up limit"
   },
   "BridgeKyc": {
     "title": "I-akhawunti ye-USD",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -685,7 +685,8 @@
     "maxFeeSelected": "Lo ngowona mrhumo uphezulu oza kubizwa ngawo kule ntengiselwano. Inokuphela incinci xa intlawulo yenziwe.",
     "feeError": "Ayiphumelelanga ukubala umrhumo",
     "breezFeeText": "There may be a small fee for routing",
-    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one."
+    "heldInvoiceExpired": "This invoice expired before the payment was sent. Go back and confirm again to get a fresh one.",
+    "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "bankName:} amagama abasebenzisi ngoku {bankName: string} iidilesi.",
@@ -1595,8 +1596,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "I-akhawunti ye-USD",


### PR DESCRIPTION
Fixes the actionable half of #694.

## The bug, honestly scoped

On external sends from cash wallets, IBEX's pre-send estimate for some routes is **0** while settlement deducts the real routing fee **from the amount** — the repro: $1.10 sent, "$0.00" fee displayed, $1.07 delivered. The app cannot conjure the true fee pre-send; IBEX does not provide it on those routes. So "make the number right" is not available — what's available is to stop presenting the 0 as a promise.

## The fix

Under exactly that case, the confirmation screen adds:

> *The network fee is deducted from the amount — the recipient may receive slightly less.*

The predicate (`fee-from-amount.logic.ts`) fires only on a **probed zero** from a **cash wallet** on an **external** send. Each exclusion is a decision, each pinned by a test:

| case | silent because |
|---|---|
| intraledger | free is *true* there — crying wolf teaches users to ignore the caveat where it matters |
| BTC-wallet sends | their probes price the actual route; a zero is a genuinely free path |
| loading / error / unset | those states already render their own caveats |
| probed nonzero | a priced fee is on screen; the caveat would dilute it |

A rare genuinely-free external route reads the soft copy — a mild false positive, priced against the current false **negative**: a customer discovering the fee on the recipient's side.

## i18n

Key added at the source (`app/i18n/en/index.ts`), types + raw exports regenerated, all 23 locales filled (Spanish translated, others English fallback — #706's convention). `check:translation-drift` and `check:translations` both green.

## Deliberately not here (follow-ups on the issue)

- A backend signal distinguishing "estimate 0" from "fee deducted from amount" — worth a small schema addition if this heuristic ever misfires
- Actual settled fee in the transaction detail

88 suites / 867 tests; tsc + eslint clean.