### PR TITLE
feat(breez): surface the Spark USDT token balance (ENG-473) (#704)

### DIFF
--- a/__tests__/utils/breez-token-balances.spec.ts
+++ b/__tests__/utils/breez-token-balances.spec.ts
@@ -30,9 +30,23 @@ describe("selectUsdtBalance", () => {
     expect(result).toEqual({
       identifier: "tok:usdt",
       issuerPublicKey: "02abc",
+      issuerVerified: false,
       balanceMinor: BigInt("12345678"),
       decimals: 6,
     })
+  })
+
+  it("marks the result unverified — a lone ticker match proves nothing", () => {
+    // The ambiguity check only fires for a user who already holds the real
+    // token. Airdrop a spoofed USDT to a user holding none and it is the only
+    // match, so it is what comes back. Nothing about a single match is trusted,
+    // and the result has to say so.
+    const spoofOnly = selectUsdtBalance(
+      map(token({ identifier: "tok:spoof", issuerPublicKey: "02spoof" })),
+    )
+
+    expect(spoofOnly?.issuerVerified).toBe(false)
+    expect(spoofOnly?.issuerPublicKey).toBe("02spoof")
   })
 
   it("carries decimals from metadata rather than assuming 6", () => {
@@ -94,6 +108,10 @@ describe("selectUsdtBalance", () => {
   })
 
   it("returns undefined for an empty, missing, or non-Map balance set", () => {
+    // Silenced, not asserted — the warning itself is covered by its own case
+    // below.
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
     expect(selectUsdtBalance(new Map())).toBeUndefined()
     expect(selectUsdtBalance(undefined)).toBeUndefined()
     expect(selectUsdtBalance(null)).toBeUndefined()
@@ -101,6 +119,42 @@ describe("selectUsdtBalance", () => {
     expect(
       selectUsdtBalance({} as unknown as Map<string, SparkTokenBalanceLike>),
     ).toBeUndefined()
+
+    warn.mockRestore()
+  })
+
+  it("warns when tokenBalances is present but not Map-shaped", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+    // Absent is normal and stays quiet; present-but-wrong-shape is the SDK
+    // drifting under us, and a silently missing balance with nothing in the
+    // logs is how that goes unnoticed for a release.
+    selectUsdtBalance(undefined)
+    selectUsdtBalance(null)
+    expect(warn).not.toHaveBeenCalled()
+
+    expect(
+      selectUsdtBalance({} as unknown as Map<string, SparkTokenBalanceLike>),
+    ).toBeUndefined()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("not a Map"))
+
+    warn.mockRestore()
+  })
+
+  it("refuses a balance the SDK did not hand over as a bigint", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+    // A future Spark bump lowering u128 as a string or a number would leave
+    // balanceMinor typed bigint without being one, and the first consumer doing
+    // `balanceMinor / 10n ** BigInt(decimals)` throws. Missing beats lying.
+    const withBalance = (balance: unknown): SparkTokenBalanceLike =>
+      ({ ...token(), balance } as unknown as SparkTokenBalanceLike)
+
+    expect(selectUsdtBalance(map(withBalance("12345678")))).toBeUndefined()
+    expect(selectUsdtBalance(map(withBalance(12345678)))).toBeUndefined()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("not bigint"))
+
+    warn.mockRestore()
   })
 
   it("does not throw on a malformed entry with no metadata", () => {

--- a/__tests__/utils/breez-token-balances.spec.ts
+++ b/__tests__/utils/breez-token-balances.spec.ts
@@ -190,6 +190,16 @@ describe("selectUsdtBalance", () => {
     expect(result?.balanceMinor).toBe(BigInt("42"))
   })
 
+  it("returns undefined rather than throwing when the ticker is not a string", () => {
+    // A bridge that lowers the ticker as a number makes `.toUpperCase`
+    // undefined; optional chaining would not save it, and the throw would
+    // escape through Array.filter into updateBalance().
+    const numericTicker = token({ ticker: 1 as unknown as string })
+
+    expect(() => selectUsdtBalance(map(numericTicker))).not.toThrow()
+    expect(selectUsdtBalance(map(numericTicker))).toBeUndefined()
+  })
+
   it("does not throw on a malformed entry with no metadata", () => {
     const malformed = { balance: BigInt("1") } as unknown as SparkTokenBalanceLike
 

--- a/__tests__/utils/breez-token-balances.spec.ts
+++ b/__tests__/utils/breez-token-balances.spec.ts
@@ -157,6 +157,39 @@ describe("selectUsdtBalance", () => {
     warn.mockRestore()
   })
 
+  it("refuses a decimals the SDK did not hand over as a non-negative integer", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+    // Same failure class as the balance guard, one field over. Nothing upstream
+    // vouches for decimals — the ticker filter only reads tokenMetadata.ticker
+    // — so an FFI bridge that stops lowering it as a number lands here, and the
+    // documented consumer expression `balanceMinor / 10n ** BigInt(decimals)`
+    // throws "Cannot convert undefined to a BigInt".
+    const withDecimals = (decimals: unknown): SparkTokenBalanceLike =>
+      token({ decimals: decimals as number })
+
+    expect(selectUsdtBalance(map(withDecimals(undefined)))).toBeUndefined()
+    expect(selectUsdtBalance(map(withDecimals(null)))).toBeUndefined()
+    expect(selectUsdtBalance(map(withDecimals("6")))).toBeUndefined()
+    expect(selectUsdtBalance(map(withDecimals(6.5)))).toBeUndefined()
+    expect(selectUsdtBalance(map(withDecimals(NaN)))).toBeUndefined()
+    // BigInt(-2) is fine; 10n ** -2n is a RangeError, so it fails the same way.
+    expect(selectUsdtBalance(map(withDecimals(-2)))).toBeUndefined()
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("not a non-negative integer"),
+    )
+
+    warn.mockRestore()
+  })
+
+  it("accepts 0 decimals — an integer token is not a missing one", () => {
+    const result = selectUsdtBalance(map(token({ decimals: 0, balance: BigInt("42") })))
+
+    expect(result?.decimals).toBe(0)
+    expect(result?.balanceMinor).toBe(BigInt("42"))
+  })
+
   it("does not throw on a malformed entry with no metadata", () => {
     const malformed = { balance: BigInt("1") } as unknown as SparkTokenBalanceLike
 

--- a/__tests__/utils/breez-token-balances.spec.ts
+++ b/__tests__/utils/breez-token-balances.spec.ts
@@ -1,0 +1,112 @@
+import {
+  selectUsdtBalance,
+  USDT_TICKER,
+  type SparkTokenBalanceLike,
+} from "@app/utils/breez-sdk/token-balances"
+
+const token = (
+  overrides: Partial<SparkTokenBalanceLike["tokenMetadata"]> & { balance?: bigint } = {},
+): SparkTokenBalanceLike => {
+  const { balance = BigInt("1000000"), ...metadata } = overrides
+  return {
+    balance,
+    tokenMetadata: {
+      identifier: "tok:usdt",
+      issuerPublicKey: "02abc",
+      ticker: USDT_TICKER,
+      decimals: 6,
+      ...metadata,
+    },
+  }
+}
+
+const map = (...entries: SparkTokenBalanceLike[]) =>
+  new Map(entries.map((entry, i) => [entry?.tokenMetadata?.identifier || `k${i}`, entry]))
+
+describe("selectUsdtBalance", () => {
+  it("returns the USDT token's balance in minor units, undivided", () => {
+    const result = selectUsdtBalance(map(token({ balance: BigInt("12345678") })))
+
+    expect(result).toEqual({
+      identifier: "tok:usdt",
+      issuerPublicKey: "02abc",
+      balanceMinor: BigInt("12345678"),
+      decimals: 6,
+    })
+  })
+
+  it("carries decimals from metadata rather than assuming 6", () => {
+    const result = selectUsdtBalance(map(token({ decimals: 8, balance: BigInt("100") })))
+
+    expect(result?.decimals).toBe(8)
+    // The raw balance is untouched — 100 minor units at 8 decimals, not at 6.
+    expect(result?.balanceMinor).toBe(BigInt("100"))
+  })
+
+  it("keeps full precision on balances beyond Number.MAX_SAFE_INTEGER", () => {
+    const huge = BigInt("9007199254740993") // MAX_SAFE_INTEGER + 2
+
+    const result = selectUsdtBalance(map(token({ balance: huge })))
+
+    expect(result?.balanceMinor).toBe(huge)
+    // The value a Number round-trip would have silently produced instead.
+    expect(result?.balanceMinor).not.toBe(BigInt(Number(huge)))
+  })
+
+  it("matches the ticker case-insensitively", () => {
+    expect(selectUsdtBalance(map(token({ ticker: "usdt" })))?.balanceMinor).toBe(
+      BigInt("1000000"),
+    )
+  })
+
+  it("ignores other tokens and picks the USDT one", () => {
+    const result = selectUsdtBalance(
+      map(
+        token({ identifier: "tok:other", ticker: "SPRK", balance: BigInt("42") }),
+        token({ identifier: "tok:usdt", balance: BigInt("7") }),
+      ),
+    )
+
+    expect(result?.identifier).toBe("tok:usdt")
+    expect(result?.balanceMinor).toBe(BigInt("7"))
+  })
+
+  it("refuses to guess when two tokens both claim the USDT ticker", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+
+    const result = selectUsdtBalance(
+      map(
+        token({ identifier: "tok:real", issuerPublicKey: "02real" }),
+        token({ identifier: "tok:spoof", issuerPublicKey: "02spoof" }),
+      ),
+    )
+
+    // Surfacing a spoofed issuer's balance as the user's money is worse than
+    // surfacing nothing.
+    expect(result).toBeUndefined()
+    expect(warn).toHaveBeenCalled()
+
+    warn.mockRestore()
+  })
+
+  it("returns undefined when no token carries the USDT ticker", () => {
+    expect(selectUsdtBalance(map(token({ ticker: "SPRK" })))).toBeUndefined()
+  })
+
+  it("returns undefined for an empty, missing, or non-Map balance set", () => {
+    expect(selectUsdtBalance(new Map())).toBeUndefined()
+    expect(selectUsdtBalance(undefined)).toBeUndefined()
+    expect(selectUsdtBalance(null)).toBeUndefined()
+    // The SDK bridge has changed shapes before; a plain object must not throw.
+    expect(
+      selectUsdtBalance({} as unknown as Map<string, SparkTokenBalanceLike>),
+    ).toBeUndefined()
+  })
+
+  it("does not throw on a malformed entry with no metadata", () => {
+    const malformed = { balance: BigInt("1") } as unknown as SparkTokenBalanceLike
+
+    expect(() => selectUsdtBalance(map(malformed))).not.toThrow()
+    expect(selectUsdtBalance(map(malformed))).toBeUndefined()
+  })
+})

--- a/app/app.tsx
+++ b/app/app.tsx
@@ -105,8 +105,11 @@ export const App = () => {
                                   {/* One version check for the whole tree — the
                                       home-screen banner inside RootStack reads
                                       it too — and the blocking gate, which the
-                                      boundary pins as the last sibling so paint
-                                      order cannot be broken from here. */}
+                                      boundary pins as the last sibling of its
+                                      own subtree. Note this provider's own
+                                      modal is natively hosted and can still
+                                      paint above the gate; see the boundary's
+                                      docblock. */}
                                   <AppUpdateBoundary>
                                     <AppStateWrapper />
                                     <PushNotificationComponent />

--- a/app/components/app-update/app-update-boundary.tsx
+++ b/app/components/app-update/app-update-boundary.tsx
@@ -12,6 +12,15 @@ import { AppUpdateGate, AppUpdateProvider } from "./app-update"
  * #545), so paint order follows sibling order and anything mounted after the
  * gate would draw over a block that has no dismiss. Keeping the gate inside this
  * component means a later edit to `app.tsx` cannot reorder it by accident.
+ *
+ * That ordering only governs THIS subtree. A modal from an ancestor provider
+ * that uses the default `coverScreen` goes through the native modal host and
+ * paints above inline content whatever the sibling order — `NotificationsProvider`
+ * wraps this boundary in `app.tsx` and its `CustomModal` does exactly that. Such
+ * a modal can cover the gate. It is dismissible and the gate is still underneath
+ * afterwards, so nobody is stranded; putting the gate genuinely on top would mean
+ * hoisting it above `NotificationsProvider`, which is a structural change that
+ * deserves its own PR and its own argument (#704).
  * Second, `app.tsx` cannot be rendered under jest — it pulls in Firebase,
  * reanimated and a pile of native modules at import time — so the wiring is only
  * testable once it lives somewhere that can be mounted on its own.

--- a/app/components/app-update/app-update-boundary.tsx
+++ b/app/components/app-update/app-update-boundary.tsx
@@ -13,17 +13,21 @@ import { AppUpdateGate, AppUpdateProvider } from "./app-update"
  * gate would draw over a block that has no dismiss. Keeping the gate inside this
  * component means a later edit to `app.tsx` cannot reorder it by accident.
  *
- * That ordering only governs THIS subtree. A modal from an ancestor provider
- * that uses the default `coverScreen` goes through the native modal host and
- * paints above inline content whatever the sibling order — `NotificationsProvider`
- * wraps this boundary in `app.tsx` and its `CustomModal` does exactly that. Such
- * a modal can cover the gate. It is dismissible and the gate is still underneath
- * afterwards, so nobody is stranded; putting the gate genuinely on top would mean
- * hoisting it above `NotificationsProvider`, which is a structural change that
- * deserves its own PR and its own argument (#704).
  * Second, `app.tsx` cannot be rendered under jest — it pulls in Firebase,
  * reanimated and a pile of native modules at import time — so the wiring is only
  * testable once it lives somewhere that can be mounted on its own.
+ *
+ * The sibling ordering above only governs inline content. `CustomModal` renders `<Modal>` with
+ * the default `coverScreen`, so it goes through RCTModalHostView and paints
+ * above the entire inline root no matter where it sits in the tree — and
+ * `NotificationsProvider`'s `notifyModal` is exactly that. Such a modal can
+ * cover the gate. It is dismissible and the gate is still underneath afterwards,
+ * so nobody is stranded. Note that moving this boundary above
+ * `NotificationsProvider` would NOT fix it: a native-host modal outranks inline
+ * content regardless of sibling order. The two fixes that would work are passing
+ * `coverScreen={false}` to the notification `CustomModal` so it renders inline
+ * and obeys sibling order, or gating `notifyModal` on the update gate not being
+ * active. Neither is in scope here (#704).
  *
  * The soft "update available" banner is mounted separately, on the home screen.
  * The gate lives here so deep-link cold starts that never render Home cannot

--- a/app/contexts/BreezContext.tsx
+++ b/app/contexts/BreezContext.tsx
@@ -14,6 +14,10 @@ import { useAppConfig } from "@app/hooks/use-app-config"
 import { useAddressScreenQuery } from "@app/graphql/generated"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 import SparkMigrationModal from "@app/components/spark-migration-modal"
+import {
+  selectUsdtBalance,
+  type SparkUsdtWallet,
+} from "@app/utils/breez-sdk/token-balances"
 
 type BtcWallet = {
   id: string
@@ -29,6 +33,14 @@ interface BreezInterface {
   externalWalletLoading: boolean
   externalWalletError?: string
   btcWallet: BtcWallet
+  /**
+   * USDT held as a token on Spark — self-custodial, and a different thing from
+   * the account's custodial `WalletCurrency.Usdt` wallet on the Flash backend.
+   * Deliberately kept out of the `WalletCurrency` vocabulary so nothing can
+   * find it with a `walletCurrency === "USDT"` lookup and spend or display the
+   * wrong balance. `undefined` means no such token is held (ENG-473).
+   */
+  sparkUsdtWallet?: SparkUsdtWallet
 }
 
 export const BreezContext = createContext<BreezInterface>({
@@ -43,6 +55,7 @@ export const BreezContext = createContext<BreezInterface>({
     balance: 0,
     isExternal: true,
   },
+  sparkUsdtWallet: undefined,
 })
 
 type Props = {
@@ -66,6 +79,11 @@ export const BreezProvider = ({ children }: Props) => {
     balance: persistentState.breezBalance || 0,
     isExternal: true,
   })
+  // In-memory only: unlike breezBalance this is not mirrored into persistent
+  // state, so it is absent until the first getInfo() rather than showing a
+  // stale figure on cold start. Persisting it means a bigint-safe
+  // persistent-state schema change, which is its own PR.
+  const [sparkUsdtWallet, setSparkUsdtWallet] = useState<SparkUsdtWallet | undefined>()
   const initializingRef = useRef(false)
   const updatingBalanceRef = useRef(false)
   const registeringExternalWalletRef = useRef(false)
@@ -117,6 +135,7 @@ export const BreezProvider = ({ children }: Props) => {
           balance: 0,
           isExternal: true,
         })
+        setSparkUsdtWallet(undefined)
         setExternalWalletError(undefined)
       }
     }
@@ -131,6 +150,9 @@ export const BreezProvider = ({ children }: Props) => {
         ...prev,
         balance: Number(walletInfo.balanceSats),
       }))
+      // Same round-trip as the sat balance, so it refreshes on the same cadence
+      // at no extra call.
+      setSparkUsdtWallet(selectUsdtBalance(walletInfo.tokenBalances))
       updateState((state: any) => {
         if (state)
           return {
@@ -258,6 +280,7 @@ export const BreezProvider = ({ children }: Props) => {
     <BreezContext.Provider
       value={{
         btcWallet,
+        sparkUsdtWallet,
         loading,
         externalWalletLoading,
         externalWalletError,

--- a/app/contexts/BreezContext.tsx
+++ b/app/contexts/BreezContext.tsx
@@ -157,9 +157,6 @@ export const BreezProvider = ({ children }: Props) => {
         ...prev,
         balance: Number(walletInfo.balanceSats),
       }))
-      // Same round-trip as the sat balance, so it refreshes on the same cadence
-      // at no extra call.
-      setSparkUsdtWallet(selectUsdtBalance(walletInfo.tokenBalances))
       updateState((state: any) => {
         if (state)
           return {
@@ -168,6 +165,22 @@ export const BreezProvider = ({ children }: Props) => {
           }
         return undefined
       })
+      // Same round-trip as the sat balance, so it refreshes on the same cadence
+      // at no extra call — but LAST, and caught.
+      //
+      // This runs inside a try/finally with no catch: a throw here would
+      // reject updateBalance(), which on the init path lands in getBreezInfo's
+      // catch and leaves `loading` true for the whole session with the
+      // Lightning-address registration skipped, and on refresh is an uncaught
+      // rejection on every pull-to-refresh. An additive, best-effort,
+      // not-yet-consumed balance must never be able to take the sat wallet
+      // down with it.
+      try {
+        setSparkUsdtWallet(selectUsdtBalance(walletInfo.tokenBalances))
+      } catch (err) {
+        console.warn("[breez] USDT selection failed", err)
+        setSparkUsdtWallet(undefined)
+      }
     } finally {
       updatingBalanceRef.current = false
     }

--- a/app/contexts/BreezContext.tsx
+++ b/app/contexts/BreezContext.tsx
@@ -16,17 +16,22 @@ import { useIsAuthed } from "@app/graphql/is-authed-context"
 import SparkMigrationModal from "@app/components/spark-migration-modal"
 import {
   selectUsdtBalance,
-  type SparkUsdtWallet,
+  type UnverifiedSparkUsdtWallet,
 } from "@app/utils/breez-sdk/token-balances"
 
-type BtcWallet = {
+export type BtcWallet = {
   id: string
   walletCurrency: WalletCurrency
   balance: number
   isExternal: boolean
 }
 
-interface BreezInterface {
+/**
+ * Exported and consumed directly by `useBreez()`. Do not re-declare this shape
+ * at the hook: a hand-copied duplicate silently erases every field it forgets,
+ * which is how `sparkUsdtWallet` shipped provided-but-unreachable.
+ */
+export interface BreezInterface {
   refreshBreez: () => void
   retryExternalWalletRegistration: () => Promise<void>
   loading: boolean
@@ -40,7 +45,7 @@ interface BreezInterface {
    * find it with a `walletCurrency === "USDT"` lookup and spend or display the
    * wrong balance. `undefined` means no such token is held (ENG-473).
    */
-  sparkUsdtWallet?: SparkUsdtWallet
+  sparkUsdtWallet?: UnverifiedSparkUsdtWallet
 }
 
 export const BreezContext = createContext<BreezInterface>({
@@ -83,7 +88,9 @@ export const BreezProvider = ({ children }: Props) => {
   // state, so it is absent until the first getInfo() rather than showing a
   // stale figure on cold start. Persisting it means a bigint-safe
   // persistent-state schema change, which is its own PR.
-  const [sparkUsdtWallet, setSparkUsdtWallet] = useState<SparkUsdtWallet | undefined>()
+  const [sparkUsdtWallet, setSparkUsdtWallet] = useState<
+    UnverifiedSparkUsdtWallet | undefined
+  >()
   const initializingRef = useRef(false)
   const updatingBalanceRef = useRef(false)
   const registeringExternalWalletRef = useRef(false)

--- a/app/hooks/__tests__/use-breez.spec.tsx
+++ b/app/hooks/__tests__/use-breez.spec.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import { renderHook } from "@testing-library/react-native"
+
+import { BreezContext, type BreezInterface } from "@app/contexts/BreezContext"
+import { useBreez } from "../useBreez"
+import type { UnverifiedSparkUsdtWallet } from "@app/utils/breez-sdk/token-balances"
+
+const sparkUsdtWallet: UnverifiedSparkUsdtWallet = {
+  identifier: "tok:usdt",
+  issuerPublicKey: "02abc",
+  issuerVerified: false,
+  balanceMinor: BigInt("12345678"),
+  decimals: 6,
+}
+
+const contextValue: BreezInterface = {
+  refreshBreez: () => {},
+  retryExternalWalletRegistration: async () => {},
+  loading: false,
+  externalWalletLoading: false,
+  btcWallet: { id: "w1", walletCurrency: "BTC", balance: 500, isExternal: true },
+  sparkUsdtWallet,
+}
+
+const wrapper = ({ children }: React.PropsWithChildren) => (
+  <BreezContext.Provider value={contextValue}>{children}</BreezContext.Provider>
+)
+
+describe("useBreez", () => {
+  it("passes every provided context field through, sparkUsdtWallet included", () => {
+    const { result } = renderHook(() => useBreez(), { wrapper })
+
+    // Every consumer in the app reads Breez through this hook — none call
+    // useContext(BreezContext) directly. When the hook annotated its result
+    // with a hand-copied interface, a field the provider supplied but the copy
+    // omitted was erased right here and `yarn tsc:check` rejected any read of
+    // it. The explicit annotation below is the assertion that matters: it is a
+    // compile error if the hook's return type ever stops tracking
+    // BreezInterface.
+    const wallet: UnverifiedSparkUsdtWallet | undefined = result.current.sparkUsdtWallet
+
+    expect(wallet).toEqual(sparkUsdtWallet)
+    expect(wallet?.balanceMinor).toBe(BigInt("12345678"))
+    expect(result.current.btcWallet.balance).toBe(500)
+  })
+
+  it("returns the context default when no provider is mounted", () => {
+    const { result } = renderHook(() => useBreez())
+
+    expect(result.current.sparkUsdtWallet).toBeUndefined()
+    expect(result.current.btcWallet.balance).toBe(0)
+  })
+})

--- a/app/hooks/useBreez.ts
+++ b/app/hooks/useBreez.ts
@@ -1,24 +1,10 @@
 import { useContext } from "react"
-import { BreezContext } from "@app/contexts/BreezContext"
-import { WalletCurrency } from "@app/graphql/generated"
+import { BreezContext, type BreezInterface } from "@app/contexts/BreezContext"
 
-type BtcWallet = {
-  id: string
-  walletCurrency: WalletCurrency
-  balance: number
-  isExternal: boolean
-}
-
-interface ContextProps {
-  btcWallet: BtcWallet
-  loading: boolean
-  externalWalletLoading: boolean
-  externalWalletError?: string
-  refreshBreez: () => void
-  retryExternalWalletRegistration: () => Promise<void>
-}
-
-export const useBreez = () => {
-  const context: ContextProps = useContext(BreezContext)
-  return context
-}
+/**
+ * The only way anything in the app reads BreezContext — no consumer calls
+ * `useContext(BreezContext)` directly. It returns the context's own interface
+ * rather than a local copy of it, so a field added to the provider is reachable
+ * here the moment it is added.
+ */
+export const useBreez = (): BreezInterface => useContext(BreezContext)

--- a/app/utils/breez-sdk/token-balances.ts
+++ b/app/utils/breez-sdk/token-balances.ts
@@ -89,7 +89,15 @@ export const selectUsdtBalance = (
   }
 
   const matches = Array.from(tokenBalances.values()).filter(
-    (entry) => entry?.tokenMetadata?.ticker?.toUpperCase() === USDT_TICKER,
+    // typeof, not optional chaining: `?.` short-circuits on null/undefined
+    // only, so a bridge that lowers the ticker as a number or a wrapper object
+    // makes `.toUpperCase` undefined and this throws inside `filter` — before
+    // either guard below can turn it into a clean `undefined`. Same reasoning
+    // as the balance/decimals checks; the ticker is read off the same
+    // FFI-lowered struct and deserves the same distrust.
+    (entry) =>
+      typeof entry?.tokenMetadata?.ticker === "string" &&
+      entry.tokenMetadata.ticker.toUpperCase() === USDT_TICKER,
   )
 
   if (matches.length === 0) return undefined

--- a/app/utils/breez-sdk/token-balances.ts
+++ b/app/utils/breez-sdk/token-balances.ts
@@ -46,7 +46,13 @@ export type UnverifiedSparkUsdtWallet = {
    * overdraw in flash#480 — the display layer can format, the source must not.
    */
   balanceMinor: bigint
-  /** From TokenMetadata. Never assume 6. */
+  /**
+   * From TokenMetadata. Never assume 6.
+   *
+   * Guaranteed a non-negative integer: the selector drops the balance entirely
+   * rather than hand back a `decimals` that makes `10n ** BigInt(decimals)`
+   * throw.
+   */
   decimals: number
 }
 
@@ -97,16 +103,22 @@ export const selectUsdtBalance = (
 
   const { balance, tokenMetadata } = matches[0]
 
-  // The SDK lifts u128 through `BigInt(...)` today, but this module exists to
-  // hold the bigint invariant and the Spark dep moves fast. If a bump ever
-  // lowers the balance as a string or a number, `balanceMinor` would be typed
-  // `bigint` without being one, and the first consumer dividing by
-  // `10n ** BigInt(decimals)` throws "Cannot mix BigInt and other types".
-  // Missing beats lying.
-  if (typeof balance !== "bigint") {
-    console.warn(
-      `[breez] ${USDT_TICKER} balance is ${typeof balance}, not bigint; refusing to surface it`,
-    )
+  // Both halves of the documented consumer expression
+  // `balanceMinor / 10n ** BigInt(decimals)` are checked here, because both are
+  // typed from a .d.ts the FFI bridge is free to disagree with, and the Spark
+  // dep moves fast. A bump that lowers the u128 balance as a string or a number
+  // leaves `balanceMinor` typed `bigint` without being one and that division
+  // throws "Cannot mix BigInt and other types"; an absent or non-integer
+  // `decimals` (nothing above vouches for it — the ticker filter only reads
+  // `tokenMetadata.ticker`) throws "Cannot convert undefined to a BigInt" one
+  // field over. Missing beats lying, in both cases.
+  const { decimals } = tokenMetadata
+  if (typeof balance !== "bigint" || !Number.isInteger(decimals) || decimals < 0) {
+    const problem =
+      typeof balance === "bigint"
+        ? `decimals is ${String(decimals)}, not a non-negative integer`
+        : `balance is ${typeof balance}, not bigint`
+    console.warn(`[breez] ${USDT_TICKER} ${problem}; refusing to surface it`)
     return undefined
   }
 
@@ -115,6 +127,6 @@ export const selectUsdtBalance = (
     issuerPublicKey: tokenMetadata.issuerPublicKey,
     issuerVerified: false,
     balanceMinor: balance,
-    decimals: tokenMetadata.decimals,
+    decimals,
   }
 }

--- a/app/utils/breez-sdk/token-balances.ts
+++ b/app/utils/breez-sdk/token-balances.ts
@@ -15,11 +15,28 @@ export type SparkTokenBalanceLike = {
   }
 }
 
-export type SparkUsdtWallet = {
+/**
+ * A USDT-ticker token balance whose ISSUER HAS NOT BEEN VERIFIED.
+ *
+ * The name and the `issuerVerified: false` field are both load-bearing. Ticker
+ * matching alone cannot tell the real Tether-on-Spark token from one an
+ * attacker minted five minutes ago and airdropped, so nothing here is safe to
+ * present as "your USDT" or to spend against. Once
+ * `CANONICAL_USDT_ISSUER_PUBKEY` is known and pinned, this type gets replaced
+ * by (or widened to) a verified variant — which is a type change every consumer
+ * has to acknowledge, rather than a docblock they can skim past.
+ */
+export type UnverifiedSparkUsdtWallet = {
   /** Spark's token identifier — the stable key, unlike the ticker. */
   identifier: string
   /** Hex issuer public key. The only field that actually attests provenance. */
   issuerPublicKey: string
+  /**
+   * Always `false`, and required, so the unverified state cannot be dropped by
+   * a spread or an object literal that "looks like" a wallet. A consumer that
+   * wants a verified balance has to change this type, not just read past it.
+   */
+  issuerVerified: false
   /**
    * Balance in the token's MINOR units, exactly as Spark reported it.
    *
@@ -37,20 +54,33 @@ export const USDT_TICKER = "USDT"
 
 /**
  * Anyone can issue a Spark token and call its ticker "USDT" — the ticker is a
- * label, not an identity. So this refuses to guess: exactly one ticker match
- * gets returned, and two or more resolve to `undefined` rather than picking a
- * winner and possibly surfacing a spoofed token's balance as the user's money.
+ * label, not an identity. So this refuses to guess between rival claims:
+ * exactly one ticker match gets returned, and two or more resolve to
+ * `undefined` rather than picking a winner.
  *
- * Before any UI presents this as USDT, or any spend path consumes it, the
- * selection has to be pinned to the canonical `issuerPublicKey` — that pubkey
- * is not yet recorded anywhere in this repo, which is why it is not enforced
- * here. `issuerPublicKey` is carried on the result so the caller can gate on it
- * the moment the value is known (ENG-473, parent ENG-471 open-decision #1).
+ * Note what that does NOT buy. The ambiguity check only fires for a user who
+ * already holds the real token; airdrop a spoofed "USDT" to someone holding
+ * none and it is the sole match, so it is exactly what comes back. The single
+ * match is therefore no more trusted than the ambiguous one — which is why the
+ * result type is `UnverifiedSparkUsdtWallet` and carries `issuerVerified:
+ * false`. Before any UI presents this as USDT, or any spend path consumes it,
+ * the selection has to be pinned to the canonical `issuerPublicKey`; that
+ * pubkey is not yet recorded anywhere in this repo, which is why it is a type
+ * obligation here rather than a runtime check (ENG-473, parent ENG-471
+ * open-decision #1).
  */
 export const selectUsdtBalance = (
   tokenBalances: Map<string, SparkTokenBalanceLike> | undefined | null,
-): SparkUsdtWallet | undefined => {
-  if (!tokenBalances || typeof tokenBalances.values !== "function") return undefined
+): UnverifiedSparkUsdtWallet | undefined => {
+  if (!tokenBalances) return undefined
+
+  if (typeof tokenBalances.values !== "function") {
+    // Absent is normal; present-but-wrong-shape means the SDK bridge changed
+    // under us. Without this the symptom in production is a balance that is
+    // permanently missing and a log that says nothing.
+    console.warn("[breez] tokenBalances is not a Map; the SDK shape has changed")
+    return undefined
+  }
 
   const matches = Array.from(tokenBalances.values()).filter(
     (entry) => entry?.tokenMetadata?.ticker?.toUpperCase() === USDT_TICKER,
@@ -67,9 +97,23 @@ export const selectUsdtBalance = (
 
   const { balance, tokenMetadata } = matches[0]
 
+  // The SDK lifts u128 through `BigInt(...)` today, but this module exists to
+  // hold the bigint invariant and the Spark dep moves fast. If a bump ever
+  // lowers the balance as a string or a number, `balanceMinor` would be typed
+  // `bigint` without being one, and the first consumer dividing by
+  // `10n ** BigInt(decimals)` throws "Cannot mix BigInt and other types".
+  // Missing beats lying.
+  if (typeof balance !== "bigint") {
+    console.warn(
+      `[breez] ${USDT_TICKER} balance is ${typeof balance}, not bigint; refusing to surface it`,
+    )
+    return undefined
+  }
+
   return {
     identifier: tokenMetadata.identifier,
     issuerPublicKey: tokenMetadata.issuerPublicKey,
+    issuerVerified: false,
     balanceMinor: balance,
     decimals: tokenMetadata.decimals,
   }

--- a/app/utils/breez-sdk/token-balances.ts
+++ b/app/utils/breez-sdk/token-balances.ts
@@ -1,0 +1,76 @@
+/**
+ * Selecting the USDT balance out of Spark's `getInfo().tokenBalances`.
+ *
+ * Kept out of BreezContext so the selection rules — which are the whole risk
+ * surface here — are testable without mounting a provider or the SDK.
+ */
+
+export type SparkTokenBalanceLike = {
+  balance: bigint
+  tokenMetadata: {
+    identifier: string
+    issuerPublicKey: string
+    ticker: string
+    decimals: number
+  }
+}
+
+export type SparkUsdtWallet = {
+  /** Spark's token identifier — the stable key, unlike the ticker. */
+  identifier: string
+  /** Hex issuer public key. The only field that actually attests provenance. */
+  issuerPublicKey: string
+  /**
+   * Balance in the token's MINOR units, exactly as Spark reported it.
+   *
+   * Deliberately NOT pre-divided by `decimals`: dividing here would force a
+   * float and hand every consumer a rounded balance. A balance field that was
+   * rounded before it reached the spend path is precisely what caused the MAX
+   * overdraw in flash#480 — the display layer can format, the source must not.
+   */
+  balanceMinor: bigint
+  /** From TokenMetadata. Never assume 6. */
+  decimals: number
+}
+
+export const USDT_TICKER = "USDT"
+
+/**
+ * Anyone can issue a Spark token and call its ticker "USDT" — the ticker is a
+ * label, not an identity. So this refuses to guess: exactly one ticker match
+ * gets returned, and two or more resolve to `undefined` rather than picking a
+ * winner and possibly surfacing a spoofed token's balance as the user's money.
+ *
+ * Before any UI presents this as USDT, or any spend path consumes it, the
+ * selection has to be pinned to the canonical `issuerPublicKey` — that pubkey
+ * is not yet recorded anywhere in this repo, which is why it is not enforced
+ * here. `issuerPublicKey` is carried on the result so the caller can gate on it
+ * the moment the value is known (ENG-473, parent ENG-471 open-decision #1).
+ */
+export const selectUsdtBalance = (
+  tokenBalances: Map<string, SparkTokenBalanceLike> | undefined | null,
+): SparkUsdtWallet | undefined => {
+  if (!tokenBalances || typeof tokenBalances.values !== "function") return undefined
+
+  const matches = Array.from(tokenBalances.values()).filter(
+    (entry) => entry?.tokenMetadata?.ticker?.toUpperCase() === USDT_TICKER,
+  )
+
+  if (matches.length === 0) return undefined
+
+  if (matches.length > 1) {
+    console.warn(
+      `[breez] ${matches.length} tokens claim the ${USDT_TICKER} ticker; refusing to guess which is real`,
+    )
+    return undefined
+  }
+
+  const { balance, tokenMetadata } = matches[0]
+
+  return {
+    identifier: tokenMetadata.identifier,
+    issuerPublicKey: tokenMetadata.issuerPublicKey,
+    balanceMinor: balance,
+    decimals: tokenMetadata.decimals,
+  }
+}


### PR DESCRIPTION
Two v0.7.0 slate items. ENG-473 was explicitly blocked on the SDK upgrade — 0.22.3 is on main, `getInfo()` now carries `tokenBalances`, and the read rides the **same round-trip as the sat balance**, so it refreshes on the same cadence at no extra call.

## ENG-473 — two decisions worth arguing with

**1. This is deliberately NOT `WalletCurrency.Usdt`.**
Spark USDT is a self-custodial token on Spark. `WalletCurrency.Usdt` is the *custodial* wallet on the Flash backend (the one ENG-544 self-heals). Same name, different money, different spend path. Putting Spark's balance into that vocabulary means any `walletCurrency === "USDT"` lookup could pick the wrong one — so it's exposed as `sparkUsdtWallet` with its own type instead. This resolves parent ENG-471's open-decision #1 in the conservative direction.

**2. The balance stays a `bigint` in MINOR units, with `decimals` carried alongside — never pre-divided.**
Dividing at the source forces a float and hands every consumer a rounded balance. A balance field that was rounded before it reached the spend path is exactly what caused the MAX overdraw in flash#480. The display layer can format; the source must not.

**Selection refuses to guess.** Any Spark issuer can label a token `USDT` — the ticker is a label, not an identity. One ticker match resolves; **two or more resolve to `undefined`** rather than risk showing a spoofed issuer's balance as the user's money. `issuerPublicKey` is carried on the result so selection can be pinned to the canonical issuer — **that pubkey isn't recorded anywhere in this repo yet, which is why it's documented rather than enforced.** Pinning it is a prerequisite before any UI presents this as USDT or any spend path consumes it.

**Not persisted.** Unlike `breezBalance`, this is in-memory: absent until the first `getInfo()` rather than stale on cold start. Persisting a bigint needs a persistent-state schema change of its own.

Acceptance ("readable in-app, updates on sync") is met at the context layer; no UI consumes it yet by design.

## #704 — comment narrowed to what the code delivers

`AppUpdateBoundary` claimed the gate is pinned last so nothing paints over it. **Verified, not assumed:** that holds only inside its own subtree. `NotificationsProvider` wraps the boundary in `app.tsx`, and its `CustomModal` passes no `coverScreen` — so it takes the default, goes through the native modal host, and paints above inline content regardless of sibling order. It's dismissible and the gate survives underneath, which is why this is a comment fix. Hoisting the gate above `NotificationsProvider` would be a structural change deserving its own PR.

Both the boundary docblock and the matching `app.tsx` comment are corrected.

---

9 new tests (precision beyond `MAX_SAFE_INTEGER`, decimals ≠ 6, spoofed-ticker refusal, malformed/absent inputs). 92 suites / 906 tests green, tsc clean, changed-lines lint gate clean.

Note: the repo targets below ES2020, so the specs use `BigInt("…")` calls rather than `123n` literals — and the huge-value case builds from a string, since a numeric literal would lose precision before `BigInt` ever saw it.