### PR TITLE
feat(send): give the zero fee the prominence it earns (#561)

### DIFF
--- a/__tests__/components/fee-from-amount.spec.ts
+++ b/__tests__/components/fee-from-amount.spec.ts
@@ -3,6 +3,7 @@ import { PaymentType } from "@galoymoney/client"
 import { GALOY_INSTANCES } from "@app/config"
 import { WalletCurrency } from "../../app/graphql/generated"
 import {
+  shouldCelebrateZeroFee,
   payeeNodePubkey,
   shouldDiscloseFeeFromAmount,
 } from "../../app/components/send-flow/fee-from-amount.logic"
@@ -177,5 +178,43 @@ describe("payeeNodePubkey", () => {
     expect(payeeNodePubkey("")).toBeUndefined()
     expect(payeeNodePubkey("bc1qexampledestination")).toBeUndefined()
     expect(payeeNodePubkey("lnbc-not-an-invoice")).toBeUndefined()
+  })
+})
+
+describe("shouldCelebrateZeroFee (#561)", () => {
+  it("celebrates a genuinely free send — intraledger, settled zero", () => {
+    expect(shouldCelebrateZeroFee({ ...base, paymentType: "intraledger" })).toBe(true)
+  })
+
+  it("never celebrates the probed zero that carries the disclosure", () => {
+    // The exact contradiction this predicate exists to prevent: "Flash fee
+    // $0.00, we're proud of it" rendered directly above "the network fee is
+    // deducted from the amount". If both fire, the app argues with itself on
+    // a money screen.
+    const args = { ...base } // external USD send, probed zero -> discloses
+    expect(shouldCelebrateZeroFee(args)).toBe(false)
+  })
+
+  it("celebration and disclosure are mutually exclusive for every input", () => {
+    const paymentTypes = ["intraledger", "lightning", "lnurl", "onchain"] as const
+    const currencies = [
+      WalletCurrency.Usd,
+      WalletCurrency.Usdt,
+      WalletCurrency.Btc,
+    ] as const
+    for (const paymentType of paymentTypes) {
+      for (const sendingWalletCurrency of currencies) {
+        const args = { ...base, paymentType, sendingWalletCurrency }
+        const both = shouldCelebrateZeroFee(args) && shouldDiscloseFeeFromAmount(args)
+        expect(both).toBe(false)
+      }
+    }
+  })
+
+  it("does not celebrate a nonzero fee or an unsettled state", () => {
+    expect(shouldCelebrateZeroFee({ ...base, feeAmount: 3 })).toBe(false)
+    for (const feeStatus of ["loading", "error", "unset"] as const) {
+      expect(shouldCelebrateZeroFee({ ...base, feeStatus })).toBe(false)
+    }
   })
 })

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -1,5 +1,6 @@
 import React, { PropsWithChildren } from "react"
 
+import { StyleSheet } from "react-native"
 import { act, fireEvent, render, waitFor } from "@testing-library/react-native"
 import { Intraledger } from "../../app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.stories"
 import { ContextForScreen } from "./helper"
