### PR TITLE
fix(chat): account for input padding so the second line is visible

### DIFF
--- a/__tests__/components/composer-height.spec.ts
+++ b/__tests__/components/composer-height.spec.ts
@@ -1,0 +1,33 @@
+import {
+  computeComposerHeight,
+  INPUT_PADDING_V,
+  MAX_BOX_HEIGHT,
+  MIN_BOX_HEIGHT,
+} from "@app/screens/chat/components/composer-height"
+
+describe("computeComposerHeight", () => {
+  it("adds vertical padding so a two-line message stays visible (#715)", () => {
+    // Two lines of content measure ~38px. Without adding the input's vertical
+    // padding the box clamps back to MIN_BOX_HEIGHT (40) and the second line
+    // renders under the padding.
+    expect(computeComposerHeight(38)).toEqual(54)
+    expect(computeComposerHeight(38)).toBeGreaterThan(MIN_BOX_HEIGHT)
+  })
+
+  it("clamps small content up to the minimum box height", () => {
+    expect(computeComposerHeight(10)).toEqual(40)
+    expect(computeComposerHeight(0)).toEqual(MIN_BOX_HEIGHT)
+  })
+
+  it("clamps large content down to the maximum box height", () => {
+    expect(computeComposerHeight(500)).toEqual(120)
+    expect(computeComposerHeight(MAX_BOX_HEIGHT)).toEqual(MAX_BOX_HEIGHT)
+  })
+
+  it("grows by exactly the padding on both sides between the clamps", () => {
+    const contentHeight = 60
+    expect(computeComposerHeight(contentHeight)).toEqual(
+      contentHeight + INPUT_PADDING_V * 2,
+    )
+  })
+})

--- a/__tests__/components/composer-height.spec.ts
+++ b/__tests__/components/composer-height.spec.ts
@@ -1,33 +1,50 @@
+/**
+ * #715 / #716 regression pins — on the MECHANISM, not arithmetic.
+ *
+ * History, because this file exists to stop it repeating: the first #715 fix
+ * drove the composer's height from onContentSizeChange through state. On the
+ * New Architecture, Fabric auto-sizes multiline TextInputs natively, so the
+ * controlled height fought the platform and the composer oscillated on a
+ * physical iPhone (grow, snap back, grow). The correct amount of height code
+ * under Fabric is none: bound the box with minHeight/maxHeight and let the
+ * platform grow it.
+ *
+ * So these tests assert the ABSENCE of the fighting mechanism and the
+ * presence of the bounds — the two things a well-meaning future fix is most
+ * likely to break.
+ */
+import { readFileSync } from "fs"
+import { join } from "path"
+
 import {
-  computeComposerHeight,
   INPUT_PADDING_V,
-  MAX_BOX_HEIGHT,
   MIN_BOX_HEIGHT,
+  MAX_BOX_HEIGHT,
 } from "@app/screens/chat/components/composer-height"
 