@@ -16,7 +17,8 @@ import {
 import { ConvertMoneyAmount } from "@app/screens/send-bitcoin-screen/payment-details/index.types"
 import { BreezContext } from "@app/contexts/BreezContext"
 import { WalletCurrency } from "@app/graphql/generated"
-import { DisplayCurrency, toBtcMoneyAmount } from "@app/types/amounts"
+import { DisplayCurrency, toBtcMoneyAmount, toUsdMoneyAmount } from "@app/types/amounts"
+import { light as lightColors } from "@app/rne-theme/colors"
 import { payLightningBreez, payLnurlBreez } from "@app/utils/breez-sdk"
 import { getAnalytics } from "@react-native-firebase/analytics"
 import baseTranslation from "@app/i18n/en"
@@ -35,6 +37,19 @@ loadLocale("en")
 // against these rather than string literals means renaming a key or editing
 // the copy cannot leave a test quietly asserting the wrong sentence.
 const en = baseTranslation as Translation
+
+// The real invoice from the ENG-555 incident: issued 1787243982, expires
+// 1787244042. Its payee is the PROD Flash node (03501a…) — the same node the
+// StoryScreen-pinned "Main" instance lists in lnNodePubkeys — so for the
+// fee-from-amount disclosure it reads as a Flash-internal destination.
+const INCIDENT_INVOICE =
+  "lnbc1p4gwtwwpp5wwulk8jw0llvgjadwzuen6nxh7hgmddplj3evpgjc7n8l5kzqvmqdph2pshjgr5dusyvmrpwd5zq4mpd3kx2apq24ek2u36ypj8yetpv3kkz7qcqzzsxqzpusp5wane88x5twmdlpnu4cqrk4wd6g3tks7xgq798nt9zt68vmcnnp6q9qxpqysgqnszg0ycjk4255es2hdd3ajep3yquuvra6jn4k8shskhpzg80mrl9m9pgylahzq80aw9ekz6e47ycpcf558080xrxn6uljn54lc447rqpn9u06u"
+
+const convertMoneyAmount: ConvertMoneyAmount = (moneyAmount, currency) => ({
+  amount: moneyAmount.amount,
+  currency,
+  currencyCode: currency === DisplayCurrency ? "NGN" : currency,
+})
 
 it("SendScreen Confirmation", async () => {
   const { findByLabelText } = render(
@@ -61,9 +76,7 @@ it("SendScreen Confirmation", async () => {
 // reach the user instead of a doomed round trip — while the one path that
 // re-mints at send time is left alone.
 describe("expired held invoice", () => {
-  // The real invoice from the incident: issued 1787243982, expires 1787244042.
-  const INCIDENT_INVOICE =
-    "lnbc1p4gwtwwpp5wwulk8jw0llvgjadwzuen6nxh7hgmddplj3evpgjc7n8l5kzqvmqdph2pshjgr5dusyvmrpwd5zq4mpd3kx2apq24ek2u36ypj8yetpv3kkz7qcqzzsxqzpusp5wane88x5twmdlpnu4cqrk4wd6g3tks7xgq798nt9zt68vmcnnp6q9qxpqysgqnszg0ycjk4255es2hdd3ajep3yquuvra6jn4k8shskhpzg80mrl9m9pgylahzq80aw9ekz6e47ycpcf558080xrxn6uljn54lc447rqpn9u06u"
+  // INCIDENT_INVOICE's timestamps: issued 1787243982, expires 1787244042.
   const ISSUED = 1787243982
   const EXPIRES = 1787244042
   // This screen can perfectly well open on a dead invoice. parsePaymentDestination
@@ -84,12 +97,6 @@ describe("expired held invoice", () => {
   // 60-second Flash invoice but leaves it younger than expiry + the 120s
   // clock-skew grace. Only the elapsed-since-first-sight reading can see this one.
   const AFTER_ORDINARY_PAUSE_MS = MOUNTED_MS + 90 * 1000
-
-  const convertMoneyAmount: ConvertMoneyAmount = (moneyAmount, currency) => ({
-    amount: moneyAmount.amount,
-    currency,
-    currencyCode: currency === DisplayCurrency ? "NGN" : currency,
-  })
 
   const btcSendingWalletDescriptor = {
     currency: WalletCurrency.Btc,
@@ -366,5 +373,107 @@ describe("expired held invoice", () => {
     await waitFor(() =>
       expect(navigate).toHaveBeenCalledWith("sendBitcoinSuccess", expect.anything()),
     )
+  })
+})
+
+// #561 — the zero-fee celebration asserted at the rendered screen, not the
+// predicate. shouldCelebrateZeroFee is unit-tested in
+// __tests__/components/fee-from-amount.spec.ts, but only a render can catch
+// the wiring in ConfirmationWalletFee: `fee.amount?.amount` (not the object)
+// into the predicate, the ternary picking the celebration styles, the
+// comparison line mounting under the row. These pin both directions — a TRUE
+// zero celebrates with no caveat, and the probed zero that owes the
+// fee-from-amount disclosure (#694) gets the caveat and never the green.
+describe("zero-fee prominence (#561)", () => {
+  // A real bolt11 minted by the Test instance (2026-08-24, long expired —
+  // expiry is irrelevant here; nothing presses Send). Its payee is the Test
+  // node (02004d…, IBEX_SB), NOT the "Main" node the StoryScreen test tree
+  // pins — so the disclosure logic reads it as an external destination.
+  // INCIDENT_INVOICE would not do: it pays Main's own node, which correctly
+  // suppresses the caveat.
+  const EXTERNAL_INVOICE =
+    "lnbc14060n1p4gclcjpp555k59jc4xn0x3mej3gzmuj7lg66u0rtkq73vtvwqtrmd8luemprqdpvvejk2ttswfhkyefqwejhy6txd93kzarfdahzqgek8y6qcqzzsxqzpusp5rprrqnqhclwmc7au9vqf306mg6wndelar076yu6f8nr7md6kzv9q9qxpqysgqnpc09nfh90rew3z7d06pu3056nu24e809j5sj6qn0ytquu252h0sp2dkd6gc3qudwduecfvxw7m6vlt6mc0s3seqv0nvet4u9xpq6wsqfhuttw"
+
+  it("celebrates the intraledger zero: green fee, remittance comparison, no caveat", async () => {
+    const { findByLabelText, queryByLabelText } = render(
+      <ContextForScreen>
+        <Intraledger />
+      </ContextForScreen>,
+    )
+
+    await act(async () => {})
+    await act(async () => {})
+
+    // The comparison line renders with the real copy — not just the predicate
+    // returning true somewhere off-screen.
+    const comparison = await findByLabelText("Zero Fee Comparison")
+    expect(comparison.children).toEqual([
+      en.SendBitcoinConfirmationScreen.typicalRemittanceComparison,
+    ])
+
+    // The fee itself wears the celebration styles. An inverted ternary at the
+    // style prop would ship a plain row past every predicate test.
+    const feeText = await findByLabelText("Successful Fee")
+    expect(StyleSheet.flatten(feeText.props.style)).toMatchObject({
+      color: lightColors.green,
+      fontWeight: "bold",
+    })
+
+    // An intraledger zero is TRUE — the fee-from-amount caveat must stay silent.
+    expect(queryByLabelText("Fee From Amount Disclosure")).toBeNull()
+  })
+
+  it("never celebrates a probed zero — the caveat renders instead", async () => {
+    // The #694 shape: an external lightning send from the cash wallet whose
+    // fee probe returns a set 0. The zero is not a promise, so the disclosure
+    // must render and the celebration must not — green above a caveat would be
+    // the app contradicting itself on a money screen.
+    const usdDetail = createAmountLightningPaymentDetails({
+      paymentRequest: EXTERNAL_INVOICE,
+      paymentRequestAmount: toBtcMoneyAmount(100),
+      convertMoneyAmount,
+      sendingWalletDescriptor: { currency: WalletCurrency.Usd, id: "testwallet" },
+    })
+    const paymentDetail = {
+      ...usdDetail,
+      // Stands in for the galoy probe resolving `{ amount: 0 }` — the exact
+      // response a Test-instance probe returned live (see
+      // fee-from-amount.logic.ts). useFee reads this as status "set", amount 0.
+      getFee: async () => ({ amount: toUsdMoneyAmount(0) }),
+    }
+
+    const route = {
+      key: "sendBitcoinConfirmationScreen",
+      name: "sendBitcoinConfirmation",
+      params: { paymentDetail },
+    } as const
+
+    const { findByLabelText, queryByLabelText } = render(
+      <ContextForScreen>
+        <SendBitcoinConfirmationScreen
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          route={route as any}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          navigation={{ navigate: jest.fn() } as any}
+        />
+      </ContextForScreen>,
+    )
+
+    await act(async () => {})
+    await act(async () => {})
+
+    const disclosure = await findByLabelText("Fee From Amount Disclosure")
+    expect(disclosure.children).toEqual([
+      en.SendBitcoinConfirmationScreen.feeDeductedFromAmount,
+    ])
+
+    // No celebration anywhere on the screen: no comparison line, and the fee
+    // row keeps the theme's plain text styling (RNEUI merges a base style, so
+    // assert the celebration attributes specifically).
+    expect(queryByLabelText("Zero Fee Comparison")).toBeNull()
+    const feeText = await findByLabelText("Successful Fee")
+    const feeStyle = StyleSheet.flatten(feeText.props.style)
+    expect(feeStyle?.color).not.toBe(lightColors.green)
+    expect(feeStyle?.fontWeight).not.toBe("bold")
   })
 })

--- a/app/components/send-flow/ConfirmationError.tsx
+++ b/app/components/send-flow/ConfirmationError.tsx
@@ -15,14 +15,15 @@ const ConfirmationError: React.FC<Props> = ({
 
   const errorMessage = paymentError || invalidAmountErrorMessage
 
-  if (errorMessage) {
+  if (!!errorMessage) {
     return (
       <View style={styles.errorContainer}>
         <Text style={styles.errorText}>{errorMessage}</Text>
       </View>
     )
+  } else {
+    return null
   }
-  return null
 }
 
 export default ConfirmationError

--- a/app/components/send-flow/ConfirmationError.tsx
+++ b/app/components/send-flow/ConfirmationError.tsx
@@ -15,15 +15,14 @@ const ConfirmationError: React.FC<Props> = ({
 
   const errorMessage = paymentError || invalidAmountErrorMessage
 
-  if (!!errorMessage) {
+  if (errorMessage) {
     return (
       <View style={styles.errorContainer}>
         <Text style={styles.errorText}>{errorMessage}</Text>
       </View>
     )
-  } else {
-    return null
   }
+  return null
 }
 
 export default ConfirmationError

--- a/app/components/send-flow/ConfirmationWalletFee.tsx
+++ b/app/components/send-flow/ConfirmationWalletFee.tsx
@@ -6,7 +6,11 @@ import { makeStyles, Text } from "@rneui/themed"
 // hooks
 import useFee, { FeeType } from "@app/screens/send-bitcoin-screen/use-fee"
 
-import { payeeNodePubkey, shouldDiscloseFeeFromAmount } from "./fee-from-amount.logic"
+import {
+  payeeNodePubkey,
+  shouldCelebrateZeroFee,
+  shouldDiscloseFeeFromAmount,
+} from "./fee-from-amount.logic"
 import { useAppConfig } from "@app/hooks/use-app-config"
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 import { useFormatSats } from "@app/hooks/use-format-sats"
@@ -149,6 +153,18 @@ const ConfirmationWalletFee: React.FC<Props> = ({
     feeDisplayText = "Unable to calculate fee"
   }
 
+  // #561: celebrate a TRUE zero — never the probed zero that carries the
+  // fee-from-amount disclosure (#694); green above a caveat would be the app
+  // contradicting itself on a money screen.
+  const celebrateZeroFee = shouldCelebrateZeroFee({
+    paymentType,
+    sendingWalletCurrency: sendingWalletDescriptor.currency,
+    feeStatus: fee.status,
+    feeAmount: fee.amount?.amount,
+    destinationPayeePubkey,
+    flashNodePubkeys: galoyInstance.lnNodePubkeys,
+  })
+
   const CurrencyIcon =
     sendingWalletDescriptor.currency === WalletCurrency.Btc ? Bitcoin : Cash
   return (
@@ -180,12 +196,17 @@ const ConfirmationWalletFee: React.FC<Props> = ({
       </View>
       <View style={styles.fieldContainer}>
         <Text style={styles.fieldTitleText}>
-          {LL.SendBitcoinConfirmationScreen.feeLabel()}
+          {LL.SendBitcoinConfirmationScreen.flashFeeLabel()}
         </Text>
         <View style={styles.fieldBackground}>
           {fee.status === "loading" && <ActivityIndicator />}
           {fee.status === "set" && (
-            <Text {...testProps("Successful Fee")}>{feeDisplayText}</Text>
+            <Text
+              {...testProps("Successful Fee")}
+              style={celebrateZeroFee ? styles.zeroFeeText : undefined}
+            >
+              {feeDisplayText}
+            </Text>
           )}
           {fee.status === "error" && Boolean(fee.amount) && (
             <Text>{feeDisplayText} *</Text>
@@ -200,6 +221,11 @@ const ConfirmationWalletFee: React.FC<Props> = ({
         {fee.status === "error" && Boolean(fee.amount) && (
           <Text style={styles.maxFeeWarningText}>
             {"*" + LL.SendBitcoinConfirmationScreen.maxFeeSelected()}
+          </Text>
+        )}
+        {celebrateZeroFee && (
+          <Text {...testProps("Zero Fee Comparison")} style={styles.feeComparisonText}>
+            {LL.SendBitcoinConfirmationScreen.typicalRemittanceComparison()}
           </Text>
         )}
         {shouldDiscloseFeeFromAmount({
@@ -260,6 +286,15 @@ const useStyles = makeStyles(({ colors }) => ({
   walletSelectorBalanceContainer: {
     flex: 1,
     flexDirection: "row",
+  },
+  zeroFeeText: {
+    color: colors.green,
+    fontWeight: "bold",
+  },
+  feeComparisonText: {
+    color: colors.grey3,
+    fontSize: 12,
+    marginTop: 4,
   },
   maxFeeWarningText: {
     color: colors.warning,

--- a/app/components/send-flow/DetailDestination.tsx
+++ b/app/components/send-flow/DetailDestination.tsx
@@ -18,7 +18,8 @@ const DetailDestination: React.FC<Props> = ({ flashUserAddress, paymentDetail })
 
   if (
     paymentDetail.paymentType === "intraledger" ||
-    (paymentDetail.paymentType === "lnurl" && !!paymentDetail.lnurlParams.identifier)
+    (paymentDetail.paymentType === "lnurl" &&
+      Boolean(paymentDetail.lnurlParams.identifier))
   ) {
     return (
       <View style={styles.fieldContainer}>
@@ -35,9 +36,8 @@ const DetailDestination: React.FC<Props> = ({ flashUserAddress, paymentDetail })
         </View>
       </View>
     )
-  } else {
-    return null
   }
+  return null
 }
 
 export default DetailDestination

--- a/app/components/send-flow/DetailDestination.tsx
+++ b/app/components/send-flow/DetailDestination.tsx
@@ -18,8 +18,7 @@ const DetailDestination: React.FC<Props> = ({ flashUserAddress, paymentDetail })
 
   if (
     paymentDetail.paymentType === "intraledger" ||
-    (paymentDetail.paymentType === "lnurl" &&
-      Boolean(paymentDetail.lnurlParams.identifier))
+    (paymentDetail.paymentType === "lnurl" && !!paymentDetail.lnurlParams.identifier)
   ) {
     return (
       <View style={styles.fieldContainer}>
@@ -36,8 +35,9 @@ const DetailDestination: React.FC<Props> = ({ flashUserAddress, paymentDetail })
         </View>
       </View>
     )
+  } else {
+    return null
   }
-  return null
 }
 
 export default DetailDestination

--- a/app/components/send-flow/fee-from-amount.logic.ts
+++ b/app/components/send-flow/fee-from-amount.logic.ts
@@ -124,3 +124,21 @@ export const shouldDiscloseFeeFromAmount = ({
   (sendingWalletCurrency === WalletCurrency.Usd ||
     sendingWalletCurrency === WalletCurrency.Usdt) &&
   !isFlashNodePayee(destinationPayeePubkey, flashNodePubkeys)
+
+/**
+ * Whether the fee row may CELEBRATE — "Flash fee: $0.00" in brand green with
+ * the remittance-cost comparison underneath (#561).
+ *
+ * The celebration is the PMF moment: a transfer that would cost J$1,500–2,000
+ * through a typical remittance service costs nothing here. But a zero is only
+ * worth celebrating when it is TRUE. The same probed-zero that triggers the
+ * fee-from-amount disclosure (#694) must never be dressed in green — a row
+ * that says "$0.00, we're proud of it" directly above "the fee is deducted
+ * from the amount" would be the app contradicting itself on a money screen.
+ * So: celebrate exactly when the fee is a settled zero AND the disclosure has
+ * nothing to say.
+ */
+export const shouldCelebrateZeroFee = (
+  args: Parameters<typeof shouldDiscloseFeeFromAmount>[0],
+): boolean =>
+  args.feeStatus === "set" && args.feeAmount === 0 && !shouldDiscloseFeeFromAmount(args)

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -982,7 +982,6 @@ const en: BaseTranslation = {
     confirmPayment: "Confirm payment",
     confirmPaymentQuestion: "Do you want to confirm this payment?",
     destinationLabel: "To:",
-    feeLabel: "Fee",
     feeDeductedFromAmount:
       "The network fee is deducted from the amount — the recipient may receive slightly less.",
     flashFeeLabel: "Flash fee",

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -985,6 +985,9 @@ const en: BaseTranslation = {
     feeLabel: "Fee",
     feeDeductedFromAmount:
       "The network fee is deducted from the amount — the recipient may receive slightly less.",
+    flashFeeLabel: "Flash fee",
+    typicalRemittanceComparison:
+      "Typical remittance services charge J$1,500–2,000 for this.",
     memoLabel: "Note:",
     paymentFinal: "Payments are final.",
     stalePrice:

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -3124,6 +3124,14 @@ type RootTranslation = {
 		 */
 		feeDeductedFromAmount: string
 		/**
+		 * F​l​a​s​h​ ​f​e​e
+		 */
+		flashFeeLabel: string
+		/**
+		 * T​y​p​i​c​a​l​ ​r​e​m​i​t​t​a​n​c​e​ ​s​e​r​v​i​c​e​s​ ​c​h​a​r​g​e​ ​J​$​1​,​5​0​0​–​2​,​0​0​0​ ​f​o​r​ ​t​h​i​s​.
+		 */
+		typicalRemittanceComparison: string
+		/**
 		 * N​o​t​e​:
 		 */
 		memoLabel: string
@@ -9460,6 +9468,14 @@ export type TranslationFunctions = {
 		 * The network fee is deducted from the amount — the recipient may receive slightly less.
 		 */
 		feeDeductedFromAmount: () => LocalizedString
+		/**
+		 * Flash fee
+		 */
+		flashFeeLabel: () => LocalizedString
+		/**
+		 * Typical remittance services charge J$1,500–2,000 for this.
+		 */
+		typicalRemittanceComparison: () => LocalizedString
 		/**
 		 * Note:
 		 */

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -3116,10 +3116,6 @@ type RootTranslation = {
 		 */
 		destinationLabel: string
 		/**
-		 * F​e​e
-		 */
-		feeLabel: string
-		/**
 		 * T​h​e​ ​n​e​t​w​o​r​k​ ​f​e​e​ ​i​s​ ​d​e​d​u​c​t​e​d​ ​f​r​o​m​ ​t​h​e​ ​a​m​o​u​n​t​ ​—​ ​t​h​e​ ​r​e​c​i​p​i​e​n​t​ ​m​a​y​ ​r​e​c​e​i​v​e​ ​s​l​i​g​h​t​l​y​ ​l​e​s​s​.
 		 */
 		feeDeductedFromAmount: string
@@ -9460,10 +9456,6 @@ export type TranslationFunctions = {
 		 * To:
 		 */
 		destinationLabel: () => LocalizedString
-		/**
-		 * Fee
-		 */
-		feeLabel: () => LocalizedString
 		/**
 		 * The network fee is deducted from the amount — the recipient may receive slightly less.
 		 */

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -886,6 +886,8 @@
         "destinationLabel": "To:",
         "feeLabel": "Fee",
         "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
+        "flashFeeLabel": "Flash fee",
+        "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
         "memoLabel": "Note:",
         "paymentFinal": "Payments are final.",
         "stalePrice": "Your bitcoin price is old and was last updated {timePeriod} ago. Please restart the app before making a payment.",

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -884,7 +884,6 @@
         "confirmPayment": "Confirm payment",
         "confirmPaymentQuestion": "Do you want to confirm this payment?",
         "destinationLabel": "To:",
-        "feeLabel": "Fee",
         "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
         "flashFeeLabel": "Flash fee",
         "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -629,6 +629,8 @@
     "backupDescription": "To set a PIN code, please back up your account by adding a phone number."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Bedrag:",
     "confirmPayment": "Bevestig betaling",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -636,7 +636,6 @@
     "confirmPayment": "Bevestig betaling",
     "confirmPaymentQuestion": "Wil jy hierdie betaling bevestig?",
     "destinationLabel": "Aan:",
-    "feeLabel": "Fooi",
     "memoLabel": "Nota:",
     "paymentFinal": "Betalings is finaal en onomkeerbaar.",
     "stalePrice": "Jou Bitcoin prys is oud en was {timePeriod} gelede laas hersien. Herlaai asseblief die toepassing voordat jy betalngs maak.",
@@ -1600,8 +1599,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD-rekening",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -628,7 +628,6 @@
     "confirmPayment": "تأكيد الدفع",
     "confirmPaymentQuestion": "هل تريد تأكيد هذا الدفع؟",
     "destinationLabel": "الى:",
-    "feeLabel": "رسوم تحويل",
     "memoLabel": "اكتب ملاحظة:",
     "paymentFinal": "المدفوعات نهائية.",
     "stalePrice": "سعر البيتكوين عندك قديم لم يحدّث منذ {timePeriod}. أعد تشغيل التطبيق رجاءً قبل أي دفع.",
@@ -1605,8 +1604,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "حساب بالدولار",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -621,6 +621,8 @@
     "backupDescription": "To set a PIN code, please back up your account by adding a phone number."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "كمية:",
     "confirmPayment": "تأكيد الدفع",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Confirma el pagament",
     "confirmPaymentQuestion": "Vols confirmar aquest pagament?",
     "destinationLabel": "A:",
-    "feeLabel": "Comissió",
     "memoLabel": "Nota:",
     "paymentFinal": "Els pagaments són definitius.",
     "stalePrice": "El preu de bitcoin és antic i es va actualitzar per última vegada fa {timePeriod}. Si us plau, reinicia l'aplicació abans de fer un pagament.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Compte en USD",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -671,6 +671,8 @@
     "backupDescription": "Per a configurar un codi PIN, si us plau, fer una copia de seguretat del vostre compte afegint un número de telèfon."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Import:",
     "confirmPayment": "Confirma el pagament",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Potvrďte platbu",
     "confirmPaymentQuestion": "Chcete tuto platbu potvrdit?",
     "destinationLabel": "Komu:",
-    "feeLabel": "Poplatek",
     "memoLabel": "Poznámka:",
     "paymentFinal": "Platby jsou konečné.",
     "stalePrice": "Vaše cena bitcoinu je stará a naposledy byla aktualizována před {timePeriod}. Před provedením platby prosím restartujte aplikaci.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD účet",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -671,6 +671,8 @@
     "backupDescription": "Pokud chcete nastavit kód PIN, zálohte si svůj účet přidáním telefonního čísla."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Částka:",
     "confirmPayment": "Potvrďte platbu",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -671,6 +671,8 @@
     "backupDescription": "Til at indstille en PIN-kode, skal du sikkerhedskopiere din konto ved at tilføje et telefonnummer."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Beløb:",
     "confirmPayment": "Bekræft betaling",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Bekræft betaling",
     "confirmPaymentQuestion": "Vil du bekræfte denne betaling?",
     "destinationLabel": "Til:",
-    "feeLabel": "Gebyr",
     "memoLabel": "Note:",
     "paymentFinal": "Betalinger er endelige.",
     "stalePrice": "Din bitcoin-pris er gammel og blev sidst opdateret for {timePeriod} siden. Genstart appen, inden du foretager en betaling.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD-konto",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Zahlung bestätigen",
     "confirmPaymentQuestion": "Möchtest Du diese Zahlung bestätigen?",
     "destinationLabel": "An:",
-    "feeLabel": "Gebühr",
     "memoLabel": "Notiz:",
     "paymentFinal": "Zahlungen sind final.",
     "stalePrice": "Der Bitcoin Preis ist veraltet und wurde zuletzt {timePeriod} aktualisiert. Bitte starte die App erneut, bevor Du eine Zahlung tätigst.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD-Konto",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -671,6 +671,8 @@
     "backupDescription": "Um einen PIN-Code einzurichten, unterstützen Sie bitte Ihr Konto, indem Sie eine Telefonnummer hinzufügen."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Betrag:",
     "confirmPayment": "Zahlung bestätigen",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -671,6 +671,8 @@
     "backupDescription": "Για να ορίσετε έναν κωδικό PIN, παρακαλούμε κάντε αντίγραφο ασφαλείας του λογαριασμού σας προσθέτοντας έναν αριθμό τηλεφώνου."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Ποσό:",
     "confirmPayment": "Επιβεβαίωση πληρωμής",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Επιβεβαίωση πληρωμής",
     "confirmPaymentQuestion": "Θέλετε να επιβεβαιώσετε αυτή την πληρωμή;",
     "destinationLabel": "Προς:",
-    "feeLabel": "Τέλη ",
     "memoLabel": "Σημείωση:",
     "paymentFinal": "Οι πληρωμές είναι οριστικές.",
     "stalePrice": "Η τιμή του bitcoin σας είναι παλιά και ενημερώθηκε για τελευταία φορά πριν από {timePeriod}. Παρακαλούμε κάντε επανεκκίνηση της εφαρμογής πριν πραγματοποιήσετε μια πληρωμή.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Λογαριασμός USD",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -671,6 +671,8 @@
     "backupDescription": "Para configurar un código PIN, haga una copia de seguridad de su cuenta añadiendo un número de teléfono."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Comisión Flash",
+    "typicalRemittanceComparison": "Los servicios de remesas típicos cobran J$1,500–2,000 por esto.",
     "feeDeductedFromAmount": "La comisión de red se deduce del monto — el destinatario puede recibir un poco menos.",
     "amountLabel": "Cantidad:",
     "confirmPayment": "Confirmar y pagar",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Confirmar y pagar",
     "confirmPaymentQuestion": "¿Desea confirmar este pago?",
     "destinationLabel": "Para:",
-    "feeLabel": "Tarifa de red",
     "memoLabel": "Nota:",
     "paymentFinal": "Recuerde que los pagos son definitivos y una vez realizados son irreversibles.",
     "stalePrice": "El precio de bitcoin está desactualizado, se actualizó por última vez hace {timePeriod}. Por favor reinicie la aplicación antes de realizar el pago.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Cuenta en USD",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -671,6 +671,8 @@
     "backupDescription": "Pour définir un code PIN, veuillez sauvegarder votre compte en ajoutant un numéro de téléphone."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Montant :",
     "confirmPayment": "Confirmer le paiement",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Confirmer le paiement",
     "confirmPaymentQuestion": "Voulez-vous confirmer le paiement ?",
     "destinationLabel": "À :",
-    "feeLabel": "Frais",
     "memoLabel": "Note :",
     "paymentFinal": "Les paiements sont définitifs.",
     "stalePrice": "Votre prix pour un bitcoin n’est plus valable et a été mis-à-jour il y a {timePeriod}. Veuillez redémarrer l’application avant d’effectuer un paiement.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Compte en USD",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -671,6 +671,8 @@
     "backupDescription": "Za postavljanje PIN koda, molimo vas da se zauzmete pomoću dodavanja telefonskog broja."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Iznos:",
     "confirmPayment": "Potvrdi plaćanje",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Potvrdi plaćanje",
     "confirmPaymentQuestion": "Želite li potvrditi ovo plaćanje?",
     "destinationLabel": "Za:",
-    "feeLabel": "Naknada",
     "memoLabel": "Bilješka:",
     "paymentFinal": "Plaćanja su konačna.",
     "stalePrice": "Vaša cijena bitcoina je stara i zadnji put je ažurirana prije {timePeriod}. Ponovno pokrenite aplikaciju prije plaćanja.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD račun",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Fizetés megerősítése",
     "confirmPaymentQuestion": "Megerősíted ezt a fizetést?",
     "destinationLabel": "Címzett:",
-    "feeLabel": "Díj",
     "memoLabel": "Megjegyzés:",
     "paymentFinal": "A fizetések véglegesek.",
     "stalePrice": "A Bitcoin ár elavult. Az utolsó frissítés óta eltelt idő: {timePeriod}. Kérjük, indítsd újra az alkalmazást, mielőtt fizetést hajtanál végre.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD-számla",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -671,6 +671,8 @@
     "backupDescription": "Ha egy PIN kódot állítanak be, kérjük, biztonsági mentse a fiókját egy telefonszám hozzáadásával."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Összeg:",
     "confirmPayment": "Fizetés megerősítése",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -671,6 +671,8 @@
     "backupDescription": "PIN կոդը սահմանելու համար խնդրում ենք պահեստավորել ձեր հաշիվը' ավելացնելով հեռախոսահամար:"
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Չափը․",
     "confirmPayment": "Հաստատել վճարումը",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Հաստատել վճարումը",
     "confirmPaymentQuestion": "Դուք ցանկանու՞մ եք հաստատել այս վճարումը։ ",
     "destinationLabel": "Ստացող՝",
-    "feeLabel": "Վճար",
     "memoLabel": "Նշում․",
     "paymentFinal": "Վճարումները վերջնական են։ ",
     "stalePrice": "Ձեր բիթքոյնի գինը հին է և վերջին անգամ թարմացվել է {timePeriod} առաջ։ Խնդում ենք վերաթողարկել հավելվածը վճարումն անելուց առաջ։ ",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD հաշիվ",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Conferma pagamento",
     "confirmPaymentQuestion": "Vuoi confermare questo pagamento?",
     "destinationLabel": "A:",
-    "feeLabel": "Fee",
     "memoLabel": "Nota:",
     "paymentFinal": "I pagamenti non sono reversibili.",
     "stalePrice": "Il prezzo del bitcoin è vecchio ed è stato aggiornato l'ultima volta {timePeriod} fa. Riavvia l'applicazione prima di effettuare un pagamento.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Conto in USD",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -671,6 +671,8 @@
     "backupDescription": "Per impostare un codice PIN, si prega di fare un backup dell'account aggiungendo un numero di telefono."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Importo:",
     "confirmPayment": "Conferma pagamento",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Bayar dengan pasti ",
     "confirmPaymentQuestion": "Anda pasti nak buat pembayaran ini?",
     "destinationLabel": "Kepada",
-    "feeLabel": "Cas dikenakan",
     "memoLabel": "Nota pesanan:",
     "paymentFinal": "Bayaran adalah betul",
     "stalePrice": "Harga bitcoin anda ni yang lama dan tidak dikemaskin{tempohWaktu} yang lalu. Sila mula semula aplikasi ini sebelum membuat apa apa bayaran.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Akaun USD",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -671,6 +671,8 @@
     "backupDescription": "Untuk menetapkan kod PIN, sila sandarkan akaun anda dengan menambah nombor telefon."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Jumlah:",
     "confirmPayment": "Bayar dengan pasti ",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -671,6 +671,8 @@
     "backupDescription": "Als u een PIN-code hebt ingesteld, moet u uw account back-up maken door een telefoonnummer toe te voegen."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Bedrag:",
     "confirmPayment": "Bevestig betaling",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Bevestig betaling",
     "confirmPaymentQuestion": "Wil je deze betaling bevestigen?",
     "destinationLabel": "Naar:",
-    "feeLabel": "Kosten",
     "memoLabel": "Noot:",
     "paymentFinal": "Betalingen zijn definitief.",
     "stalePrice": "Je bitcoin-prijs is oud en is {timePeriod} geleden voor het laatst bijgewerkt. Start de app opnieuw voordat u een betaling uitvoert.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD-rekening",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -671,6 +671,8 @@
     "backupDescription": "Para definir um código PIN, faça backup da sua conta adicionando um número de telefone."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Quantidade:",
     "confirmPayment": "Confirmar pagamento",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Confirmar pagamento",
     "confirmPaymentQuestion": "Deseja confirmar este pagamento?",
     "destinationLabel": "Para:",
-    "feeLabel": "Taxa:",
     "memoLabel": "Observação:",
     "paymentFinal": "Os pagamentos são finais.",
     "stalePrice": "O preço do seu bitcoin é antigo e foi atualizado pela última vez {timePeriod} atrás. Reinicie o aplicativo antes de fazer um pagamento.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Conta em USD",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -671,6 +671,8 @@
     "backupDescription": "PIN kodonpi qhawariyta munaspaqa, huk telefonata qoykuspa cuentaykita saqerunchis."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Suma:",
     "confirmPayment": "Kawsayniyta qillqata sutichinaqinmi",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Kawsayniyta qillqata sutichinaqinmi",
     "confirmPaymentQuestion": "Kawsayniyta qillqata sutichinaqinmi kaniy rikuyta munanpi yachanakuyta sutichaqmi?",
     "destinationLabel": "Kaniy:",
-    "feeLabel": "Fee",
     "memoLabel": "Ñuqa:",
     "paymentFinal": "Kawsayniyta qillqata sutichinaqinmi, kaniy rikuyta munanpi ch'usaq kayniyta rikuy munanpi kawsayniyta qillqata sutichinaqinmi.",
     "stalePrice": "Kaniyta rikuyta munanpi, Bitcoin kawsayniyta qillqata sutichinaqinmi, chaypi {timePeriod} qhipa kaniyta rikuyta munanpi ch'usaqta munanpi kawsayniyta qillqata sutichinaqinmi. Kawsayniyta qillqata sutichinaqinmi kaniy rikuyta munanpi ch'usaq kayniyta rikuy munanpi kawsayniyta qillqata sutichinaqinmi.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD cuenta",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -671,6 +671,8 @@
     "backupDescription": "Да бисте поставили PIN код, молимо вас да резервирате свој рачун додавањем телефонског броја."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Износ:",
     "confirmPayment": "Потврди плаћање",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Потврди плаћање",
     "confirmPaymentQuestion": "Да ли желите да потврдите ово плаћање?",
     "destinationLabel": "За:",
-    "feeLabel": "Накнада",
     "memoLabel": "Белешка:",
     "paymentFinal": "Плаћања су неповратна.",
     "stalePrice": "Ваша цена Биткоина је стара и последњи пут је ажурирана пре {timePeriod}. Молимо вас поново покрените апликацију пре него што извршите плаћање.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD рачун",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -628,7 +628,6 @@
     "confirmPayment": "Thibithisha malipo",
     "confirmPaymentQuestion": "Je, unataka kuthibitisha malipo haya?",
     "destinationLabel": "Kwa:",
-    "feeLabel": "Ada:",
     "memoLabel": "Kidokezo:",
     "paymentFinal": "Malipo hayawezi kubadilishwa",
     "stalePrice": "Bei yako ya Bitcoin ni zee na ilisasishwa mwisho {timePeriod} iliopita. Tafadhali anzisha upya programu yako kabla ya kufanya malipo.",
@@ -1605,8 +1604,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Akaunti ya USD",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -621,6 +621,8 @@
     "backupDescription": "To set a PIN code, please back up your account by adding a phone number."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Kiasi",
     "confirmPayment": "Thibithisha malipo",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -671,6 +671,8 @@
     "backupDescription": "สําหรับการตั้งรหัส PIN กรุณาทําสํารองบัญชีของคุณโดยการเพิ่มเบอร์โทรศัพท์"
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "จำนวน:",
     "confirmPayment": "ยืนยันการชำระเงิน",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -678,7 +678,6 @@
     "confirmPayment": "ยืนยันการชำระเงิน",
     "confirmPaymentQuestion": "ยืนยันการทำธุรกรรมนี้หรือไม่?",
     "destinationLabel": "ถึง:",
-    "feeLabel": "ค่าธรรมเนียม",
     "memoLabel": "โน้ต:",
     "paymentFinal": "การชำระเงินเสร็จสิ้น",
     "stalePrice": "ราคาบิตคอยน์ของคุณเป็นราคาเก่า ซึ่งอัปเดตล่าสุดเมื่อ {timePeriod} ที่แล้ว โปรดรีสตาร์ทแอปใหม่ ก่อนจะนำมาชำระเงิน",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "บัญชี USD",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Ödemeyi onayla",
     "confirmPaymentQuestion": "Bu ödemeyi onaylıyor musunuz?",
     "destinationLabel": "Şuna:",
-    "feeLabel": "Ücret:",
     "memoLabel": "Not:",
     "paymentFinal": "Ödemeler iptal edilemez.",
     "stalePrice": "Bitcoin fiyatınız eski ve en son {timePeriod} önce güncellendi. Lütfen ödeme yapmadan önce uygulamayı yeniden başlatın.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "USD hesabı",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -671,6 +671,8 @@
     "backupDescription": "Bir PIN kodu ayarlamak için, lütfen bir telefon numarası ekleyerek hesabınızı yedekleyin."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Miktar:",
     "confirmPayment": "Ödemeyi onayla",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Xác nhận thanh toán",
     "confirmPaymentQuestion": "Bạn có muốn xác nhận thanh toán này?",
     "destinationLabel": "Tới:",
-    "feeLabel": "Phí",
     "memoLabel": "Ghi chú:",
     "paymentFinal": "Thanh toán không thể sửa đổi khi đã hoàn tất.",
     "stalePrice": "Giá bitcoin của bạn đã cũ và được cập nhật lần cuối vào {timePeriod} trước. Vui lòng khởi động lại ứng dụng trước khi thanh toán.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "Tài khoản USD",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -671,6 +671,8 @@
     "backupDescription": "Để đặt mã PIN, vui lòng sao lưu tài khoản của bạn bằng cách thêm một số điện thoại."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Số tiền",
     "confirmPayment": "Xác nhận thanh toán",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -678,7 +678,6 @@
     "confirmPayment": "Qinisekisa intlawulo",
     "confirmPaymentQuestion": "Ngaba uyafuna ukuqinisekisa le ntlawulo?",
     "destinationLabel": "ukuya:",
-    "feeLabel": "Umrhumo",
     "memoLabel": "Phawula:",
     "paymentFinal": "Iintlawulo zokugqibela.",
     "stalePrice": "Ixabiso lakho le-bitcoin lidala kwaye ligqibele ukuhlaziywa {timePeriod} eyadlulayo. Nceda uqalise kwakhona i-app phambi kokuba wenze intlawulo.",
@@ -1599,8 +1598,7 @@
     "checkoutFailed": "We couldn't set up your payment. Nothing has been charged — please try again.",
     "upgradeRequiredTitle": "Upgrade required",
     "invalidAmountTitle": "Invalid amount",
-    "paymentSetupFailed": "Failed to initiate payment. Please try again.",
-    "allowanceExhausted": "You've used today's {limit} top-up limit"
+    "paymentSetupFailed": "Failed to initiate payment. Please try again."
   },
   "BridgeKyc": {
     "title": "I-akhawunti ye-USD",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -671,6 +671,8 @@
     "backupDescription": "Ukuseta ikhowudi ye-PIN, nceda wenze isipele kwiakhawunti yakho ngokongeza inombolo yefowuni."
   },
   "SendBitcoinConfirmationScreen": {
+    "flashFeeLabel": "Flash fee",
+    "typicalRemittanceComparison": "Typical remittance services charge J$1,500–2,000 for this.",
     "feeDeductedFromAmount": "The network fee is deducted from the amount — the recipient may receive slightly less.",
     "amountLabel": "Isixa",
     "confirmPayment": "Qinisekisa intlawulo",


### PR DESCRIPTION
Closes #561 (Lori's app-audit P1). **Based on `fix/fee-from-amount-disclosure` — merges after #708**, because the two features share the fee row and must agree.

## What changes

| before | after |
|---|---|
| `Fee` — same weight as every row | `Flash fee` — value in theme green, **bold** |
| no context | small gray line: *"Typical remittance services charge J$1,500–2,000 for this."* |

Copy decided with Jabari: the comparison lands without naming a competitor in-app (brand rule).

## The integration decision, pinned by a property test

**Celebration and #708's fee-from-amount disclosure are mutually exclusive by construction.** `shouldCelebrateZeroFee` fires only on a settled zero that `shouldDiscloseFeeFromAmount` has nothing to say about. A row that says *"$0.00, we're proud of it"* directly above *"the network fee is deducted from the amount"* would be the app contradicting itself on a money screen. The test sweeps every `paymentType × currency` combination and asserts both predicates never fire together — so a future edit to either can't silently reintroduce the contradiction.

Concretely: intraledger sends and Flash-to-Flash lightning (payee-node suppressed) celebrate; an external USD send with a probed zero shows the caveat, never the green.

## Color note

#561 asked for `#3ab54a`, which isn't in the theme. This uses `colors.green` (defined for light *and* dark) rather than hardcoding an off-theme hex — a one-line palette addition if the exact brand hex is wanted, and I'd rather that be a deliberate design call.

## i18n

Two keys at the source, types regenerated, all 23 locales filled (Spanish translated: *"Los servicios de remesas típicos cobran J$1,500–2,000 por esto."*), drift check green.

88 suites / 884 tests.