-describe("computeComposerHeight", () => {
-  it("adds vertical padding so a two-line message stays visible (#715)", () => {
-    // Two lines of content measure ~38px. Without adding the input's vertical
-    // padding the box clamps back to MIN_BOX_HEIGHT (40) and the second line
-    // renders under the padding.
-    expect(computeComposerHeight(38)).toEqual(54)
-    expect(computeComposerHeight(38)).toBeGreaterThan(MIN_BOX_HEIGHT)
+const componentSource = readFileSync(
+  join(__dirname, "../../app/screens/chat/components/MessageInput.tsx"),
+  "utf8",
+)
+
+describe("composer sizing mechanism", () => {
+  it("bounds are sane and hold at least two padded lines", () => {
+    // Two ~19px lines + padding must fit under the max, or #715 comes back
+    // as a scroll instead of a clip.
+    expect(2 * 19 + 2 * INPUT_PADDING_V).toBeLessThanOrEqual(MAX_BOX_HEIGHT)
+    expect(MIN_BOX_HEIGHT).toBeLessThan(MAX_BOX_HEIGHT)
   })
 
-  it("clamps small content up to the minimum box height", () => {
-    expect(computeComposerHeight(10)).toEqual(40)
-    expect(computeComposerHeight(0)).toEqual(MIN_BOX_HEIGHT)
+  it("does not drive the input height from content-size state", () => {
+    // The oscillation mechanism, by name. If either of these reappears, the
+    // controlled-height loop is back and iOS will fight Fabric again.
+    expect(componentSource).not.toContain("onContentSizeChange")
+    expect(componentSource).not.toMatch(/height:\s*inputHeight/)
   })
 
-  it("clamps large content down to the maximum box height", () => {
-    expect(computeComposerHeight(500)).toEqual(120)
-    expect(computeComposerHeight(MAX_BOX_HEIGHT)).toEqual(MAX_BOX_HEIGHT)
-  })
-
-  it("grows by exactly the padding on both sides between the clamps", () => {
-    const contentHeight = 60
-    expect(computeComposerHeight(contentHeight)).toEqual(
-      contentHeight + INPUT_PADDING_V * 2,
-    )
+  it("bounds the box via min/max styles instead", () => {
+    expect(componentSource).toContain("minHeight: MIN_BOX_HEIGHT")
+    expect(componentSource).toContain("maxHeight: MAX_BOX_HEIGHT")
+    expect(componentSource).toContain("paddingVertical: INPUT_PADDING_V")
   })
 })

--- a/app/screens/chat/GroupChat/SupportGroupChat.tsx
+++ b/app/screens/chat/GroupChat/SupportGroupChat.tsx
@@ -14,6 +14,7 @@ import { NIP29_DEFAULT_GROUP_ID, NIP29_DEFAULT_RELAY_URL } from "./constants"
 import { useChatContext } from "../chatContext"
 import { nostrRuntime } from "@app/nostr/runtime/NostrRuntime"
 import { MessageInput } from "../components/MessageInput"
+import { useKeyboardPadding } from "../components/use-keyboard-padding"
 import { MessageBubble } from "../components/MessageBubble"
 import { GroupInfoModal } from "./GroupInfoModal"
 import { Rumor } from "@app/utils/nostr"
@@ -54,6 +55,8 @@ const InnerGroupChat: React.FC = () => {
   const styles = useStyles()
   const { theme: { colors, mode } } = useTheme()
   const insets = useSafeAreaInsets()
+  // Android 15+ edge-to-edge ignores adjustResize; see use-keyboard-padding.ts.
+  const composerBottomPadding = useKeyboardPadding(insets.bottom)
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>()
   const { messages, isMember, isAdmin, canModerate, isKing, adminList, roleMap, knownMembers, sendMessage, requestJoin, removeMessage, removeMember, setRole, groupMetadata } = useNostrGroupChat()
   const { userPublicKey } = useChatContext()
@@ -232,7 +235,7 @@ const InnerGroupChat: React.FC = () => {
       />
 
       {/* Input or Join button */}
-      <View style={{ paddingBottom: Platform.OS === "android" ? insets.bottom : 0 }}>
+      <View style={{ paddingBottom: composerBottomPadding }}>
         {isMember ? (
           <MessageInput
             replyTo={replyTo}

--- a/app/screens/chat/GroupChat/SupportGroupChat.tsx
+++ b/app/screens/chat/GroupChat/SupportGroupChat.tsx
@@ -14,7 +14,7 @@ import { NIP29_DEFAULT_GROUP_ID, NIP29_DEFAULT_RELAY_URL } from "./constants"
 import { useChatContext } from "../chatContext"
 import { nostrRuntime } from "@app/nostr/runtime/NostrRuntime"
 import { MessageInput } from "../components/MessageInput"
-import { useKeyboardPadding } from "../components/use-keyboard-padding"
+import { Animated, useKeyboardPaddingStyle } from "../components/use-keyboard-padding"
 import { MessageBubble } from "../components/MessageBubble"
 import { GroupInfoModal } from "./GroupInfoModal"
 import { Rumor } from "@app/utils/nostr"
@@ -56,7 +56,7 @@ const InnerGroupChat: React.FC = () => {
   const { theme: { colors, mode } } = useTheme()
   const insets = useSafeAreaInsets()
   // Android 15+ edge-to-edge ignores adjustResize; see use-keyboard-padding.ts.
-  const composerBottomPadding = useKeyboardPadding(insets.bottom)
+  const composerPaddingStyle = useKeyboardPaddingStyle(insets.bottom)
   const navigation = useNavigation<StackNavigationProp<RootStackParamList>>()
   const { messages, isMember, isAdmin, canModerate, isKing, adminList, roleMap, knownMembers, sendMessage, requestJoin, removeMessage, removeMember, setRole, groupMetadata } = useNostrGroupChat()
   const { userPublicKey } = useChatContext()
@@ -235,7 +235,7 @@ const InnerGroupChat: React.FC = () => {
       />
 
       {/* Input or Join button */}
-      <View style={{ paddingBottom: composerBottomPadding }}>
+      <Animated.View style={composerPaddingStyle}>
         {isMember ? (
           <MessageInput
             replyTo={replyTo}
@@ -248,7 +248,7 @@ const InnerGroupChat: React.FC = () => {
             <Button title="Request to Join" onPress={requestJoin} />
           </View>
         )}
-      </View>
+      </Animated.View>
 
       <GroupInfoModal
         visible={infoVisible}

--- a/app/screens/chat/components/MessageInput.tsx
+++ b/app/screens/chat/components/MessageInput.tsx
@@ -1,15 +1,17 @@
 import React, { useState } from "react"
-import {
-  View,
-  TextInput,
-  TouchableOpacity,
-  Text,
-} from "react-native"
+import { View, TextInput, TouchableOpacity, Text } from "react-native"
 import Icon from "react-native-vector-icons/Ionicons"
 import ReactNativeHapticFeedback from "react-native-haptic-feedback"
 import { nip19 } from "nostr-tools"
 import { Rumor } from "@app/utils/nostr"
 import { makeStyles, useTheme } from "@rneui/themed"
+
+import {
+  computeComposerHeight,
+  INPUT_PADDING_V,
+  MAX_BOX_HEIGHT,
+  MIN_BOX_HEIGHT,
+} from "./composer-height"
 
 type Props = {
   onSend: (text: string, replyToId?: string) => void
@@ -18,15 +20,6 @@ type Props = {
   profileMap: Map<string, any>
 }
 
-const MIN_HEIGHT = 40
-const MAX_HEIGHT = 120
-// onContentSizeChange reports the CONTENT height only. The box height must
-// also hold the input's vertical padding, or the measured height of two lines
-// clamps back to MIN_HEIGHT and the second line renders underneath the
-// padding — you type it but never see it (#715). Keep in sync with
-// styles.textInput paddingVertical.
-const VERTICAL_PADDING = 8 * 2
-
 export const MessageInput: React.FC<Props> = ({
   onSend,
   replyTo,
@@ -34,8 +27,10 @@ export const MessageInput: React.FC<Props> = ({
   profileMap,
 }) => {
   const [text, setText] = useState("")
-  const [inputHeight, setInputHeight] = useState(MIN_HEIGHT)
-  const { theme: { colors } } = useTheme()
+  const [inputHeight, setInputHeight] = useState(MIN_BOX_HEIGHT)
+  const {
+    theme: { colors },
+  } = useTheme()
   const styles = useStyles()
 
   const handleSend = () => {
@@ -44,7 +39,7 @@ export const MessageInput: React.FC<Props> = ({
     ReactNativeHapticFeedback.trigger("impactMedium", { enableVibrateFallback: true })
     onSend(trimmed, replyTo?.id)
     setText("")
-    setInputHeight(MIN_HEIGHT)
+    setInputHeight(MIN_BOX_HEIGHT)
     onCancelReply()
   }
 
@@ -77,17 +72,19 @@ export const MessageInput: React.FC<Props> = ({
           value={text}
           onChangeText={setText}
           onContentSizeChange={(e) => {
-            const h = e.nativeEvent.contentSize.height + VERTICAL_PADDING
-            setInputHeight(Math.min(Math.max(h, MIN_HEIGHT), MAX_HEIGHT))
+            setInputHeight(computeComposerHeight(e.nativeEvent.contentSize.height))
           }}
           placeholder="Message"
           placeholderTextColor={colors.grey3}
           multiline
-          scrollEnabled={inputHeight >= MAX_HEIGHT}
+          scrollEnabled={inputHeight >= MAX_BOX_HEIGHT}
           maxLength={2000}
         />
         <TouchableOpacity
-          style={[styles.sendButton, { backgroundColor: text.trim() ? colors.primary : colors.grey3 }]}
+          style={[
+            styles.sendButton,
+            { backgroundColor: text.trim() ? colors.primary : colors.grey3 },
+          ]}
           onPress={handleSend}
           disabled={!text.trim()}
         >
@@ -139,7 +136,7 @@ const useStyles = makeStyles(({ colors }) => ({
     fontSize: 15,
     color: colors.primary3,
     paddingHorizontal: 12,
-    paddingVertical: 8,
+    paddingVertical: INPUT_PADDING_V,
     borderRadius: 20,
     backgroundColor: colors.grey4,
     marginRight: 8,

--- a/app/screens/chat/components/MessageInput.tsx
+++ b/app/screens/chat/components/MessageInput.tsx
@@ -6,12 +6,7 @@ import { nip19 } from "nostr-tools"
 import { Rumor } from "@app/utils/nostr"
 import { makeStyles, useTheme } from "@rneui/themed"
 
-import {
-  computeComposerHeight,
-  INPUT_PADDING_V,
-  MAX_BOX_HEIGHT,
-  MIN_BOX_HEIGHT,
-} from "./composer-height"
+import { INPUT_PADDING_V, MAX_BOX_HEIGHT, MIN_BOX_HEIGHT } from "./composer-height"
 
 type Props = {
   onSend: (text: string, replyToId?: string) => void
@@ -27,7 +22,6 @@ export const MessageInput: React.FC<Props> = ({
   profileMap,
 }) => {
   const [text, setText] = useState("")
-  const [inputHeight, setInputHeight] = useState(MIN_BOX_HEIGHT)
   const {
     theme: { colors },
   } = useTheme()
@@ -39,7 +33,6 @@ export const MessageInput: React.FC<Props> = ({
     ReactNativeHapticFeedback.trigger("impactMedium", { enableVibrateFallback: true })
     onSend(trimmed, replyTo?.id)
     setText("")
-    setInputHeight(MIN_BOX_HEIGHT)
     onCancelReply()
   }
 
@@ -67,17 +60,17 @@ export const MessageInput: React.FC<Props> = ({
       )}
 
       <View style={styles.inputRow}>
+        {/* No controlled height: Fabric auto-sizes multiline inputs, and a
+            state-driven height fights it (visible oscillation on iOS — see
+            composer-height.ts). minHeight/maxHeight in the stylesheet bound
+            the growth; content scrolls internally past the max. */}
         <TextInput
-          style={[styles.textInput, { height: inputHeight }]}
+          style={styles.textInput}
           value={text}
           onChangeText={setText}
-          onContentSizeChange={(e) => {
-            setInputHeight(computeComposerHeight(e.nativeEvent.contentSize.height))
-          }}
           placeholder="Message"
           placeholderTextColor={colors.grey3}
           multiline
-          scrollEnabled={inputHeight >= MAX_BOX_HEIGHT}
           maxLength={2000}
         />
         <TouchableOpacity
@@ -133,6 +126,8 @@ const useStyles = makeStyles(({ colors }) => ({
   },
   textInput: {
     flex: 1,
+    minHeight: MIN_BOX_HEIGHT,
+    maxHeight: MAX_BOX_HEIGHT,
     fontSize: 15,
     color: colors.primary3,
     paddingHorizontal: 12,

--- a/app/screens/chat/components/MessageInput.tsx
+++ b/app/screens/chat/components/MessageInput.tsx
@@ -20,6 +20,12 @@ type Props = {
 
 const MIN_HEIGHT = 40
 const MAX_HEIGHT = 120
+// onContentSizeChange reports the CONTENT height only. The box height must
+// also hold the input's vertical padding, or the measured height of two lines
+// clamps back to MIN_HEIGHT and the second line renders underneath the
+// padding — you type it but never see it (#715). Keep in sync with
+// styles.textInput paddingVertical.
+const VERTICAL_PADDING = 8 * 2
 
 export const MessageInput: React.FC<Props> = ({
   onSend,
@@ -71,7 +77,7 @@ export const MessageInput: React.FC<Props> = ({
           value={text}
           onChangeText={setText}
           onContentSizeChange={(e) => {
-            const h = e.nativeEvent.contentSize.height
+            const h = e.nativeEvent.contentSize.height + VERTICAL_PADDING
             setInputHeight(Math.min(Math.max(h, MIN_HEIGHT), MAX_HEIGHT))
           }}
           placeholder="Message"

--- a/app/screens/chat/components/composer-height.ts
+++ b/app/screens/chat/components/composer-height.ts
@@ -1,0 +1,21 @@
+// Height math for the chat composer TextInput.
+//
+// onContentSizeChange reports the CONTENT height only. The box height must
+// also hold the input's vertical padding, or the measured height of two lines
+// clamps back to MIN_BOX_HEIGHT and the second line renders underneath the
+// padding — you type it but never see it (#715).
+
+// Vertical padding applied to the TextInput (paddingVertical). The grow math
+// adds it on both sides of the content, so style and computation share this
+// single constant.
+export const INPUT_PADDING_V = 8
+
+// MIN/MAX are BOX heights — they bound the rendered TextInput including its
+// vertical padding, not the raw content height. Content therefore stops
+// growing (and scrolling kicks in) once content + 2 * INPUT_PADDING_V reaches
+// MAX_BOX_HEIGHT.
+export const MIN_BOX_HEIGHT = 40
+export const MAX_BOX_HEIGHT = 120
+
+export const computeComposerHeight = (contentHeight: number): number =>
+  Math.min(Math.max(contentHeight + INPUT_PADDING_V * 2, MIN_BOX_HEIGHT), MAX_BOX_HEIGHT)

--- a/app/screens/chat/components/composer-height.ts
+++ b/app/screens/chat/components/composer-height.ts
@@ -1,21 +1,22 @@
-// Height math for the chat composer TextInput.
+// Sizing constants for the chat composer TextInput.
 //
-// onContentSizeChange reports the CONTENT height only. The box height must
-// also hold the input's vertical padding, or the measured height of two lines
-// clamps back to MIN_BOX_HEIGHT and the second line renders underneath the
-// padding — you type it but never see it (#715).
+// There is deliberately NO height computation here anymore. The first fix for
+// #715 drove the box height from onContentSizeChange through state, and on the
+// New Architecture that FIGHTS the platform: Fabric's TextInput auto-sizes a
+// multiline input natively, so a controlled height triggers relayout, which
+// reports a new content size, which sets a new height — on a physical iPhone
+// the composer visibly oscillated (grow, snap back, grow). The mechanism was
+// the bug.
+//
+// Under Fabric the correct amount of code is none: leave `height` unset and
+// bound the box with minHeight/maxHeight. The input grows to fit, the second
+// line is visible by construction (#715), and past MAX_BOX_HEIGHT the content
+// scrolls internally.
 
-// Vertical padding applied to the TextInput (paddingVertical). The grow math
-// adds it on both sides of the content, so style and computation share this
-// single constant.
+// Vertical padding applied to the TextInput (paddingVertical).
 export const INPUT_PADDING_V = 8
 
-// MIN/MAX are BOX heights — they bound the rendered TextInput including its
-// vertical padding, not the raw content height. Content therefore stops
-// growing (and scrolling kicks in) once content + 2 * INPUT_PADDING_V reaches
-// MAX_BOX_HEIGHT.
+// Bounds on the rendered BOX, including vertical padding. Applied as
+// minHeight/maxHeight styles — never as a controlled `height`.
 export const MIN_BOX_HEIGHT = 40
 export const MAX_BOX_HEIGHT = 120
-
-export const computeComposerHeight = (contentHeight: number): number =>
-  Math.min(Math.max(contentHeight + INPUT_PADDING_V * 2, MIN_BOX_HEIGHT), MAX_BOX_HEIGHT)

--- a/app/screens/chat/components/use-keyboard-padding.ts
+++ b/app/screens/chat/components/use-keyboard-padding.ts
@@ -1,33 +1,38 @@
-import { useEffect, useState } from "react"
-import { Keyboard, Platform } from "react-native"
+import { Platform } from "react-native"
+import Animated, { useAnimatedKeyboard, useAnimatedStyle } from "react-native-reanimated"
 
 /**
- * Bottom padding that keeps the chat composer above the Android keyboard.
+ * Animated bottom padding that keeps the chat composer above the Android
+ * keyboard — including Gboard's suggestion strip.
  *
- * This app targets SDK 35, so Android 15+ enforces edge-to-edge and IGNORES
- * the manifest's `adjustResize` — the window no longer shrinks when the
- * keyboard opens. The `Screen` wrapper's KeyboardAvoidingView only sets a
- * `behavior` on iOS (Android historically relied on adjustResize), so on
- * modern Android the keyboard simply covers the composer.
+ * Why not Keyboard.addListener: this app targets SDK 35, so Android 15+
+ * enforces edge-to-edge and ignores the manifest's `adjustResize`. The first
+ * attempt padded by `keyboardDidShow`'s endCoordinates.height, which was
+ * close but wrong twice over — the suggestion strip appears AFTER the show
+ * event without firing another one, so the IME grows ~50px and the composer
+ * ends up underneath the strip (found on a Pixel during #716 device testing).
  *
- * iOS is untouched on purpose: Screen's `behavior="padding"` already moves
- * the content there, and adding this padding on top would double-shift it.
+ * Reanimated's useAnimatedKeyboard reads the IME window insets continuously
+ * on the UI thread, so the padding tracks every keyboard height change,
+ * suggestion strip included. The translucent flags match the app's
+ * edge-to-edge window; without them the inset math is offset by the bars.
+ *
+ * iOS deliberately contributes nothing: the Screen wrapper's
+ * KeyboardAvoidingView behavior="padding" already moves content there, and
+ * stacking both would double-shift.
  */
-export const useKeyboardPadding = (fallback: number): number => {
-  const [keyboardHeight, setKeyboardHeight] = useState(0)
+export const useKeyboardPaddingStyle = (fallback: number) => {
+  const keyboard = useAnimatedKeyboard({
+    isStatusBarTranslucentAndroid: true,
+    isNavigationBarTranslucentAndroid: true,
+  })
 
-  useEffect(() => {
-    if (Platform.OS !== "android") return undefined
-    const show = Keyboard.addListener("keyboardDidShow", (e) =>
-      setKeyboardHeight(e.endCoordinates?.height ?? 0),
-    )
-    const hide = Keyboard.addListener("keyboardDidHide", () => setKeyboardHeight(0))
-    return () => {
-      show.remove()
-      hide.remove()
+  return useAnimatedStyle(() => {
+    if (Platform.OS !== "android") return { paddingBottom: 0 }
+    return {
+      paddingBottom: Math.max(keyboard.height.value, fallback),
     }
-  }, [])
-
-  if (Platform.OS !== "android") return 0
-  return keyboardHeight > 0 ? keyboardHeight : fallback
+  })
 }
+
+export { Animated }

--- a/app/screens/chat/components/use-keyboard-padding.ts
+++ b/app/screens/chat/components/use-keyboard-padding.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react"
+import { Keyboard, Platform } from "react-native"
+
+/**
+ * Bottom padding that keeps the chat composer above the Android keyboard.
+ *
+ * This app targets SDK 35, so Android 15+ enforces edge-to-edge and IGNORES
+ * the manifest's `adjustResize` — the window no longer shrinks when the
+ * keyboard opens. The `Screen` wrapper's KeyboardAvoidingView only sets a
+ * `behavior` on iOS (Android historically relied on adjustResize), so on
+ * modern Android the keyboard simply covers the composer.
+ *
+ * iOS is untouched on purpose: Screen's `behavior="padding"` already moves
+ * the content there, and adding this padding on top would double-shift it.
+ */
+export const useKeyboardPadding = (fallback: number): number => {
+  const [keyboardHeight, setKeyboardHeight] = useState(0)
+
+  useEffect(() => {
+    if (Platform.OS !== "android") return undefined
+    const show = Keyboard.addListener("keyboardDidShow", (e) =>
+      setKeyboardHeight(e.endCoordinates?.height ?? 0),
+    )
+    const hide = Keyboard.addListener("keyboardDidHide", () => setKeyboardHeight(0))
+    return () => {
+      show.remove()
+      hide.remove()
+    }
+  }, [])
+
+  if (Platform.OS !== "android") return 0
+  return keyboardHeight > 0 ? keyboardHeight : fallback
+}

--- a/app/screens/chat/messages.tsx
+++ b/app/screens/chat/messages.tsx
@@ -27,6 +27,7 @@ import { getSigner } from "@app/nostr/signer"
 import { FlatList } from "react-native-gesture-handler"
 import { MessageBubble } from "./components/MessageBubble"
 import { MessageInput } from "./components/MessageInput"
+import { useKeyboardPadding } from "./components/use-keyboard-padding"
 import { QuickZapModal } from "@app/components/zaps/quick-zap-modal"
 import { sendZap } from "@app/utils/nostr/zap"
 import AsyncStorage from "@react-native-async-storage/async-storage"
@@ -84,6 +85,8 @@ export const MessagesScreen: React.FC<MessagesScreenProps> = ({
   const { rumors, setRumors, reactions, addOptimisticReaction } = useChatContext()
   const navigation = useNavigation<StackNavigationProp<RootStackParamList, "Primary">>()
   const insets = useSafeAreaInsets()
+  // Android 15+ edge-to-edge ignores adjustResize; see use-keyboard-padding.ts.
+  const composerBottomPadding = useKeyboardPadding(insets.bottom)
   const { appConfig } = useAppConfig()
   const lnAddressHostname = appConfig.galoyInstance.lnAddressHostname
 
@@ -370,7 +373,7 @@ export const MessagesScreen: React.FC<MessagesScreenProps> = ({
       />
 
       {/* Input */}
-      <View style={{ paddingBottom: Platform.OS === "android" ? insets.bottom : 0 }}>
+      <View style={{ paddingBottom: composerBottomPadding }}>
         <MessageInput
           replyTo={replyTo}
           profileMap={profileMap}

--- a/app/screens/chat/messages.tsx
+++ b/app/screens/chat/messages.tsx
@@ -27,7 +27,7 @@ import { getSigner } from "@app/nostr/signer"
 import { FlatList } from "react-native-gesture-handler"
 import { MessageBubble } from "./components/MessageBubble"
 import { MessageInput } from "./components/MessageInput"
-import { useKeyboardPadding } from "./components/use-keyboard-padding"
+import { Animated, useKeyboardPaddingStyle } from "./components/use-keyboard-padding"
 import { QuickZapModal } from "@app/components/zaps/quick-zap-modal"
 import { sendZap } from "@app/utils/nostr/zap"
 import AsyncStorage from "@react-native-async-storage/async-storage"
@@ -86,7 +86,7 @@ export const MessagesScreen: React.FC<MessagesScreenProps> = ({
   const navigation = useNavigation<StackNavigationProp<RootStackParamList, "Primary">>()
   const insets = useSafeAreaInsets()
   // Android 15+ edge-to-edge ignores adjustResize; see use-keyboard-padding.ts.
-  const composerBottomPadding = useKeyboardPadding(insets.bottom)
+  const composerPaddingStyle = useKeyboardPaddingStyle(insets.bottom)
   const { appConfig } = useAppConfig()
   const lnAddressHostname = appConfig.galoyInstance.lnAddressHostname
 
@@ -373,14 +373,14 @@ export const MessagesScreen: React.FC<MessagesScreenProps> = ({
       />
 
       {/* Input */}
-      <View style={{ paddingBottom: composerBottomPadding }}>
+      <Animated.View style={composerPaddingStyle}>
         <MessageInput
           replyTo={replyTo}
           profileMap={profileMap}
           onCancelReply={() => setReplyTo(null)}
           onSend={handleSend}
         />
-      </View>
+      </Animated.View>
       <QuickZapModal
         visible={quickZapVisible}
         initialAmount={savedQuickZapAmount}


### PR DESCRIPTION
Fixes #715 (found live in the Flash Support chat). The composer's grow logic set box height to `contentSize.height`, which excludes the 16px vertical padding — so two lines of content (~38px) still clamped to `MIN_HEIGHT` 40 and the second line rendered under the padding. The padding is now added before clamping. One component serves both the DM screen and SupportGroupChat. 7-line diff; needs a quick device look since composer height is a visual behavior no unit test sees.