### PR TITLE
feat: freeze-the-attempt send idempotency (ENG-533)

### DIFF
--- a/__tests__/payment-details/amount-lightning-payment-details.spec.ts
+++ b/__tests__/payment-details/amount-lightning-payment-details.spec.ts
@@ -101,6 +101,9 @@ describe("amount lightning payment details", () => {
           input: {
             paymentRequest: defaultParams.paymentRequest,
             walletId: btcSendingWalletParams.sendingWalletDescriptor.id,
+            // ENG-533. Accepted here since ENG-530; omitting it left the
+            // backend's exactly-once wrapper in passthrough on a live path.
+            idempotencyKey: sendPaymentMocks.idempotencyKey,
           },
         },
       })
@@ -153,6 +156,7 @@ describe("amount lightning payment details", () => {
           input: {
             paymentRequest: defaultParams.paymentRequest,
             walletId: usdSendingWalletParams.sendingWalletDescriptor.id,
+            idempotencyKey: sendPaymentMocks.idempotencyKey,
           },
         },
       })

--- a/__tests__/payment-details/helpers.ts
+++ b/__tests__/payment-details/helpers.ts
@@ -130,6 +130,9 @@ export const createSendPaymentMocks = (): SendPaymentMutationParams => {
     // Fixed rather than random so a spec can assert the exact value reaches
     // the mutation input.
     idempotencyKey: "test-idempotency-key",
+    // First dispatch of an attempt by default; a spec exercising the retry
+    // path overrides this to true.
+    attemptIsRetry: false,
     // The gate is scoped per (endpoint, input type), so a spec that wants two
     // backends can vary this one field.
     apiEndpoint: "https://api.test.flashapp.me/graphql",

--- a/__tests__/payment-details/helpers.ts
+++ b/__tests__/payment-details/helpers.ts
@@ -127,6 +127,12 @@ export const createGetFeeMocks = (): GetFeeParams => {
 
 export const createSendPaymentMocks = (): SendPaymentMutationParams => {
   return {
+    // Fixed rather than random so a spec can assert the exact value reaches
+    // the mutation input.
+    idempotencyKey: "test-idempotency-key",
+    // The gate is scoped per (endpoint, input type), so a spec that wants two
+    // backends can vary this one field.
+    apiEndpoint: "https://api.test.flashapp.me/graphql",
     lnInvoicePaymentSend: jest.fn(),
     lnNoAmountInvoicePaymentSend: jest.fn(),
     lnNoAmountUsdInvoicePaymentSend: jest.fn(),

--- a/__tests__/payment-details/helpers.ts
+++ b/__tests__/payment-details/helpers.ts
@@ -136,6 +136,10 @@ export const createSendPaymentMocks = (): SendPaymentMutationParams => {
     // The gate is scoped per (endpoint, input type), so a spec that wants two
     // backends can vary this one field.
     apiEndpoint: "https://api.test.flashapp.me/graphql",
+    // Observed by specs asserting WHICH dispatches went out keyless — the
+    // gate must report every un-keyed send so the hook can refuse to
+    // auto-retry an attempt the server has no key to replay for.
+    onKeylessDispatch: jest.fn(),
     lnInvoicePaymentSend: jest.fn(),
     lnNoAmountInvoicePaymentSend: jest.fn(),
     lnNoAmountUsdInvoicePaymentSend: jest.fn(),

--- a/__tests__/payment-details/intraledger-payment-details.spec.ts
+++ b/__tests__/payment-details/intraledger-payment-details.spec.ts
@@ -84,6 +84,11 @@ describe("intraledger payment details", () => {
             recipientWalletId: defaultParams.recipientWalletId,
             amount: settlementAmount.amount,
             walletId: btcSendingWalletParams.sendingWalletDescriptor.id,
+            // ENG-533. This input has accepted the key since ENG-530 and runs
+            // through the backend's withPaymentIdempotency wrapper, whose
+            // contract is "no key = passthrough" — so omitting it left the
+            // exactly-once machinery switched off on a live send path.
+            idempotencyKey: sendPaymentMocks.idempotencyKey,
           },
         },
       })
@@ -120,6 +125,9 @@ describe("intraledger payment details", () => {
             recipientWalletId: defaultParams.recipientWalletId,
             amount: settlementAmount.amount,
             walletId: usdSendingWalletParams.sendingWalletDescriptor.id,
+            // USD/USDT Flash-to-Flash: the same double-debit class the PR
+            // title claims to close, and the path a repeated tap hits most.
+            idempotencyKey: sendPaymentMocks.idempotencyKey,
           },
         },
       })

--- a/__tests__/payment-details/lnurl-payment-details.spec.ts
+++ b/__tests__/payment-details/lnurl-payment-details.spec.ts
@@ -177,6 +177,9 @@ describe("lnurl payment details", () => {
           input: {
             paymentRequest: btcSendingWalletParams.paymentRequest,
             walletId: btcSendingWalletParams.sendingWalletDescriptor.id,
+            // An LNURL detail that has been given an invoice delegates to the
+            // amount-lightning builder, so it carries the key too.
+            idempotencyKey: sendPaymentMocks.idempotencyKey,
           },
         },
       })
@@ -229,6 +232,7 @@ describe("lnurl payment details", () => {
           input: {
             paymentRequest: usdSendingWalletParams.paymentRequest,
             walletId: usdSendingWalletParams.sendingWalletDescriptor.id,
+            idempotencyKey: sendPaymentMocks.idempotencyKey,
           },
         },
       })

--- a/__tests__/payment-details/no-amount-lightning-payment-details.spec.ts
+++ b/__tests__/payment-details/no-amount-lightning-payment-details.spec.ts
@@ -112,6 +112,9 @@ describe("no amount lightning payment details", () => {
             paymentRequest: defaultParams.paymentRequest,
             amount: settlementAmount.amount,
             walletId: btcSendingWalletParams.sendingWalletDescriptor.id,
+            // ENG-533. Accepted here since ENG-530; omitting it left the
+            // backend's exactly-once wrapper in passthrough on a live path.
+            idempotencyKey: sendPaymentMocks.idempotencyKey,
           },
         },
       })
@@ -171,6 +174,11 @@ describe("no amount lightning payment details", () => {
             paymentRequest: defaultParams.paymentRequest,
             amount: settlementAmount.amount,
             walletId: usdSendingWalletParams.sendingWalletDescriptor.id,
+            memo: undefined,
+            // The whole point of ENG-533's app half: a send repeated after a
+            // lost response has to carry the caller's key so the backend can
+            // recognise it instead of paying again.
+            idempotencyKey: sendPaymentMocks.idempotencyKey,
           },
         },
       })

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -15,6 +15,7 @@ import {
   createLnurlPaymentDetails,
 } from "@app/screens/send-bitcoin-screen/payment-details/lightning"
 import { ConvertMoneyAmount } from "@app/screens/send-bitcoin-screen/payment-details/index.types"
+import { ActivityIndicatorContext } from "@app/contexts/ActivityIndicatorContext"
 import { BreezContext } from "@app/contexts/BreezContext"
 import { WalletCurrency } from "@app/graphql/generated"
 import { DisplayCurrency, toBtcMoneyAmount, toUsdMoneyAmount } from "@app/types/amounts"
@@ -475,5 +476,100 @@ describe("zero-fee prominence (#561)", () => {
     const feeStyle = StyleSheet.flatten(feeText.props.style)
     expect(feeStyle?.color).not.toBe(lightColors.green)
     expect(feeStyle?.fontWeight).not.toBe("bold")
+  })
+})
+
+// The in-flight guard's screen-side contract: an ignored duplicate tap must
+// not touch the activity indicator. The indicator is a plain boolean, not a
+// counter, so a `toggleActivityIndicator(false)` from the ignored tap would
+// clobber the owning tap's `true` and hide the spinner for the entire
+// in-flight send — the user watches a multi-second lightning payment with no
+// feedback and concludes nothing happened. The hook suite structurally cannot
+// catch this: the toggle lives in this screen's handler.
+describe("duplicate-tap spinner contract", () => {
+  // INCIDENT_INVOICE's issue time; mount four seconds into its 60s window so
+  // the ENG-555 expiry guard stays out of the way.
+  const ISSUED = 1787243982
+  const MOUNTED_MS = (ISSUED + 4) * 1000
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(Date, "now").mockReturnValue(MOUNTED_MS)
+    resetInvoiceFirstSight()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("an ignored same-frame duplicate tap leaves the spinner to the owning tap", async () => {
+    const usdDetail = createAmountLightningPaymentDetails({
+      paymentRequest: INCIDENT_INVOICE,
+      paymentRequestAmount: toBtcMoneyAmount(100),
+      convertMoneyAmount,
+      sendingWalletDescriptor: { currency: WalletCurrency.Usd, id: "testwallet" },
+    })
+    let resolveSend: (value: unknown) => void = () => {}
+    const sendPaymentMutation = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveSend = resolve
+        }),
+    )
+    const paymentDetail = { ...usdDetail, sendPaymentMutation }
+
+    const toggleActivityIndicator = jest.fn()
+    const route = {
+      key: "sendBitcoinConfirmationScreen",
+      name: "sendBitcoinConfirmation",
+      params: { paymentDetail },
+    } as const
+
+    const screen = render(
+      <ContextForScreen>
+        <ActivityIndicatorContext.Provider
+          value={{ toggleActivityIndicator, loadableVisible: false }}
+        >
+          <SendBitcoinConfirmationScreen
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            route={route as any}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            navigation={{ navigate: jest.fn() } as any}
+          />
+        </ActivityIndicatorContext.Provider>
+      </ContextForScreen>,
+    )
+    await act(async () => {})
+    await act(async () => {})
+
+    // Two taps in the same frame invoke the handler captured from the SAME
+    // render — before hasAttemptedSend can re-render the button disabled.
+    // fireEvent would flush between presses, so take the handler directly.
+    const { onPress } = screen.UNSAFE_getByProps({
+      label: en.SendBitcoinConfirmationScreen.title,
+    }).props
+
+    let owningTap: Promise<unknown> = Promise.resolve()
+    await act(async () => {
+      owningTap = onPress()
+      // The duplicate resolves (ignored) while the real send is still on the
+      // wire.
+      await onPress()
+    })
+
+    expect(sendPaymentMutation).toHaveBeenCalledTimes(1)
+    expect(toggleActivityIndicator).toHaveBeenCalledWith(true)
+    // The contract under test: the ignored tap never hides the spinner.
+    expect(toggleActivityIndicator).not.toHaveBeenCalledWith(false)
+
+    await act(async () => {
+      resolveSend({ status: "SUCCESS", errors: [] })
+      await owningTap
+    })
+
+    // The owning tap turns it off exactly once, when its own send resolves.
+    expect(
+      toggleActivityIndicator.mock.calls.filter(([visible]) => visible === false),
+    ).toHaveLength(1)
   })
 })

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -561,6 +561,15 @@ describe("duplicate-tap spinner contract", () => {
     expect(toggleActivityIndicator).toHaveBeenCalledWith(true)
     // The contract under test: the ignored tap never hides the spinner.
     expect(toggleActivityIndicator).not.toHaveBeenCalledWith(false)
+    // ...and never logs. An ignored tap attempted nothing, so a second
+    // `payment_attempt` here would count two attempts for one result and
+    // skew failure-rate metrics on every double tap. The screen must decide
+    // "ignored" BEFORE its analytics side effect, not after the hook answers.
+    expect(
+      (getAnalytics().logEvent as jest.Mock).mock.calls.filter(
+        ([eventName]) => eventName === "payment_attempt",
+      ),
+    ).toHaveLength(1)
 
     await act(async () => {
       resolveSend({ status: "SUCCESS", errors: [] })

--- a/__tests__/send-bitcoin/idempotency-support.spec.ts
+++ b/__tests__/send-bitcoin/idempotency-support.spec.ts
@@ -368,6 +368,60 @@ describe("an API that does not have the field on this input", () => {
   })
 })
 
+// The keyless fallback is only sound on an attempt's FIRST dispatch, where a
+// coercion refusal proves nothing executed. On a RETRY an earlier keyed
+// dispatch with an UNKNOWN outcome exists by definition — the mixed-fleet
+// shape: tap 1 commits on a new pod, the response is lost (502), the retry
+// hits a stale pod that refuses the field. Falling back keyless there would
+// silently execute a second payment on exactly the path ENG-533 protects.
+describe("a retry of a dispatched attempt", () => {
+  const retryMocks = () => ({ ...createSendPaymentMocks(), attemptIsRetry: true })
+
+  it("never falls back keyless on a coercion refusal — the error surfaces instead", async () => {
+    const mocks = retryMocks()
+    const mutation = mocks.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    mutation.mockRejectedValue(new Error(COERCION_REFUSAL))
+
+    await expect(send(mocks)).rejects.toThrow(
+      /may have already been sent.*transaction history/i,
+    )
+    // Exactly one dispatch, and it carried the key: no silent keyless re-send.
+    expect(mutation).toHaveBeenCalledTimes(1)
+    expect(keysSent(mutation)).toEqual([mocks.idempotencyKey])
+    // The refusal is still recorded, so a NEW attempt degrades as usual.
+    expect(
+      idempotencyKeySupported(gate(IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice)),
+    ).toBe(false)
+  })
+
+  it("dispatches keyed even when the gate is already latched", async () => {
+    // Latch the gate the ordinary way: a first-dispatch refusal.
+    const first = createSendPaymentMocks()
+    const firstMutation = first.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    firstMutation.mockRejectedValueOnce(new Error(COERCION_REFUSAL)).mockResolvedValue({
+      data: { lnNoAmountUsdInvoicePaymentSend: { status: "SUCCESS", errors: [] } },
+    })
+    await send(first)
+    expect(
+      idempotencyKeySupported(gate(IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice)),
+    ).toBe(false)
+
+    // A retry must not read the latch as licence to go keyless: the key is the
+    // one spelling the server can recognise as a repeat. If the fleet finished
+    // deploying, the keyed retry succeeds; if not, the refusal surfaces.
+    const retry = retryMocks()
+    const retryMutation = retry.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    retryMutation.mockResolvedValue({
+      data: { lnNoAmountUsdInvoicePaymentSend: { status: "SUCCESS", errors: [] } },
+    })
+
+    const result = await send(retry)
+
+    expect(keysSent(retryMutation)).toEqual([retry.idempotencyKey])
+    expect(result.status).toBe("SUCCESS")
+  })
+})
+
 // Every send input the app calls, driven through its real builder. The claim
 // this replaced — "four of these are long deployed, so they can pass the field
 // unconditionally" — was never measured anywhere in this repo, and being wrong

--- a/__tests__/send-bitcoin/idempotency-support.spec.ts
+++ b/__tests__/send-bitcoin/idempotency-support.spec.ts
@@ -422,6 +422,67 @@ describe("a retry of a dispatched attempt", () => {
   })
 })
 
+// The gate must CONFESS every dispatch that goes out without the key. The
+// hook records it on the attempt: once an attempt has gone keyless, a later
+// retry has no key the server could replay — re-dispatching could execute a
+// second payment — so the hook refuses to auto-retry it. That refusal is only
+// possible if neither keyless path here goes unreported.
+describe("reporting keyless dispatches", () => {
+  it("reports the keyless fallback after a first-dispatch refusal", async () => {
+    const mocks = createSendPaymentMocks()
+    const mutation = mocks.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    mutation.mockRejectedValueOnce(new Error(COERCION_REFUSAL)).mockResolvedValueOnce({
+      data: { lnNoAmountUsdInvoicePaymentSend: { status: "SUCCESS", errors: [] } },
+    })
+
+    await send(mocks)
+
+    expect(mocks.onKeylessDispatch).toHaveBeenCalledTimes(1)
+  })
+
+  it("reports a latched-gate first dispatch, which goes keyless from the start", async () => {
+    const first = createSendPaymentMocks()
+    const firstMutation = first.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    firstMutation.mockRejectedValueOnce(new Error(COERCION_REFUSAL)).mockResolvedValue({
+      data: { lnNoAmountUsdInvoicePaymentSend: { status: "SUCCESS", errors: [] } },
+    })
+    await send(first)
+
+    const latched = createSendPaymentMocks()
+    const latchedMutation = latched.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    latchedMutation.mockResolvedValue({
+      data: { lnNoAmountUsdInvoicePaymentSend: { status: "SUCCESS", errors: [] } },
+    })
+
+    await send(latched)
+
+    expect(keysSent(latchedMutation)).toEqual([undefined])
+    expect(latched.onKeylessDispatch).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not report a keyed dispatch", async () => {
+    const mocks = createSendPaymentMocks()
+    const mutation = mocks.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    mutation.mockResolvedValue({
+      data: { lnNoAmountUsdInvoicePaymentSend: { status: "SUCCESS", errors: [] } },
+    })
+
+    await send(mocks)
+
+    expect(mocks.onKeylessDispatch).not.toHaveBeenCalled()
+  })
+
+  it("does not report a retry's refusal — nothing keyless was dispatched", async () => {
+    const mocks = { ...createSendPaymentMocks(), attemptIsRetry: true }
+    const mutation = mocks.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    mutation.mockRejectedValue(new Error(COERCION_REFUSAL))
+
+    await expect(send(mocks)).rejects.toThrow(/transaction history/i)
+
+    expect(mocks.onKeylessDispatch).not.toHaveBeenCalled()
+  })
+})
+
 // Every send input the app calls, driven through its real builder. The claim
 // this replaced — "four of these are long deployed, so they can pass the field
 // unconditionally" — was never measured anywhere in this repo, and being wrong

--- a/__tests__/send-bitcoin/idempotency-support.spec.ts
+++ b/__tests__/send-bitcoin/idempotency-support.spec.ts
@@ -1,0 +1,493 @@
+/**
+ * The app can ship ahead of any given environment's API, and GraphQL rejects
+ * unknown input-object fields during INPUT COERCION — before execution. So an
+ * unconditional `idempotencyKey` does not degrade against an older backend: it
+ * errors the whole mutation out and that entire send path stops working.
+ * `yarn graphql-check` cannot see this — it validates our operations against
+ * the checked-in snapshot, not against a deployed server.
+ *
+ * That hazard is not special to the newest input. The app had never sent ANY
+ * of these fields before, so "ENG-530 is long deployed" is an assumption
+ * nothing in this repo measures — which is why all five inputs are gated, and
+ * why the cases below drive all five through the REAL builders. They fail if
+ * the gate is removed from lightning.ts or intraledger.ts as well as if the
+ * gate itself regresses.
+ */
+import fs from "fs"
+import path from "path"
+
+import { AppState, AppStateStatus } from "react-native"
+import { WalletCurrency } from "@app/graphql/generated"
+import {
+  createAmountLightningPaymentDetails,
+  createNoAmountLightningPaymentDetails,
+} from "@app/screens/send-bitcoin-screen/payment-details/lightning"
+import { createIntraledgerPaymentDetails } from "@app/screens/send-bitcoin-screen/payment-details/intraledger"
+import {
+  IDEMPOTENT_SEND_INPUTS,
+  idempotencyKeySupported,
+  isIdempotencyKeyReuseError,
+  isUnsupportedIdempotencyKeyError,
+  rearmIdempotencyKeySupport,
+  resetIdempotencyKeySupport,
+} from "@app/screens/send-bitcoin-screen/payment-details/idempotency-support"
+import { PaymentDetail } from "@app/screens/send-bitcoin-screen/payment-details/index.types"
+
+// `PaymentDetail<T>` is invariant in T, so a BTC detail and a USD detail have
+// no common supertype to hold them in one list. The union is what the builders
+// under test actually return.
+type SendableDetail = PaymentDetail<"BTC"> | PaymentDetail<"USD">
+import { toBtcMoneyAmount, toUsdMoneyAmount } from "@app/types/amounts"
+
+import {
+  convertMoneyAmountMock,
+  createSendPaymentMocks,
+} from "../payment-details/helpers"
+
+const PAYMENT_REQUEST = "lnbc1someinvoice"
+const ENDPOINT = "https://api.test.flashapp.me/graphql"
+const OTHER_ENDPOINT = "https://api.staging.flashapp.me/graphql"
+
+// The message graphql-js really produces when an input object is handed a
+// field its type does not declare — i.e. what an API from before the field was
+// added answers with. Pinned to the actual shape: `coerceVariableValues`
+// reports an unknown field at the INPUT OBJECT's path, inspecting the whole
+// object (so the offending key appears in the "got invalid value" half too),
+// not at `input.idempotencyKey`. A test that invents a tidier message lets a
+// gate that only matches the tidier message pass.
+const coercionRefusalFor = (inputType: string) =>
+  'Variable "$input" got invalid value { walletId: "usd-wallet", paymentRequest: ' +
+  '"lnbc1someinvoice", amount: 250, idempotencyKey: "test-idempotency-key" }; ' +
+  `Field "idempotencyKey" is not defined by type "${inputType}".`
+
+const COERCION_REFUSAL = coercionRefusalFor(IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice)
+
+// The same generated shape, for a field that has nothing to do with this gate:
+// the server added a required input field the app does not know about yet. The
+// whole input — `idempotencyKey` included — is inspected into the message, so
+// a gate built from "mentions the key" AND "says got invalid value" reads this
+// as "the server lacks idempotencyKey" and disarms idempotency for the rest of
+// the process.
+const UNRELATED_COERCION_REFUSAL =
+  'Variable "$input" got invalid value { walletId: "usd-wallet", paymentRequest: ' +
+  '"lnbc1someinvoice", amount: 250, idempotencyKey: "test-idempotency-key" }; ' +
+  'Field "recipientTag" of required type "String!" was not provided.'
+
+const usdNoAmountDetail = () =>
+  createNoAmountLightningPaymentDetails({
+    paymentRequest: PAYMENT_REQUEST,
+    unitOfAccountAmount: toUsdMoneyAmount(250),
+    convertMoneyAmount: convertMoneyAmountMock,
+    sendingWalletDescriptor: { currency: WalletCurrency.Usd, id: "usd-wallet" },
+  })
+
+const sendWith = async (
+  detail: SendableDetail,
+  mocks: ReturnType<typeof createSendPaymentMocks>,
+) => {
+  if (!detail.canSendPayment) throw new Error("Cannot send payment")
+  return detail.sendPaymentMutation(mocks)
+}
+
+const send = async (mocks: ReturnType<typeof createSendPaymentMocks>) =>
+  sendWith(usdNoAmountDetail(), mocks)
+
+const keysSent = (mutation: jest.Mock) =>
+  mutation.mock.calls.map(([args]) => args.variables.input.idempotencyKey)
+
+const gate = (
+  inputType: (typeof IDEMPOTENT_SEND_INPUTS)[keyof typeof IDEMPOTENT_SEND_INPUTS],
+) => ({
+  apiEndpoint: ENDPOINT,
+  inputType,
+})
+
+beforeEach(resetIdempotencyKeySupport)
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+// The input names are load-bearing twice: they scope the gate, and a coercion
+// refusal has to NAME one before it is read as being about that input. A typo
+// disables the gate silently, so it is checked against the schema the app is
+// generated from rather than against itself.
+describe("the gated input names are the ones the server declares", () => {
+  const sdl = fs.readFileSync(
+    path.join(__dirname, "../../app/graphql/public-schema.graphql"),
+    "utf8",
+  )
+
+  Object.values(IDEMPOTENT_SEND_INPUTS).forEach((inputType) => {
+    it(`${inputType} exists and carries idempotencyKey`, () => {
+      const block = sdl.match(new RegExp(`input ${inputType} \\{[^}]*\\}`))
+      expect(block).not.toBeNull()
+      expect(block?.[0]).toContain("idempotencyKey")
+    })
+  })
+
+  it("gates every send input the app actually calls", () => {
+    // Five inputs, five gates. A sixth send path appearing without a gate is
+    // the regression this counts.
+    expect(Object.values(IDEMPOTENT_SEND_INPUTS)).toHaveLength(5)
+  })
+})
+
+describe("an API that has the field", () => {
+  it("sends the key, and only once", async () => {
+    const mocks = createSendPaymentMocks()
+    const mutation = mocks.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    mutation.mockResolvedValue({
+      data: { lnNoAmountUsdInvoicePaymentSend: { status: "SUCCESS", errors: [] } },
+    })
+
+    const result = await send(mocks)
+
+    expect(keysSent(mutation)).toEqual([mocks.idempotencyKey])
+    expect(result.status).toBe("SUCCESS")
+    expect(
+      idempotencyKeySupported(gate(IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice)),
+    ).toBe(true)
+  })
+
+  it("does not swallow a real send failure as a missing field", async () => {
+    // The dangerous confusion: reading any error as "the field does not
+    // exist" would retry the send WITHOUT the key — which is the double-pay
+    // this whole mechanism exists to prevent.
+    const mocks = createSendPaymentMocks()
+    const mutation = mocks.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    mutation.mockRejectedValue(new Error("Network request failed"))
+
+    await expect(send(mocks)).rejects.toThrow("Network request failed")
+    expect(mutation).toHaveBeenCalledTimes(1)
+    expect(
+      idempotencyKeySupported(gate(IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice)),
+    ).toBe(true)
+  })
+
+  it("does not read a backend error that merely mentions the key as a missing field", async () => {
+    const mocks = createSendPaymentMocks()
+    const mutation = mocks.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    mutation.mockRejectedValue(new Error("idempotencyKey already used for a payment"))
+
+    await expect(send(mocks)).rejects.toThrow("already used")
+    expect(mutation).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not disarm itself over a coercion error about a DIFFERENT field", async () => {
+    // The way this gate silently kills idempotency for good: every
+    // input-coercion message inspects the whole input object, so the key is
+    // quoted inside a refusal that has nothing to do with it. Reading that as
+    // "the field does not exist" makes every later no-amount USD send go out
+    // bare, and a lost response plus a retry then double-pays.
+    const mocks = createSendPaymentMocks()
+    const mutation = mocks.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    mutation.mockRejectedValue(new Error(UNRELATED_COERCION_REFUSAL))
+
+    await expect(send(mocks)).rejects.toThrow("recipientTag")
+    // Not retried bare: the caller must see the real error.
+    expect(mutation).toHaveBeenCalledTimes(1)
+    expect(keysSent(mutation)).toEqual([mocks.idempotencyKey])
+    // ...and the next send still carries the key.
+    expect(
+      idempotencyKeySupported(gate(IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice)),
+    ).toBe(true)
+  })
+
+  it("does not disarm itself over an unrelated coercion error in graphQLErrors", async () => {
+    expect(
+      isUnsupportedIdempotencyKeyError(
+        {
+          message: "Response not successful",
+          graphQLErrors: [{ message: UNRELATED_COERCION_REFUSAL }],
+        },
+        IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice,
+      ),
+    ).toBe(false)
+  })
+})
+
+describe("an API that does not have the field on this input", () => {
+  it("degrades to today's behaviour instead of failing the send", async () => {
+    const mocks = createSendPaymentMocks()
+    const mutation = mocks.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    mutation.mockRejectedValueOnce(new Error(COERCION_REFUSAL)).mockResolvedValueOnce({
+      data: { lnNoAmountUsdInvoicePaymentSend: { status: "SUCCESS", errors: [] } },
+    })
+
+    const result = await send(mocks)
+
+    // Coercion fails BEFORE execution, so the refusal proves nothing settled
+    // and the un-keyed retry cannot double-pay.
+    expect(keysSent(mutation)).toEqual([mocks.idempotencyKey, undefined])
+    expect(result.status).toBe("SUCCESS")
+  })
+
+  it("stops offering the field on that input for the rest of the session", async () => {
+    const mocks = createSendPaymentMocks()
+    const mutation = mocks.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    mutation.mockRejectedValueOnce(new Error(COERCION_REFUSAL)).mockResolvedValue({
+      data: { lnNoAmountUsdInvoicePaymentSend: { status: "SUCCESS", errors: [] } },
+    })
+
+    await send(mocks)
+    await send(mocks)
+
+    expect(
+      idempotencyKeySupported(gate(IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice)),
+    ).toBe(false)
+    // First send: keyed, refused, retried bare. Second: bare from the start —
+    // no wasted round trip.
+    expect(keysSent(mutation)).toEqual([mocks.idempotencyKey, undefined, undefined])
+  })
+
+  it("recognises the refusal when it arrives as an Apollo graphQLErrors list", async () => {
+    expect(
+      isUnsupportedIdempotencyKeyError(
+        {
+          message: "Response not successful",
+          graphQLErrors: [{ message: COERCION_REFUSAL }],
+        },
+        IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice,
+      ),
+    ).toBe(true)
+  })
+
+  it("does not read one input's refusal as another input's", async () => {
+    // The five inputs gained the field in different server releases, so a
+    // refusal on one says nothing about the other four. Latching them together
+    // throws away protection on paths that provably have it.
+    expect(
+      isUnsupportedIdempotencyKeyError(
+        new Error(coercionRefusalFor(IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice)),
+        IDEMPOTENT_SEND_INPUTS.lnInvoice,
+      ),
+    ).toBe(false)
+
+    const mocks = createSendPaymentMocks()
+    const refused = mocks.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    refused.mockRejectedValueOnce(new Error(COERCION_REFUSAL)).mockResolvedValue({
+      data: { lnNoAmountUsdInvoicePaymentSend: { status: "SUCCESS", errors: [] } },
+    })
+    await send(mocks)
+
+    const accepted = mocks.lnInvoicePaymentSend as jest.Mock
+    accepted.mockResolvedValue({
+      data: { lnInvoicePaymentSend: { status: "SUCCESS", errors: [] } },
+    })
+    await sendWith(
+      createAmountLightningPaymentDetails({
+        paymentRequest: PAYMENT_REQUEST,
+        paymentRequestAmount: toBtcMoneyAmount(1000),
+        convertMoneyAmount: convertMoneyAmountMock,
+        sendingWalletDescriptor: { currency: WalletCurrency.Usd, id: "usd-wallet" },
+      }),
+      mocks,
+    )
+
+    expect(keysSent(accepted)).toEqual([mocks.idempotencyKey])
+  })
+
+  it("does not read one backend's refusal as another backend's", async () => {
+    // The app can switch galoyInstance at runtime. A single process-global let
+    // one send against staging disarm idempotency for prod for the rest of the
+    // session — on the exact path it exists to protect.
+    const staging = { ...createSendPaymentMocks(), apiEndpoint: OTHER_ENDPOINT }
+    const stagingMutation = staging.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    stagingMutation.mockRejectedValueOnce(new Error(COERCION_REFUSAL)).mockResolvedValue({
+      data: { lnNoAmountUsdInvoicePaymentSend: { status: "SUCCESS", errors: [] } },
+    })
+    await send(staging)
+
+    expect(
+      idempotencyKeySupported({
+        apiEndpoint: OTHER_ENDPOINT,
+        inputType: IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice,
+      }),
+    ).toBe(false)
+    expect(
+      idempotencyKeySupported(gate(IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice)),
+    ).toBe(true)
+
+    const prod = createSendPaymentMocks()
+    const prodMutation = prod.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    prodMutation.mockResolvedValue({
+      data: { lnNoAmountUsdInvoicePaymentSend: { status: "SUCCESS", errors: [] } },
+    })
+    await send(prod)
+
+    expect(keysSent(prodMutation)).toEqual([prod.idempotencyKey])
+  })
+
+  it("re-arms on foreground, so one stale pod costs one send and not the session", async () => {
+    // A refusal is evidence about the pod that answered, not the deployment:
+    // mid rolling deploy one stale pod can refuse while the rest of the fleet
+    // accepts. Latched for the process lifetime, that pod disarms idempotency
+    // even after the deploy finishes and the user comes back.
+    const foregroundHandlers: ((state: AppStateStatus) => void)[] = []
+    jest
+      .spyOn(AppState, "addEventListener")
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementation(((_event: string, handler: any) => {
+        foregroundHandlers.push(handler)
+        return { remove: jest.fn() }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any)
+
+    const mocks = createSendPaymentMocks()
+    const mutation = mocks.lnNoAmountUsdInvoicePaymentSend as jest.Mock
+    mutation.mockRejectedValueOnce(new Error(COERCION_REFUSAL)).mockResolvedValue({
+      data: { lnNoAmountUsdInvoicePaymentSend: { status: "SUCCESS", errors: [] } },
+    })
+
+    await send(mocks)
+    expect(
+      idempotencyKeySupported(gate(IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice)),
+    ).toBe(false)
+
+    expect(foregroundHandlers).not.toHaveLength(0)
+    foregroundHandlers.forEach((handler) => handler("background"))
+    expect(
+      idempotencyKeySupported(gate(IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice)),
+    ).toBe(false)
+
+    foregroundHandlers.forEach((handler) => handler("active"))
+    expect(
+      idempotencyKeySupported(gate(IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice)),
+    ).toBe(true)
+
+    mutation.mockClear()
+    await send(mocks)
+    expect(keysSent(mutation)).toEqual([mocks.idempotencyKey])
+  })
+
+  it("re-arms every gate at once", () => {
+    rearmIdempotencyKeySupport()
+    Object.values(IDEMPOTENT_SEND_INPUTS).forEach((inputType) => {
+      expect(idempotencyKeySupported(gate(inputType))).toBe(true)
+    })
+  })
+})
+
+// Every send input the app calls, driven through its real builder. The claim
+// this replaced — "four of these are long deployed, so they can pass the field
+// unconditionally" — was never measured anywhere in this repo, and being wrong
+// about one environment takes out every intraledger and USD lightning send.
+describe("all five send inputs are gated", () => {
+  const usdWallet = { currency: WalletCurrency.Usd, id: "usd-wallet" } as const
+  const btcWallet = { currency: WalletCurrency.Btc, id: "btc-wallet" } as const
+
+  const cases: [
+    string,
+    keyof ReturnType<typeof createSendPaymentMocks>,
+    string,
+    () => SendableDetail,
+  ][] = [
+    [
+      IDEMPOTENT_SEND_INPUTS.lnInvoice,
+      "lnInvoicePaymentSend",
+      "lnInvoicePaymentSend",
+      () =>
+        createAmountLightningPaymentDetails({
+          paymentRequest: PAYMENT_REQUEST,
+          paymentRequestAmount: toBtcMoneyAmount(1000),
+          convertMoneyAmount: convertMoneyAmountMock,
+          sendingWalletDescriptor: usdWallet,
+        }),
+    ],
+    [
+      IDEMPOTENT_SEND_INPUTS.lnNoAmountInvoice,
+      "lnNoAmountInvoicePaymentSend",
+      "lnNoAmountInvoicePaymentSend",
+      () =>
+        createNoAmountLightningPaymentDetails({
+          paymentRequest: PAYMENT_REQUEST,
+          unitOfAccountAmount: toBtcMoneyAmount(1000),
+          convertMoneyAmount: convertMoneyAmountMock,
+          sendingWalletDescriptor: btcWallet,
+        }),
+    ],
+    [
+      IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice,
+      "lnNoAmountUsdInvoicePaymentSend",
+      "lnNoAmountUsdInvoicePaymentSend",
+      usdNoAmountDetail,
+    ],
+    [
+      IDEMPOTENT_SEND_INPUTS.intraLedger,
+      "intraLedgerPaymentSend",
+      "intraLedgerPaymentSend",
+      () =>
+        createIntraledgerPaymentDetails({
+          handle: "payee",
+          recipientWalletId: "recipient-wallet",
+          unitOfAccountAmount: toBtcMoneyAmount(1000),
+          convertMoneyAmount: convertMoneyAmountMock,
+          sendingWalletDescriptor: btcWallet,
+        }),
+    ],
+    [
+      IDEMPOTENT_SEND_INPUTS.intraLedgerUsd,
+      "intraLedgerUsdPaymentSend",
+      "intraLedgerUsdPaymentSend",
+      () =>
+        createIntraledgerPaymentDetails({
+          handle: "payee",
+          recipientWalletId: "recipient-wallet",
+          unitOfAccountAmount: toUsdMoneyAmount(250),
+          convertMoneyAmount: convertMoneyAmountMock,
+          sendingWalletDescriptor: usdWallet,
+        }),
+    ],
+  ]
+
+  cases.forEach(([inputType, mockName, payloadKey, build]) => {
+    it(`${inputType} carries the key, and survives a server that refuses it`, async () => {
+      const mocks = createSendPaymentMocks()
+      const mutation = mocks[mockName] as jest.Mock
+      mutation
+        .mockRejectedValueOnce(new Error(coercionRefusalFor(inputType)))
+        .mockResolvedValue({ data: { [payloadKey]: { status: "SUCCESS", errors: [] } } })
+
+      const result = await sendWith(build(), mocks)
+
+      // Keyed first — a server that has the field gets the protection...
+      expect(keysSent(mutation)[0]).toBe(mocks.idempotencyKey)
+      // ...and a server that does not gets today's un-keyed input rather than
+      // a mutation that fails outright.
+      expect(keysSent(mutation)[1]).toBeUndefined()
+      expect(result.status).toBe("SUCCESS")
+    })
+  })
+})
+
+// The other half of the contract: what the server says when it holds a result
+// for this key against DIFFERENT parameters. Pinned to the sentence
+// lnflash/flash `src/graphql/error-map.ts` builds for IdempotencyKeyReuseError,
+// because the accompanying code is the generic INVALID_INPUT that every
+// validation error carries.
+describe("recognising the backend's refusal to replay", () => {
+  const SERVER_MESSAGE =
+    "This idempotency key was already used for a different payment. Use a new key for a new payment."
+
+  it("recognises the sentence the server actually builds", () => {
+    expect(isIdempotencyKeyReuseError([{ message: SERVER_MESSAGE }])).toBe(true)
+  })
+
+  it("finds it alongside other errors", () => {
+    expect(
+      isIdempotencyKeyReuseError([
+        { message: "Something else went wrong" },
+        { message: SERVER_MESSAGE },
+      ]),
+    ).toBe(true)
+  })
+
+  it("does not fire on an ordinary failure", () => {
+    // Reading a normal failure as a reuse would lock the user out of a payment
+    // that never happened.
+    expect(isIdempotencyKeyReuseError([{ message: "Insufficient balance" }])).toBe(false)
+    expect(isIdempotencyKeyReuseError([])).toBe(false)
+    expect(isIdempotencyKeyReuseError(undefined)).toBe(false)
+    expect(isIdempotencyKeyReuseError(null)).toBe(false)
+  })
+})

--- a/__tests__/send-bitcoin/use-send-payment.spec.tsx
+++ b/__tests__/send-bitcoin/use-send-payment.spec.tsx
@@ -147,6 +147,57 @@ describe("useSendPayment — freeze-the-attempt", () => {
     expect(reRendered).not.toHaveBeenCalled()
     expect(original.mock.calls[0][0].idempotencyKey).toBe("uuid-1")
     expect(original.mock.calls[1][0].idempotencyKey).toBe("uuid-1")
+    // The gate's keyless fallback is only sound on a first dispatch, so the
+    // hook must tell it which is which: first dispatch false, retry true.
+    expect(original.mock.calls[0][0].attemptIsRetry).toBe(false)
+    expect(original.mock.calls[1][0].attemptIsRetry).toBe(true)
+  })
+
+  it("a fresh attempt after a FAILURE dispatches as a first attempt, not a retry", async () => {
+    const first = jest.fn().mockResolvedValue({ status: "FAILURE", errors: [] })
+    const { result, swapMutation } = render(first)
+
+    await act(async () => {
+      await result.current.sendPayment?.()
+    })
+
+    const second = jest.fn().mockResolvedValue({ status: "SUCCESS" })
+    swapMutation(second)
+
+    await act(async () => {
+      await result.current.sendPayment?.()
+    })
+
+    expect(second.mock.calls[0][0].attemptIsRetry).toBe(false)
+  })
+
+  it("an IdempotencyKeyReuseError failure does NOT re-arm the button — the user is sent to history", async () => {
+    // The server holding a result for this key against different parameters is
+    // never an ordinary failure: re-arming hands the next tap a FRESH key for
+    // a payment that may already have settled, and the money leaves twice.
+    const mutation = jest.fn().mockResolvedValue({
+      status: "FAILURE",
+      errors: [
+        {
+          message:
+            "This idempotency key was already used for a different payment. Use a new key for a new payment.",
+        },
+      ],
+    })
+    const { result } = render(mutation)
+
+    let outcome:
+      | Awaited<ReturnType<NonNullable<typeof result.current.sendPayment>>>
+      | undefined
+    await act(async () => {
+      outcome = await result.current.sendPayment?.()
+    })
+
+    expect(outcome?.status).toBe("FAILURE")
+    expect(outcome?.errorsMessage).toMatch(/transaction history/i)
+    // Button stays disarmed: no fresh-key tap is reachable.
+    expect(result.current.hasAttemptedSend).toBe(true)
+    expect(result.current.sendPayment).toBeUndefined()
   })
 
   it("on FAILURE, the attempt is finished: next tap gets a FRESH key and the CURRENT closure", async () => {

--- a/__tests__/send-bitcoin/use-send-payment.spec.tsx
+++ b/__tests__/send-bitcoin/use-send-payment.spec.tsx
@@ -153,6 +153,46 @@ describe("useSendPayment — freeze-the-attempt", () => {
     expect(original.mock.calls[1][0].attemptIsRetry).toBe(true)
   })
 
+  it("refuses to auto-retry an attempt whose earlier dispatch went out KEYLESS", async () => {
+    // The mixed-fleet window: the gate is latched (a stale pod refused
+    // earlier), so the attempt's first dispatch goes out keyless — reported
+    // via onKeylessDispatch — and then throws with the outcome unknown. The
+    // server has never seen this attempt's key, so a retry has nothing to
+    // replay: dispatching it (the closure would now send KEYED against a pod
+    // that accepts the field) could execute a second payment while the
+    // keyless one may have committed. The retry must not dispatch at all.
+    const mutation = jest.fn(async (params: { onKeylessDispatch?: () => void }) => {
+      params.onKeylessDispatch?.()
+      throw new Error("socket dropped")
+    })
+    const { result } = render(mutation)
+
+    await act(async () => {
+      await expect(result.current.sendPayment?.()).rejects.toThrow("socket dropped")
+    })
+    // The throw re-armed the button, so the retry tap is reachable...
+    expect(result.current.sendPayment).toBeTruthy()
+
+    let outcome:
+      | Awaited<ReturnType<NonNullable<typeof result.current.sendPayment>>>
+      | undefined
+    await act(async () => {
+      outcome = await result.current.sendPayment?.()
+    })
+
+    // ...but it surfaces the check-your-history failure WITHOUT dispatching:
+    // the mutation ran exactly once, on the keyless first dispatch.
+    expect(mutation).toHaveBeenCalledTimes(1)
+    expect(outcome?.status).toBe("FAILURE")
+    expect(outcome?.errorsMessage).toMatch(
+      /may have already been sent.*transaction history/i,
+    )
+    // Same as the reuse-error branch: the button stays disarmed, so no
+    // fresh-key tap is offered for a payment that may already have settled.
+    expect(result.current.hasAttemptedSend).toBe(true)
+    expect(result.current.sendPayment).toBeUndefined()
+  })
+
   it("a fresh attempt after a FAILURE dispatches as a first attempt, not a retry", async () => {
     const first = jest.fn().mockResolvedValue({ status: "FAILURE", errors: [] })
     const { result, swapMutation } = render(first)

--- a/__tests__/send-bitcoin/use-send-payment.spec.tsx
+++ b/__tests__/send-bitcoin/use-send-payment.spec.tsx
@@ -1,0 +1,204 @@
+import { renderHook, act } from "@testing-library/react-native"
+
+/**
+ * ENG-533 — freeze-the-attempt idempotency.
+ *
+ * An attempt is an OBJECT (the send closure captured at the first tap + one
+ * random key), never a content fingerprint. These tests pin the lifecycle:
+ *
+ *   double tap        → one mutation call; the second tap returns ignored
+ *   throw             → retry re-runs the ORIGINAL closure with the SAME key,
+ *                       even if the hook re-rendered with a new mutation
+ *   Failure           → attempt cleared; next tap = fresh key, fresh closure
+ *   Success           → attempt cleared; a later send never reuses the key
+ */
+
+jest.mock("@app/graphql/generated", () => {
+  const hook = () => [jest.fn(), { loading: false }]
+  return {
+    HomeAuthedDocument: {},
+    PaymentSendResult: {
+      Success: "SUCCESS",
+      Failure: "FAILURE",
+      Pending: "PENDING",
+      AlreadyPaid: "ALREADY_PAID",
+    },
+    WalletCurrency: { Btc: "BTC", Usd: "USD" },
+    useIntraLedgerPaymentSendMutation: hook,
+    useIntraLedgerUsdPaymentSendMutation: hook,
+    useLnInvoicePaymentSendMutation: hook,
+    useLnNoAmountInvoicePaymentSendMutation: hook,
+    useLnNoAmountUsdInvoicePaymentSendMutation: hook,
+    useOnChainPaymentSendMutation: hook,
+    useOnChainPaymentSendAllMutation: hook,
+    useOnChainUsdPaymentSendMutation: hook,
+    useOnChainUsdPaymentSendAsBtcDenominatedMutation: hook,
+  }
+})
+
+const GRAPHQL_URI = "https://api.test.flashapp.me/graphql"
+jest.mock("@app/hooks", () => ({
+  useAppConfig: () => ({
+    appConfig: {
+      galoyInstance: { lnAddressHostname: "flashapp.me", graphqlUri: GRAPHQL_URI },
+    },
+  }),
+}))
+
+jest.mock("@app/utils/breez-sdk", () => ({
+  payLightningBreez: jest.fn(),
+  payOnchainBreez: jest.fn(),
+  payLnurlBreez: jest.fn(),
+}))
+
+let uuidCounter = 0
+jest.mock("uuid", () => ({
+  v4: () => `uuid-${++uuidCounter}`,
+}))
+
+import { useSendPayment } from "@app/screens/send-bitcoin-screen/use-send-payment"
+
+// A USD payment detail: only the fields the hook reads on the GraphQL path.
+const usdPaymentDetail = {
+  sendingWalletDescriptor: { currency: "USD", id: "usd-wallet" },
+} as never
+
+const render = (mutation: jest.Mock) => {
+  let currentMutation: jest.Mock = mutation
+  const utils = renderHook(() => useSendPayment(currentMutation, usdPaymentDetail))
+  return {
+    ...utils,
+    // Re-render with a DIFFERENT mutation closure — simulates the re-render
+    // that used to re-mint invoices and re-derive amounts.
+    swapMutation: (next: jest.Mock) => {
+      currentMutation = next
+      utils.rerender(undefined as never)
+    },
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  uuidCounter = 0
+})
+
+describe("useSendPayment — freeze-the-attempt", () => {
+  it("sends once with a random key and the configured endpoint", async () => {
+    const mutation = jest.fn().mockResolvedValue({ status: "SUCCESS" })
+    const { result } = render(mutation)
+
+    let outcome
+    await act(async () => {
+      outcome = await result.current.sendPayment?.()
+    })
+
+    expect(mutation).toHaveBeenCalledTimes(1)
+    expect(mutation.mock.calls[0][0]).toMatchObject({
+      idempotencyKey: "uuid-1",
+      apiEndpoint: GRAPHQL_URI,
+    })
+    expect(outcome).toEqual({ status: "SUCCESS", errorsMessage: undefined })
+  })
+
+  it("suppresses a double tap: second call returns ignored, one mutation fires", async () => {
+    let resolveSend: (v: unknown) => void = () => {}
+    const mutation = jest.fn(() => new Promise((resolve) => (resolveSend = resolve)))
+    const { result } = render(mutation)
+
+    await act(async () => {
+      const first = result.current.sendPayment?.()
+      // Second tap lands while the first is on the wire. The render-time
+      // hasAttemptedSend gate hasn't flipped yet — this is the ref's job.
+      const second = await result.current.sendPayment?.()
+      expect(second).toEqual({
+        status: undefined,
+        errorsMessage: undefined,
+        ignored: true,
+      })
+      resolveSend({ status: "SUCCESS" })
+      await first
+    })
+
+    expect(mutation).toHaveBeenCalledTimes(1)
+  })
+
+  it("on throw, the retry re-runs the ORIGINAL closure with the SAME key — even after a re-render swapped the mutation", async () => {
+    const original = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("socket dropped"))
+      .mockResolvedValue({ status: "SUCCESS" })
+    const { result, swapMutation } = render(original)
+
+    await act(async () => {
+      await expect(result.current.sendPayment?.()).rejects.toThrow("socket dropped")
+    })
+
+    // Between taps the screen re-renders: new payment detail, new closure.
+    // A content fingerprint would have to decide whether this is "the same"
+    // payment. Object identity doesn't: the frozen attempt ignores it.
+    const reRendered = jest.fn().mockResolvedValue({ status: "SUCCESS" })
+    swapMutation(reRendered)
+
+    await act(async () => {
+      await result.current.sendPayment?.()
+    })
+
+    expect(original).toHaveBeenCalledTimes(2)
+    expect(reRendered).not.toHaveBeenCalled()
+    expect(original.mock.calls[0][0].idempotencyKey).toBe("uuid-1")
+    expect(original.mock.calls[1][0].idempotencyKey).toBe("uuid-1")
+  })
+
+  it("on FAILURE, the attempt is finished: next tap gets a FRESH key and the CURRENT closure", async () => {
+    const first = jest.fn().mockResolvedValue({ status: "FAILURE", errors: [] })
+    const { result, swapMutation } = render(first)
+
+    await act(async () => {
+      await result.current.sendPayment?.()
+    })
+
+    const second = jest.fn().mockResolvedValue({ status: "SUCCESS" })
+    swapMutation(second)
+
+    await act(async () => {
+      await result.current.sendPayment?.()
+    })
+
+    // A known failure must never pin the old key — that's the 24h
+    // cached-FAILURE lockout of the fingerprint design.
+    expect(second).toHaveBeenCalledTimes(1)
+    expect(first.mock.calls[0][0].idempotencyKey).toBe("uuid-1")
+    expect(second.mock.calls[0][0].idempotencyKey).toBe("uuid-2")
+  })
+
+  it("FAILURE re-arms the button (hasAttemptedSend false); SUCCESS does not", async () => {
+    const failing = jest.fn().mockResolvedValue({ status: "FAILURE" })
+    const { result } = render(failing)
+
+    await act(async () => {
+      await result.current.sendPayment?.()
+    })
+    expect(result.current.hasAttemptedSend).toBe(false)
+    expect(result.current.sendPayment).toBeTruthy()
+
+    const succeeding = jest.fn().mockResolvedValue({ status: "SUCCESS" })
+    const secondRender = render(succeeding)
+    await act(async () => {
+      await secondRender.result.current.sendPayment?.()
+    })
+    expect(secondRender.result.current.hasAttemptedSend).toBe(true)
+    expect(secondRender.result.current.sendPayment).toBeUndefined()
+  })
+
+  it("a throw re-arms the button so the frozen retry is reachable", async () => {
+    const mutation = jest.fn().mockRejectedValue(new Error("502"))
+    const { result } = render(mutation)
+
+    await act(async () => {
+      await expect(result.current.sendPayment?.()).rejects.toThrow("502")
+    })
+
+    expect(result.current.hasAttemptedSend).toBe(false)
+    expect(result.current.sendPayment).toBeTruthy()
+  })
+})

--- a/__tests__/send-bitcoin/use-send-payment.spec.tsx
+++ b/__tests__/send-bitcoin/use-send-payment.spec.tsx
@@ -53,7 +53,10 @@ jest.mock("@app/utils/breez-sdk", () => ({
 
 let uuidCounter = 0
 jest.mock("uuid", () => ({
-  v4: () => `uuid-${++uuidCounter}`,
+  v4: () => {
+    uuidCounter += 1
+    return `uuid-${uuidCounter}`
+  },
 }))
 
 import { useSendPayment } from "@app/screens/send-bitcoin-screen/use-send-payment"
@@ -102,7 +105,12 @@ describe("useSendPayment — freeze-the-attempt", () => {
 
   it("suppresses a double tap: second call returns ignored, one mutation fires", async () => {
     let resolveSend: (v: unknown) => void = () => {}
-    const mutation = jest.fn(() => new Promise((resolve) => (resolveSend = resolve)))
+    const mutation = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveSend = resolve
+        }),
+    )
     const { result } = render(mutation)
 
     await act(async () => {

--- a/app/screens/send-bitcoin-screen/payment-details/idempotency-support.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/idempotency-support.ts
@@ -1,0 +1,213 @@
+// Runtime capability gate for `idempotencyKey` on every send input this app
+// passes it to.
+//
+// The hazard: GraphQL rejects unknown input-object fields during *input
+// coercion*, before execution. Against a server whose input predates the
+// resolver that added the field, an unconditional `idempotencyKey` therefore
+// does not degrade — it errors the whole mutation out, and that entire send
+// path stops working. `yarn graphql-check` cannot catch that: it validates our
+// operations against the checked-in snapshot, not against the deployed server.
+// The repo already isolates card-top-up operations for exactly this reason
+// (see use-card-topup-allowance.ts); the send path must not be the exception,
+// since the app can ship ahead of any given environment's API.
+//
+// ALL FIVE inputs go through here, not just the newest one. The app had never
+// sent any of these fields before — the schema snapshot this PR refreshed was
+// 224 lines stale, which is the PR's own premise — so "ENG-530 is long
+// deployed" is an assumption nothing in this repo measures. If a single
+// environment is behind it, an ungated field takes out every intraledger and
+// lightning send from a USD wallet: a worse outage than the double-debit being
+// fixed. The gate is generic and already tested; four extra call sites buy the
+// assumption away.
+//
+// The check is an observation rather than an introspection round trip: the
+// first send that is refused for this reason tells us, and because coercion
+// happens before execution a refusal proves NOTHING settled — so retrying the
+// same send without the field cannot double-pay.
+import { AppState, AppStateStatus } from "react-native"
+
+/**
+ * The GraphQL input-object type names that carry `idempotencyKey`, exactly as
+ * the server declares them.
+ *
+ * These strings are load-bearing twice over: they scope the gate (below) and
+ * they are what a coercion refusal has to name before it is read as being
+ * about THIS input. A typo silently disables the gate rather than failing
+ * loudly, which is why `__tests__/send-bitcoin/idempotency-support.spec.ts`
+ * pins them against app/graphql/public-schema.graphql.
+ */
+export const IDEMPOTENT_SEND_INPUTS = {
+  intraLedger: "IntraLedgerPaymentSendInput",
+  intraLedgerUsd: "IntraLedgerUsdPaymentSendInput",
+  lnInvoice: "LnInvoicePaymentInput",
+  lnNoAmountInvoice: "LnNoAmountInvoicePaymentInput",
+  lnNoAmountUsdInvoice: "LnNoAmountUsdInvoicePaymentInput",
+} as const
+
+export type IdempotentSendInput =
+  (typeof IDEMPOTENT_SEND_INPUTS)[keyof typeof IDEMPOTENT_SEND_INPUTS]
+
+/**
+ * What a refusal is scoped to.
+ *
+ * Both halves matter:
+ *
+ *  - `apiEndpoint`, because the app can switch `galoyInstance` at runtime
+ *    (useSendPayment reads `useAppConfig().appConfig.galoyInstance`). A single
+ *    process-global would let one send against staging, or against a custom
+ *    instance, disarm idempotency for prod for the rest of the session.
+ *  - `inputType`, because the five inputs gained the field in different server
+ *    releases. One input's refusal says nothing about the other four, and
+ *    treating it as though it did throws away protection on paths that have it.
+ */
+export type IdempotencyGate = {
+  /** The GraphQL endpoint the send is going to — `galoyInstance.graphqlUri`. */
+  apiEndpoint: string
+  inputType: IdempotentSendInput
+}
+
+const gateId = ({ apiEndpoint, inputType }: IdempotencyGate): string =>
+  `${apiEndpoint}\u0000${inputType}`
+
+// Gates observed to refuse the field. Empty is the normal state; an entry is
+// only ever added by a refusal the server actually sent.
+const refusedGates = new Set<string>()
+
+let foregroundSubscription: { remove: () => void } | undefined
+
+/**
+ * Re-arm every gate.
+ *
+ * A refusal is evidence about the pod that answered, not about the deployment:
+ * during a rolling deploy a stale pod can refuse while the rest of the fleet
+ * accepts. Left latched, that one pod costs the whole session's protection.
+ * Foreground is the cheap, natural moment to reconsider — the app has been away
+ * long enough for a deploy to finish, and the cost of being wrong is one
+ * refused round trip that provably settled nothing.
+ */
+export const rearmIdempotencyKeySupport = (): void => {
+  refusedGates.clear()
+}
+
+const watchForeground = (): void => {
+  if (foregroundSubscription) return
+  // Subscribed lazily rather than at import time: this module is imported by
+  // the payment-detail builders, which unit tests construct directly.
+  foregroundSubscription =
+    AppState.addEventListener?.("change", (state: AppStateStatus) => {
+      if (state === "active") rearmIdempotencyKeySupport()
+    }) ?? undefined
+}
+
+/** Test seam — module state would otherwise leak between cases. */
+export const resetIdempotencyKeySupport = (): void => {
+  refusedGates.clear()
+  foregroundSubscription?.remove()
+  foregroundSubscription = undefined
+}
+
+/** Whether the field is still believed to be accepted for this gate. */
+export const idempotencyKeySupported = (gate: IdempotencyGate): boolean =>
+  !refusedGates.has(gateId(gate))
+
+// The ONE sentence graphql-js emits for an unknown input-object field, matched
+// whole and NAMING THE INPUT. Anchoring on the sentence rather than on loose
+// halves is the whole point: `coerceVariableValues` writes EVERY input-coercion
+// error as `Variable "$input" got invalid value ${inspect(invalidValue)}...;
+// <reason>`, and for an input-object error `invalidValue` is the entire input
+// object — which contains `idempotencyKey` whenever we sent it. A pair of
+// checks like "mentions the field" AND "says got invalid value" therefore
+// matches any coercion error at all: the server adds an unrelated required
+// field, answers `...; Field "x" of required type "Y!" was not provided.`, and
+// the gate reads that as "the server lacks idempotencyKey", disarms itself, and
+// later sends go out bare — so a lost response plus a retry double-pays,
+// silently, on the path this exists to protect.
+//
+// Including the type name also keeps one input's refusal from disarming
+// another's.
+const refusalSentence = (inputType: IdempotentSendInput): string =>
+  `Field "idempotencyKey" is not defined by type "${inputType}"`
+
+const messagesOf = (err: unknown): string[] => {
+  const candidate = err as {
+    message?: unknown
+    graphQLErrors?: readonly { message?: unknown }[]
+  } | null
+  if (!candidate) return []
+
+  const messages: string[] = []
+  if (typeof candidate.message === "string") messages.push(candidate.message)
+  if (Array.isArray(candidate.graphQLErrors)) {
+    for (const graphQLError of candidate.graphQLErrors) {
+      if (typeof graphQLError?.message === "string") messages.push(graphQLError.message)
+    }
+  }
+  return messages
+}
+
+/**
+ * Whether `err` is the server saying it does not know this input field, on
+ * THIS input — as opposed to any other failure, which must propagate untouched.
+ */
+export const isUnsupportedIdempotencyKeyError = (
+  err: unknown,
+  inputType: IdempotentSendInput,
+): boolean =>
+  messagesOf(err).some((message) => message.includes(refusalSentence(inputType)))
+
+/**
+ * Run `send` with the idempotency key when the gate is known to accept it, and
+ * fall back to today's un-keyed input when it turns out not to.
+ *
+ * The fallback fires only on a coercion refusal for this input, and a coercion
+ * refusal means the mutation never executed, so the retry is not a second
+ * payment attempt.
+ */
+export const withIdempotencyKey = async <T>(
+  idempotencyKey: string,
+  gate: IdempotencyGate,
+  send: (keyField: { idempotencyKey?: string }) => Promise<T>,
+): Promise<T> => {
+  watchForeground()
+
+  if (!idempotencyKeySupported(gate)) return send({})
+
+  try {
+    return await send({ idempotencyKey })
+  } catch (err) {
+    if (!isUnsupportedIdempotencyKeyError(err, gate.inputType)) throw err
+    refusedGates.add(gateId(gate))
+    return send({})
+  }
+}
+
+/**
+ * The server's answer when a key it already has a result for is presented with
+ * DIFFERENT payment parameters (`IdempotencyKeyReuseError`, mapped through
+ * lnflash/flash `src/graphql/error-map.ts`).
+ *
+ * Matched on the sentence rather than a code because the code is the generic
+ * `INVALID_INPUT` that every validation error carries. Pinned by test against
+ * the string the server actually builds.
+ */
+const KEY_REUSE_SENTENCE = "idempotency key was already used for a different payment"
+
+/**
+ * Whether a mutation's `errors` payload is the backend refusing to replay
+ * because our input no longer matches the one it cached.
+ *
+ * This must never be treated as an ordinary failure. It arrives as
+ * `{ status: "failed" }`, and a failure is what retires the key and re-enables
+ * the Confirm button — so reading it as one hands the user a FRESH key for a
+ * payment the server has already settled, and the money leaves twice. The
+ * server owns an outcome here; the only safe move is to stop and tell the user
+ * to look at their history.
+ */
+export const isIdempotencyKeyReuseError = (
+  errors: readonly { message?: string | null }[] | null | undefined,
+): boolean =>
+  Boolean(
+    errors?.some((error) =>
+      (error?.message ?? "").toLowerCase().includes(KEY_REUSE_SENTENCE),
+    ),
+  )

--- a/app/screens/send-bitcoin-screen/payment-details/idempotency-support.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/idempotency-support.ts
@@ -156,27 +156,63 @@ export const isUnsupportedIdempotencyKeyError = (
   messagesOf(err).some((message) => message.includes(refusalSentence(inputType)))
 
 /**
+ * Thrown in place of a keyless fallback when the key is refused on a RETRY of
+ * an attempt that has already been dispatched once. The earlier dispatch's
+ * outcome is unknown — that is what makes it a retry — so re-sending without
+ * the key would re-execute a payment the server may have already settled. The
+ * only safe move is to surface an error and send the user to their history.
+ */
+export class UnresolvedAttemptKeyRefusedError extends Error {
+  constructor() {
+    super(
+      "This payment may have already been sent. Check your transaction history before trying again.",
+    )
+    this.name = "UnresolvedAttemptKeyRefusedError"
+  }
+}
+
+/**
+ * The attempt half of a keyed dispatch: the key itself, plus whether this is
+ * a RETRY of an attempt that has already been dispatched once (see
+ * `attemptRef` in use-send-payment.ts — a retry exists precisely because the
+ * earlier dispatch's outcome is unknown).
+ */
+export type IdempotentAttempt = {
+  idempotencyKey: string
+  isRetry: boolean
+}
+
+/**
  * Run `send` with the idempotency key when the gate is known to accept it, and
  * fall back to today's un-keyed input when it turns out not to.
  *
- * The fallback fires only on a coercion refusal for this input, and a coercion
- * refusal means the mutation never executed, so the retry is not a second
- * payment attempt.
+ * The keyless fallback fires only on the FIRST dispatch of an attempt: there a
+ * coercion refusal means the mutation never executed, so the un-keyed retry is
+ * not a second payment attempt. On a RETRY of a dispatched attempt that
+ * reasoning covers only the dispatch that was just refused — it says nothing
+ * about the earlier keyed dispatch whose outcome is unknown (the exact
+ * mixed-fleet scenario the re-arm logic above defends against: tap 1 commits
+ * on a new pod, the response is lost, the retry hits a stale pod that refuses
+ * the field). A keyless send there could execute a second payment, so a retry
+ * NEVER goes out keyless: it is always dispatched with the key — the one
+ * spelling the server can recognise as a repeat — and a refusal surfaces as
+ * `UnresolvedAttemptKeyRefusedError` instead of a silent re-execution.
  */
 export const withIdempotencyKey = async <T>(
-  idempotencyKey: string,
+  attempt: IdempotentAttempt,
   gate: IdempotencyGate,
   send: (keyField: { idempotencyKey?: string }) => Promise<T>,
 ): Promise<T> => {
   watchForeground()
 
-  if (!idempotencyKeySupported(gate)) return send({})
+  if (!idempotencyKeySupported(gate) && !attempt.isRetry) return send({})
 
   try {
-    return await send({ idempotencyKey })
+    return await send({ idempotencyKey: attempt.idempotencyKey })
   } catch (err) {
     if (!isUnsupportedIdempotencyKeyError(err, gate.inputType)) throw err
     refusedGates.add(gateId(gate))
+    if (attempt.isRetry) throw new UnresolvedAttemptKeyRefusedError()
     return send({})
   }
 }

--- a/app/screens/send-bitcoin-screen/payment-details/idempotency-support.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/idempotency-support.ts
@@ -156,6 +156,16 @@ export const isUnsupportedIdempotencyKeyError = (
   messagesOf(err).some((message) => message.includes(refusalSentence(inputType)))
 
 /**
+ * The one sentence shown whenever the client cannot prove an earlier dispatch
+ * of this payment did NOT settle — an idempotency-key reuse answer, a key
+ * refused on a retry, or a retry of an attempt that once went out keyless.
+ * Shared so the copy cannot drift between the modules that surface it
+ * (use-send-payment.ts is the other one).
+ */
+export const CHECK_TRANSACTION_HISTORY_MESSAGE =
+  "This payment may have already been sent. Check your transaction history before trying again."
+
+/**
  * Thrown in place of a keyless fallback when the key is refused on a RETRY of
  * an attempt that has already been dispatched once. The earlier dispatch's
  * outcome is unknown — that is what makes it a retry — so re-sending without
@@ -164,9 +174,7 @@ export const isUnsupportedIdempotencyKeyError = (
  */
 export class UnresolvedAttemptKeyRefusedError extends Error {
   constructor() {
-    super(
-      "This payment may have already been sent. Check your transaction history before trying again.",
-    )
+    super(CHECK_TRANSACTION_HISTORY_MESSAGE)
     this.name = "UnresolvedAttemptKeyRefusedError"
   }
 }
@@ -180,6 +188,15 @@ export class UnresolvedAttemptKeyRefusedError extends Error {
 export type IdempotentAttempt = {
   idempotencyKey: string
   isRetry: boolean
+  /**
+   * Called synchronously, immediately before any dispatch that goes out
+   * WITHOUT the key. The caller owns the attempt's lifecycle and must know:
+   * once an attempt has gone out keyless, a later retry of it cannot lean on
+   * the server replaying the key — the server never saw one — so re-dispatching
+   * could execute a second payment. use-send-payment.ts records the flag and
+   * refuses to auto-retry such an attempt.
+   */
+  onKeylessDispatch?: () => void
 }
 
 /**
@@ -205,7 +222,10 @@ export const withIdempotencyKey = async <T>(
 ): Promise<T> => {
   watchForeground()
 
-  if (!idempotencyKeySupported(gate) && !attempt.isRetry) return send({})
+  if (!idempotencyKeySupported(gate) && !attempt.isRetry) {
+    attempt.onKeylessDispatch?.()
+    return send({})
+  }
 
   try {
     return await send({ idempotencyKey: attempt.idempotencyKey })
@@ -213,6 +233,7 @@ export const withIdempotencyKey = async <T>(
     if (!isUnsupportedIdempotencyKeyError(err, gate.inputType)) throw err
     refusedGates.add(gateId(gate))
     if (attempt.isRetry) throw new UnresolvedAttemptKeyRefusedError()
+    attempt.onKeylessDispatch?.()
     return send({})
   }
 }

--- a/app/screens/send-bitcoin-screen/payment-details/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/index.types.ts
@@ -29,6 +29,7 @@ import { WalletDescriptor } from "@app/types/wallets"
 import { PaymentType } from "@galoymoney/client"
 import { LnUrlPayServiceResponse } from "lnurl-pay/dist/types/types"
 
+
 export type ConvertMoneyAmount = <W extends WalletOrDisplayCurrency>(
   moneyAmount: MoneyAmount<WalletOrDisplayCurrency>,
   toCurrency: W,
@@ -65,6 +66,38 @@ export type GetFee<T extends WalletCurrency> = (getFeeFns: GetFeeParams) => Prom
 }>
 
 export type SendPaymentMutationParams = {
+  /**
+   * Stable per-attempt key so a send that is repeated cannot settle twice.
+   *
+   * The dangerous case is not a double tap (guarded separately) but a send
+   * whose RESPONSE was lost — a dropped socket, a gateway 502, the app
+   * backgrounded mid-flight. The server has already moved the money; the
+   * client has no way to know. Sending the same key again lets the backend
+   * (flash#494) recognise the repeat and return the original outcome instead
+   * of paying a second time.
+   *
+   * FIVE send inputs accept it, and every one this app calls passes it
+   * through the SAME runtime gate in idempotency-support.ts:
+   * intraLedgerPaymentSend, intraLedgerUsdPaymentSend,
+   * lnInvoicePaymentSend, lnNoAmountInvoicePaymentSend and
+   * lnNoAmountUsdInvoicePaymentSend. Four of them have carried the field since
+   * ENG-530 and one only since flash#494, but nothing in this repo measures
+   * which environments are on which release — and an unknown input field is
+   * rejected during coercion, taking the whole send path down rather than
+   * degrading — so none of them is exempt. The sixth, lnurlPaymentSend,
+   * accepts it server-side but is never called from here — LNURL sends go
+   * through Breez. Onchain sends likewise: those resolvers are stubbed and the
+   * money moves client-side through Breez.
+   */
+  idempotencyKey: string
+  /**
+   * The GraphQL endpoint this send is going to (`galoyInstance.graphqlUri`).
+   *
+   * Scopes the idempotency-support gate. The app can switch instance at
+   * runtime, so a refusal learned from staging — or from one stale pod mid
+   * rolling deploy — must not disarm the key for prod.
+   */
+  apiEndpoint: string
   lnInvoicePaymentSend: LnInvoicePaymentSendMutationHookResult["0"]
   lnNoAmountInvoicePaymentSend: LnNoAmountInvoicePaymentSendMutationHookResult["0"]
   lnNoAmountUsdInvoicePaymentSend: LnNoAmountUsdInvoicePaymentSendMutationHookResult["0"]

--- a/app/screens/send-bitcoin-screen/payment-details/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/index.types.ts
@@ -29,7 +29,6 @@ import { WalletDescriptor } from "@app/types/wallets"
 import { PaymentType } from "@galoymoney/client"
 import { LnUrlPayServiceResponse } from "lnurl-pay/dist/types/types"
 
-
 export type ConvertMoneyAmount = <W extends WalletOrDisplayCurrency>(
   moneyAmount: MoneyAmount<WalletOrDisplayCurrency>,
   toCurrency: W,
@@ -90,6 +89,17 @@ export type SendPaymentMutationParams = {
    * money moves client-side through Breez.
    */
   idempotencyKey: string
+  /**
+   * Whether this dispatch is a RETRY of an attempt that has already been
+   * dispatched once (set from `attempt.dispatched` in use-send-payment.ts).
+   *
+   * The idempotency-support gate needs the distinction: its keyless fallback
+   * on a coercion refusal is only sound on an attempt's FIRST dispatch, where
+   * the refusal proves nothing executed. On a retry, an earlier keyed dispatch
+   * with an unknown outcome exists by definition, so a keyless re-send could
+   * execute a second payment — the gate errors out instead.
+   */
+  attemptIsRetry: boolean
   /**
    * The GraphQL endpoint this send is going to (`galoyInstance.graphqlUri`).
    *

--- a/app/screens/send-bitcoin-screen/payment-details/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/index.types.ts
@@ -101,6 +101,15 @@ export type SendPaymentMutationParams = {
    */
   attemptIsRetry: boolean
   /**
+   * Invoked synchronously, immediately before any dispatch that goes out
+   * WITHOUT `idempotencyKey` (the idempotency-support gate's keyless
+   * fallback / latched-gate path). use-send-payment.ts records it on the
+   * attempt: an attempt that has gone out keyless must never be auto-retried,
+   * because the server has no key to replay and a re-dispatch could execute a
+   * second payment.
+   */
+  onKeylessDispatch?: () => void
+  /**
    * The GraphQL endpoint this send is going to (`galoyInstance.graphqlUri`).
    *
    * Scopes the idempotency-support gate. The app can switch instance at

--- a/app/screens/send-bitcoin-screen/payment-details/intraledger.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/intraledger.ts
@@ -1,6 +1,7 @@
 import { WalletCurrency } from "@app/graphql/generated"
 import { MoneyAmount, WalletOrDisplayCurrency, toWalletAmount } from "@app/types/amounts"
 import { PaymentType } from "@galoymoney/client"
+import { IDEMPOTENT_SEND_INPUTS, withIdempotencyKey } from "./idempotency-support"
 import {
   BaseCreatePaymentDetailsParams,
   ConvertMoneyAmount,
@@ -51,27 +52,45 @@ export const createIntraledgerPaymentDetails = <T extends WalletCurrency>(
     canSendPayment: false,
     canGetFee: false,
   }
+  // The data half of the freeze for whichever branch can send — see
+
   if (
     settlementAmount.amount &&
     sendingWalletDescriptor.currency === WalletCurrency.Btc
   ) {
-    const sendPaymentMutation: SendPaymentMutation = async (paymentMutations) => {
-      const { data } = await paymentMutations.intraLedgerPaymentSend({
-        variables: {
-          input: {
-            walletId: sendingWalletDescriptor.id,
-            recipientWalletId,
-            amount: settlementAmount.amount,
-            memo,
-          },
-        },
-      })
-
-      return {
-        status: data?.intraLedgerPaymentSend.status,
-        errors: data?.intraLedgerPaymentSend.errors,
-      }
+    const wireInput = {
+      walletId: sendingWalletDescriptor.id,
+      recipientWalletId,
+      amount: settlementAmount.amount,
+      memo,
     }
+
+    const sendPaymentMutation: SendPaymentMutation = async (paymentMutations) =>
+      // Gated like every other send input — see idempotency-support.ts.
+      withIdempotencyKey(
+        paymentMutations.idempotencyKey,
+        {
+          apiEndpoint: paymentMutations.apiEndpoint,
+          inputType: IDEMPOTENT_SEND_INPUTS.intraLedger,
+        },
+        async (keyField) => {
+          const { data } = await paymentMutations.intraLedgerPaymentSend({
+            variables: {
+              input: {
+                ...wireInput,
+                // Same key for every repeat of this attempt, so a send whose
+                // response was lost settles once. See SendPaymentMutationParams.
+                ...keyField,
+              },
+            },
+          })
+
+          return {
+            status: data?.intraLedgerPaymentSend.status,
+            errors: data?.intraLedgerPaymentSend.errors,
+          }
+        },
+      )
 
     sendPaymentAndGetFee = {
       canSendPayment: true,
@@ -84,23 +103,43 @@ export const createIntraledgerPaymentDetails = <T extends WalletCurrency>(
     (sendingWalletDescriptor.currency === WalletCurrency.Usd ||
       sendingWalletDescriptor.currency === WalletCurrency.Usdt)
   ) {
-    const sendPaymentMutation: SendPaymentMutation = async (paymentMutations) => {
-      const { data } = await paymentMutations.intraLedgerUsdPaymentSend({
-        variables: {
-          input: {
-            walletId: sendingWalletDescriptor.id,
-            recipientWalletId,
-            amount: settlementAmount.amount,
-            memo,
-          },
-        },
-      })
-
-      return {
-        status: data?.intraLedgerUsdPaymentSend.status,
-        errors: data?.intraLedgerUsdPaymentSend.errors,
-      }
+    const wireInput = {
+      walletId: sendingWalletDescriptor.id,
+      recipientWalletId,
+      amount: settlementAmount.amount,
+      memo,
     }
+
+    const sendPaymentMutation: SendPaymentMutation = async (paymentMutations) =>
+      // USD/USDT Flash-to-Flash — the same double-debit class ENG-533 exists to
+      // close, and gated like every other send input.
+      withIdempotencyKey(
+        paymentMutations.idempotencyKey,
+        {
+          apiEndpoint: paymentMutations.apiEndpoint,
+          inputType: IDEMPOTENT_SEND_INPUTS.intraLedgerUsd,
+        },
+        async (keyField) => {
+          const { data } = await paymentMutations.intraLedgerUsdPaymentSend({
+            variables: {
+              input: {
+                // `intraledger|${recipientWalletId}|${amount}`, and a USD/USDT
+                // amount is price-derived — so the rebuilt input drifts by a
+                // cent and the backend refuses to replay.
+                ...wireInput,
+                // Same key for every repeat of this attempt, so a send whose
+                // response was lost settles once. See SendPaymentMutationParams.
+                ...keyField,
+              },
+            },
+          })
+
+          return {
+            status: data?.intraLedgerUsdPaymentSend.status,
+            errors: data?.intraLedgerUsdPaymentSend.errors,
+          }
+        },
+      )
 
     sendPaymentAndGetFee = {
       canSendPayment: true,

--- a/app/screens/send-bitcoin-screen/payment-details/intraledger.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/intraledger.ts
@@ -72,6 +72,7 @@ export const createIntraledgerPaymentDetails = <T extends WalletCurrency>(
         {
           idempotencyKey: paymentMutations.idempotencyKey,
           isRetry: paymentMutations.attemptIsRetry,
+          onKeylessDispatch: paymentMutations.onKeylessDispatch,
         },
         {
           apiEndpoint: paymentMutations.apiEndpoint,
@@ -121,6 +122,7 @@ export const createIntraledgerPaymentDetails = <T extends WalletCurrency>(
         {
           idempotencyKey: paymentMutations.idempotencyKey,
           isRetry: paymentMutations.attemptIsRetry,
+          onKeylessDispatch: paymentMutations.onKeylessDispatch,
         },
         {
           apiEndpoint: paymentMutations.apiEndpoint,

--- a/app/screens/send-bitcoin-screen/payment-details/intraledger.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/intraledger.ts
@@ -52,7 +52,8 @@ export const createIntraledgerPaymentDetails = <T extends WalletCurrency>(
     canSendPayment: false,
     canGetFee: false,
   }
-  // The data half of the freeze for whichever branch can send — see
+  // The data half of the freeze for whichever branch can send — see the
+  // attemptRef comment in use-send-payment.ts for the closure half.
 
   if (
     settlementAmount.amount &&
@@ -68,7 +69,10 @@ export const createIntraledgerPaymentDetails = <T extends WalletCurrency>(
     const sendPaymentMutation: SendPaymentMutation = async (paymentMutations) =>
       // Gated like every other send input — see idempotency-support.ts.
       withIdempotencyKey(
-        paymentMutations.idempotencyKey,
+        {
+          idempotencyKey: paymentMutations.idempotencyKey,
+          isRetry: paymentMutations.attemptIsRetry,
+        },
         {
           apiEndpoint: paymentMutations.apiEndpoint,
           inputType: IDEMPOTENT_SEND_INPUTS.intraLedger,
@@ -114,7 +118,10 @@ export const createIntraledgerPaymentDetails = <T extends WalletCurrency>(
       // USD/USDT Flash-to-Flash — the same double-debit class ENG-533 exists to
       // close, and gated like every other send input.
       withIdempotencyKey(
-        paymentMutations.idempotencyKey,
+        {
+          idempotencyKey: paymentMutations.idempotencyKey,
+          isRetry: paymentMutations.attemptIsRetry,
+        },
         {
           apiEndpoint: paymentMutations.apiEndpoint,
           inputType: IDEMPOTENT_SEND_INPUTS.intraLedgerUsd,

--- a/app/screens/send-bitcoin-screen/payment-details/lightning.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/lightning.ts
@@ -108,6 +108,7 @@ export const createNoAmountLightningPaymentDetails = <T extends WalletCurrency>(
         {
           idempotencyKey: paymentMutations.idempotencyKey,
           isRetry: paymentMutations.attemptIsRetry,
+          onKeylessDispatch: paymentMutations.onKeylessDispatch,
         },
         {
           apiEndpoint: paymentMutations.apiEndpoint,
@@ -189,6 +190,7 @@ export const createNoAmountLightningPaymentDetails = <T extends WalletCurrency>(
         {
           idempotencyKey: paymentMutations.idempotencyKey,
           isRetry: paymentMutations.attemptIsRetry,
+          onKeylessDispatch: paymentMutations.onKeylessDispatch,
         },
         {
           apiEndpoint: paymentMutations.apiEndpoint,
@@ -312,6 +314,7 @@ export const createAmountLightningPaymentDetails = <T extends WalletCurrency>(
       {
         idempotencyKey: paymentMutations.idempotencyKey,
         isRetry: paymentMutations.attemptIsRetry,
+        onKeylessDispatch: paymentMutations.onKeylessDispatch,
       },
       {
         apiEndpoint: paymentMutations.apiEndpoint,

--- a/app/screens/send-bitcoin-screen/payment-details/lightning.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/lightning.ts
@@ -9,6 +9,7 @@ import {
 } from "@app/types/amounts"
 import { PaymentType } from "@galoymoney/client"
 import { LnUrlPayServiceResponse } from "lnurl-pay/dist/types/types"
+import { IDEMPOTENT_SEND_INPUTS, withIdempotencyKey } from "./idempotency-support"
 import {
   ConvertMoneyAmount,
   SetInvoice,
@@ -57,6 +58,8 @@ export const createNoAmountLightningPaymentDetails = <T extends WalletCurrency>(
     canSendPayment: false,
     canGetFee: false,
   }
+  // The wire input of whichever branch below can actually send — the data half
+  // in which case there is no attempt to freeze either.
 
   if (
     settlementAmount?.amount &&
@@ -88,23 +91,42 @@ export const createNoAmountLightningPaymentDetails = <T extends WalletCurrency>(
       }
     }
 
-    const sendPaymentMutation: SendPaymentMutation = async (paymentMutations) => {
-      const { data } = await paymentMutations.lnNoAmountInvoicePaymentSend({
-        variables: {
-          input: {
-            walletId: sendingWalletDescriptor.id,
-            paymentRequest,
-            amount: settlementAmount.amount,
-            memo,
-          },
-        },
-      })
-
-      return {
-        status: data?.lnNoAmountInvoicePaymentSend.status,
-        errors: data?.lnNoAmountInvoicePaymentSend.errors,
-      }
+    const wireInput = {
+      walletId: sendingWalletDescriptor.id,
+      paymentRequest,
+      amount: settlementAmount.amount,
+      memo,
     }
+
+    const sendPaymentMutation: SendPaymentMutation = async (paymentMutations) =>
+      // Gated like every other send input: nothing in this repo measures which
+      // environments carry the field, and an ungated refusal takes the whole
+      // path down rather than degrading. See idempotency-support.ts.
+      withIdempotencyKey(
+        paymentMutations.idempotencyKey,
+        {
+          apiEndpoint: paymentMutations.apiEndpoint,
+          inputType: IDEMPOTENT_SEND_INPUTS.lnNoAmountInvoice,
+        },
+        async (keyField) => {
+          const { data } = await paymentMutations.lnNoAmountInvoicePaymentSend({
+            variables: {
+              input: {
+                // `requestFingerprint` matches the one it cached the key
+                ...wireInput,
+                // Same key for every repeat of this attempt, so a send whose
+                // response was lost settles once. See SendPaymentMutationParams.
+                ...keyField,
+              },
+            },
+          })
+
+          return {
+            status: data?.lnNoAmountInvoicePaymentSend.status,
+            errors: data?.lnNoAmountInvoicePaymentSend.errors,
+          }
+        },
+      )
 
     sendPaymentAndGetFee = {
       canSendPayment: true,
@@ -143,23 +165,47 @@ export const createNoAmountLightningPaymentDetails = <T extends WalletCurrency>(
       }
     }
 
-    const sendPaymentMutation: SendPaymentMutation = async (paymentMutations) => {
-      const { data } = await paymentMutations.lnNoAmountUsdInvoicePaymentSend({
-        variables: {
-          input: {
-            walletId: sendingWalletDescriptor.id,
-            paymentRequest,
-            amount: settlementAmount.amount,
-            memo,
-          },
-        },
-      })
-
-      return {
-        status: data?.lnNoAmountUsdInvoicePaymentSend.status,
-        errors: data?.lnNoAmountUsdInvoicePaymentSend.errors,
-      }
+    const wireInput = {
+      walletId: sendingWalletDescriptor.id,
+      paymentRequest,
+      amount: settlementAmount.amount,
+      memo,
     }
+
+    const sendPaymentMutation: SendPaymentMutation = async (paymentMutations) =>
+      // The input that most obviously needs the gate — it only gained
+      // `idempotencyKey` in flash#494 — but the gate is not special-cased to
+      // it: an older API rejects the whole mutation during input coercion
+      // rather than ignoring the field, and that is true of all five inputs.
+      // See idempotency-support.ts.
+      withIdempotencyKey(
+        paymentMutations.idempotencyKey,
+        {
+          apiEndpoint: paymentMutations.apiEndpoint,
+          inputType: IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice,
+        },
+        async (keyField) => {
+          const { data } = await paymentMutations.lnNoAmountUsdInvoicePaymentSend({
+            variables: {
+              input: {
+                // fingerprint is `ln-noamount-usd|${paymentRequest}|${amount}`,
+                // and BOTH halves move on their own here — the amount is a
+                // price-derived estimate — so a rebuilt input under the same
+                // key is answered with IdempotencyKeyReuseError.
+                ...wireInput,
+                // Same key for every repeat of this attempt, so a send whose
+                // response was lost settles once. See SendPaymentMutationParams.
+                ...keyField,
+              },
+            },
+          })
+
+          return {
+            status: data?.lnNoAmountUsdInvoicePaymentSend.status,
+            errors: data?.lnNoAmountUsdInvoicePaymentSend.errors,
+          }
+        },
+      )
 
     sendPaymentAndGetFee = {
       canSendPayment: true,
@@ -244,22 +290,42 @@ export const createAmountLightningPaymentDetails = <T extends WalletCurrency>(
   )
   const unitOfAccountAmount = paymentRequestAmount
 
-  const sendPaymentMutation: SendPaymentMutation = async (paymentMutations) => {
-    const { data } = await paymentMutations.lnInvoicePaymentSend({
-      variables: {
-        input: {
-          walletId: sendingWalletDescriptor.id,
-          paymentRequest,
-          memo,
-        },
-      },
-    })
-
-    return {
-      status: data?.lnInvoicePaymentSend.status,
-      errors: data?.lnInvoicePaymentSend.errors,
-    }
+  const wireInput = {
+    walletId: sendingWalletDescriptor.id,
+    paymentRequest,
+    memo,
   }
+
+
+  const sendPaymentMutation: SendPaymentMutation = async (paymentMutations) =>
+    // Gated like every other send input — see idempotency-support.ts.
+    withIdempotencyKey(
+      paymentMutations.idempotencyKey,
+      {
+        apiEndpoint: paymentMutations.apiEndpoint,
+        inputType: IDEMPOTENT_SEND_INPUTS.lnInvoice,
+      },
+      async (keyField) => {
+        const { data } = await paymentMutations.lnInvoicePaymentSend({
+          variables: {
+            input: {
+              // this builder with a bolt11 that the details screen re-mints on
+              // every pass forward, and the server keys on `ln|${paymentRequest}`
+              // — so the rebuilt input would not match the cached one.
+              ...wireInput,
+              // Same key for every repeat of this attempt, so a send whose
+              // response was lost settles once. See SendPaymentMutationParams.
+              ...keyField,
+            },
+          },
+        })
+
+        return {
+          status: data?.lnInvoicePaymentSend.status,
+          errors: data?.lnInvoicePaymentSend.errors,
+        }
+      },
+    )
 
   let getFee: GetFee<T>
 
@@ -406,6 +472,8 @@ export const createLnurlPaymentDetails = <T extends WalletCurrency>(
     canGetFee: false,
     canSendPayment: false,
   }
+  // Carried over from the delegate below along with its send — the freeze is
+  // only sound if the data half describes the very input that mutation sends.
 
   if (paymentRequest && paymentRequestAmount) {
     const amountLightningPaymentDetails = createAmountLightningPaymentDetails({

--- a/app/screens/send-bitcoin-screen/payment-details/lightning.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/lightning.ts
@@ -58,8 +58,10 @@ export const createNoAmountLightningPaymentDetails = <T extends WalletCurrency>(
     canSendPayment: false,
     canGetFee: false,
   }
-  // The wire input of whichever branch below can actually send — the data half
-  // in which case there is no attempt to freeze either.
+  // Populated by whichever branch below can actually send. Each branch
+  // closure-captures its wire input alongside its mutation, so the attempt
+  // frozen in use-send-payment.ts carries both; when neither branch can send
+  // there is no mutation and nothing to freeze.
 
   if (
     settlementAmount?.amount &&
@@ -103,7 +105,10 @@ export const createNoAmountLightningPaymentDetails = <T extends WalletCurrency>(
       // environments carry the field, and an ungated refusal takes the whole
       // path down rather than degrading. See idempotency-support.ts.
       withIdempotencyKey(
-        paymentMutations.idempotencyKey,
+        {
+          idempotencyKey: paymentMutations.idempotencyKey,
+          isRetry: paymentMutations.attemptIsRetry,
+        },
         {
           apiEndpoint: paymentMutations.apiEndpoint,
           inputType: IDEMPOTENT_SEND_INPUTS.lnNoAmountInvoice,
@@ -112,7 +117,9 @@ export const createNoAmountLightningPaymentDetails = <T extends WalletCurrency>(
           const { data } = await paymentMutations.lnNoAmountInvoicePaymentSend({
             variables: {
               input: {
-                // `requestFingerprint` matches the one it cached the key
+                // Spread from the closure-captured wireInput so a repeat sends
+                // identical parameters — the server only replays when the
+                // request fingerprint matches the one it cached the key under.
                 ...wireInput,
                 // Same key for every repeat of this attempt, so a send whose
                 // response was lost settles once. See SendPaymentMutationParams.
@@ -179,7 +186,10 @@ export const createNoAmountLightningPaymentDetails = <T extends WalletCurrency>(
       // rather than ignoring the field, and that is true of all five inputs.
       // See idempotency-support.ts.
       withIdempotencyKey(
-        paymentMutations.idempotencyKey,
+        {
+          idempotencyKey: paymentMutations.idempotencyKey,
+          isRetry: paymentMutations.attemptIsRetry,
+        },
         {
           apiEndpoint: paymentMutations.apiEndpoint,
           inputType: IDEMPOTENT_SEND_INPUTS.lnNoAmountUsdInvoice,
@@ -296,11 +306,13 @@ export const createAmountLightningPaymentDetails = <T extends WalletCurrency>(
     memo,
   }
 
-
   const sendPaymentMutation: SendPaymentMutation = async (paymentMutations) =>
     // Gated like every other send input — see idempotency-support.ts.
     withIdempotencyKey(
-      paymentMutations.idempotencyKey,
+      {
+        idempotencyKey: paymentMutations.idempotencyKey,
+        isRetry: paymentMutations.attemptIsRetry,
+      },
       {
         apiEndpoint: paymentMutations.apiEndpoint,
         inputType: IDEMPOTENT_SEND_INPUTS.lnInvoice,
@@ -309,9 +321,12 @@ export const createAmountLightningPaymentDetails = <T extends WalletCurrency>(
         const { data } = await paymentMutations.lnInvoicePaymentSend({
           variables: {
             input: {
-              // this builder with a bolt11 that the details screen re-mints on
-              // every pass forward, and the server keys on `ln|${paymentRequest}`
-              // — so the rebuilt input would not match the cached one.
+              // Spread from the closure-captured wireInput: an LNURL flow
+              // re-enters this builder with a bolt11 that the details screen
+              // re-mints on every pass forward, and the server keys on
+              // `ln|${paymentRequest}` — so a rebuilt input would not match
+              // the cached one. The frozen closure keeps the original bolt11
+              // for any repeat of this attempt.
               ...wireInput,
               // Same key for every repeat of this attempt, so a send whose
               // response was lost settles once. See SendPaymentMutationParams.

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -291,12 +291,16 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
         setPaymentError(undefined)
         toggleActivityIndicator(true)
         const { status, errorsMessage, ignored } = await sendPayment()
-        toggleActivityIndicator(false)
         if (ignored) {
           // A duplicate tap while the real attempt is still in flight.
-          // Nothing happened; log nothing, navigate nowhere.
+          // Nothing happened; log nothing, navigate nowhere — and do NOT
+          // touch the activity indicator: it is a plain boolean, not a
+          // counter, so this tap's `false` would clobber the owning tap's
+          // `true` and hide the spinner for the whole in-flight send. The
+          // first tap turns it off when its own send resolves.
           return
         }
+        toggleActivityIndicator(false)
         logPaymentResult({
           paymentType: paymentDetail.paymentType,
           paymentStatus: status,

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -286,9 +286,17 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
           paymentType: paymentDetail.paymentType,
           sendingWallet: sendingWalletDescriptor.currency,
         })
+        // A previous Failure/throw left an error on screen; this tap is the
+        // retry, so clear it before the attempt runs.
+        setPaymentError(undefined)
         toggleActivityIndicator(true)
-        const { status, errorsMessage } = await sendPayment()
+        const { status, errorsMessage, ignored } = await sendPayment()
         toggleActivityIndicator(false)
+        if (ignored) {
+          // A duplicate tap while the real attempt is still in flight.
+          // Nothing happened; log nothing, navigate nowhere.
+          return
+        }
         logPaymentResult({
           paymentType: paymentDetail.paymentType,
           paymentStatus: status,
@@ -321,6 +329,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
           })
         }
       } catch (err) {
+        toggleActivityIndicator(false)
         if (err instanceof Error) {
           getCrashlytics().recordError(err)
           setPaymentError(err.message || err.toString())
@@ -361,7 +370,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
         <PrimaryBtn
           loading={sendPaymentLoading}
           label={LL.SendBitcoinConfirmationScreen.title()}
-          disabled={!isValidAmount || hasAttemptedSend || Boolean(paymentError)}
+          disabled={!isValidAmount || hasAttemptedSend}
           onPress={handleSendPayment}
         />
       </View>

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -102,6 +102,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
     loading: sendPaymentLoading,
     sendPayment,
     hasAttemptedSend,
+    isInFlight,
   } = useSendPayment(sendPaymentMutation, paymentDetail, selectedFeeType)
 
   useEffect(() => {
@@ -253,6 +254,16 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
 
   const handleSendPayment = useCallback(async () => {
     if (sendPayment && sendingWalletDescriptor?.currency) {
+      // A duplicate tap while the real attempt is still on the wire. Decide
+      // BEFORE any side effect: the contract for an ignored tap is no
+      // analytics, no spinner toggle, no error toast — logging
+      // `payment_attempt` here would count two attempts for one result and
+      // skew failure-rate metrics on every double tap. The hook's own
+      // in-flight guard (the `ignored` return below) stays as defense in
+      // depth; this synchronous read is what keeps the log honest.
+      if (isInFlight()) {
+        return
+      }
       if (heldInvoiceHasExpired()) {
         // A refusal here is the whole point of ENG-555, so it has to be
         // countable: without an event the failure just changes shape from
@@ -345,6 +356,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route, navigation }) =
   }, [
     paymentType,
     sendPayment,
+    isInFlight,
     sendingWalletDescriptor?.currency,
     heldInvoiceHasExpired,
     LL,

--- a/app/screens/send-bitcoin-screen/use-send-payment.ts
+++ b/app/screens/send-bitcoin-screen/use-send-payment.ts
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react"
+import { useMemo, useRef, useState } from "react"
+import { v4 as uuidv4 } from "uuid"
 
 // gql
 import {
@@ -23,7 +24,11 @@ import { useAppConfig } from "@app/hooks"
 import { getErrorMessages } from "@app/graphql/utils"
 
 // types
-import { PaymentDetail, SendPaymentMutation } from "./payment-details/index.types"
+import {
+  PaymentDetail,
+  SendPaymentMutation,
+  SendPaymentMutationParams,
+} from "./payment-details/index.types"
 
 // Breez SDK
 import { payLightningBreez, payOnchainBreez, payLnurlBreez } from "@app/utils/breez-sdk"
@@ -35,6 +40,14 @@ type UseSendPaymentResult = {
     | (() => Promise<{
         status: PaymentSendResult | null | undefined
         errorsMessage?: string
+        /**
+         * True when this call was suppressed by the in-flight guard: a second
+         * tap that landed while the first send was still on the wire. The
+         * caller must return immediately — no spinner toggle, no analytics,
+         * no error toast — or a double-tap on a SUCCESSFUL payment shows a
+         * failure toast and logs a phantom undefined-status result.
+         */
+        ignored?: boolean
       }>)
     | undefined
     | null
@@ -45,7 +58,7 @@ export const useSendPayment = (
   paymentDetail?: PaymentDetail<WalletCurrency>,
   selectedFeeType?: "fast" | "medium" | "slow",
 ): UseSendPaymentResult => {
-  const { lnAddressHostname } = useAppConfig().appConfig.galoyInstance
+  const { lnAddressHostname, graphqlUri } = useAppConfig().appConfig.galoyInstance
 
   const [intraLedgerPaymentSend, { loading: intraLedgerPaymentSendLoading }] =
     useIntraLedgerPaymentSendMutation({ refetchQueries: [HomeAuthedDocument] })
@@ -74,6 +87,48 @@ export const useSendPayment = (
 
   const [hasAttemptedSend, setHasAttemptedSend] = useState(false)
 
+  // ── The retained attempt: freeze-the-attempt, in one object ──
+  //
+  // ENG-533's history is six review rounds of trying to RECOGNISE a repeated
+  // send from its content — and every fingerprint that ignored a re-minted
+  // LNURL invoice or a price-ticked amount either collided two deliberate
+  // payments or mismatched the server's own fingerprint and turned the one
+  // retry this feature exists for into IdempotencyKeyReuseError → "failed" →
+  // a fresh key → a double pay.
+  //
+  // So nothing here recognises anything. An attempt IS this object: the send
+  // closure captured at the first tap (whose wire input is therefore frozen —
+  // a later re-render may rebuild the payment detail, re-mint the invoice,
+  // re-derive the amount, and none of it matters because we never call the
+  // new closure) plus one random key. Lifecycle:
+  //
+  //   created   at the first tap
+  //   retained  when the send THROWS (dropped socket, 502, backgrounded) —
+  //             the outcome is unknown, so the retry re-runs the same closure
+  //             with the same key and the backend replays the original result
+  //             if it had committed
+  //   cleared   on ANY server-supplied status — the outcome is known, so the
+  //             next tap is a new payment with a fresh key by construction.
+  //             This also kills both residual bugs of the fingerprint design:
+  //             no deliberate repeat can collide (fresh uuid every attempt),
+  //             and no 24h cached FAILURE can lock anyone out (its key is
+  //             never reused).
+  //
+  // Deliberately NOT persisted. A force-quit mid-send discards the attempt,
+  // which leaves exactly today's pre-existing risk — no worse — and avoids
+  // guessing across sessions with content fingerprints. Cross-session
+  // recovery wants a server-side lookup, not client heuristics.
+  const attemptRef = useRef<{
+    key: string
+    run: (params: SendPaymentMutationParams) => ReturnType<SendPaymentMutation>
+  } | null>(null)
+
+  // Synchronous double-tap guard. `hasAttemptedSend` gates whether
+  // `sendPayment` is DEFINED, but that is decided at render time: two taps in
+  // one frame both capture the closure from the render where it was still
+  // defined. A ref is written synchronously, so the second tap sees it.
+  const inFlightRef = useRef(false)
+
   const loading =
     intraLedgerPaymentSendLoading ||
     intraLedgerUsdPaymentSendLoading ||
@@ -88,7 +143,26 @@ export const useSendPayment = (
   const sendPayment = useMemo(() => {
     return sendPaymentMutation && !hasAttemptedSend
       ? async () => {
+          if (inFlightRef.current) {
+            return { status: undefined, errorsMessage: undefined, ignored: true }
+          }
+          inFlightRef.current = true
           setHasAttemptedSend(true)
+
+          // Shared failure epilogue for the Breez branch: a Failure is a KNOWN
+          // outcome, so re-arm the button for a fresh attempt — same semantics
+          // as the GraphQL branch below. (Breez sends are local SDK calls with
+          // no idempotency key; a retry is simply a new attempt.)
+          const finish = (result: {
+            status: PaymentSendResult
+            errorsMessage?: string
+          }) => {
+            if (result.status === PaymentSendResult.Failure) {
+              inFlightRef.current = false
+              setHasAttemptedSend(false)
+            }
+            return result
+          }
 
           if (paymentDetail && paymentDetail.sendingWalletDescriptor.currency === "BTC") {
             const { settlementAmount, memo, destination, paymentType } = paymentDetail
@@ -101,12 +175,12 @@ export const useSendPayment = (
                   settlementAmount.amount,
                 )
                 console.log("Response payLightningBreez: ", response)
-                return {
+                return finish({
                   status: response.success
                     ? PaymentSendResult.Success
                     : PaymentSendResult.Failure,
                   errorsMessage: response.error,
-                }
+                })
               } else if (paymentType === "lnurl" || paymentType === "intraledger") {
                 console.log("Starting payLnurlBreez", memo)
                 const updatedDestination =
@@ -132,42 +206,72 @@ export const useSendPayment = (
                 )
                 console.log("Response payOnchainBreez: ", response)
 
-                return {
+                return finish({
                   status: response.success
                     ? PaymentSendResult.Success
                     : PaymentSendResult.Failure,
                   errorsMessage: response.error,
-                }
+                })
               } else {
-                return {
+                return finish({
                   status: PaymentSendResult.Failure,
                   errorsMessage: "Wrong invoice type",
-                }
+                })
               }
             } catch (err: any) {
-              return {
+              return finish({
                 status: PaymentSendResult.Failure,
                 errorsMessage: err.message,
-              }
+              })
             }
           } else {
             console.log("Starting sendPaymentMutation using GraphQL")
-            const response = await sendPaymentMutation({
-              intraLedgerPaymentSend,
-              intraLedgerUsdPaymentSend,
-              lnInvoicePaymentSend,
-              lnNoAmountInvoicePaymentSend,
-              lnNoAmountUsdInvoicePaymentSend,
-              onChainPaymentSend,
-              onChainPaymentSendAll,
-              onChainUsdPaymentSend,
-              onChainUsdPaymentSendAsBtcDenominated,
-            })
+            // Repeat of an unresolved attempt → the retained closure and key.
+            // First tap of a new attempt → freeze the CURRENT closure with a
+            // fresh key. See attemptRef above for why this is the whole design.
+            if (!attemptRef.current) {
+              attemptRef.current = { key: uuidv4(), run: sendPaymentMutation }
+            }
+            const attempt = attemptRef.current
+
+            let response
+            try {
+              response = await attempt.run({
+                idempotencyKey: attempt.key,
+                apiEndpoint: graphqlUri,
+                intraLedgerPaymentSend,
+                intraLedgerUsdPaymentSend,
+                lnInvoicePaymentSend,
+                lnNoAmountInvoicePaymentSend,
+                lnNoAmountUsdInvoicePaymentSend,
+                onChainPaymentSend,
+                onChainPaymentSendAll,
+                onChainUsdPaymentSend,
+                onChainUsdPaymentSendAsBtcDenominated,
+              })
+            } catch (err) {
+              // Outcome unknown — the case this design exists for. Keep the
+              // attempt so the retry re-runs the same input under the same
+              // key, and re-arm the button.
+              // eslint-disable-next-line require-atomic-updates -- ref as a synchronous flag; the write-after-await IS the design
+              inFlightRef.current = false
+              setHasAttemptedSend(false)
+              throw err
+            }
+
+            // A status came back at all → the outcome is known and this
+            // attempt is finished, whatever the answer was.
+            if (response.status) {
+              // eslint-disable-next-line require-atomic-updates -- ref as a synchronous flag; the write-after-await IS the design
+              attemptRef.current = null
+            }
             let errorsMessage = undefined
             if (response.errors) {
               errorsMessage = getErrorMessages(response.errors)
             }
             if (response.status === PaymentSendResult.Failure) {
+              // eslint-disable-next-line require-atomic-updates -- ref as a synchronous flag; the write-after-await IS the design
+              inFlightRef.current = false
               setHasAttemptedSend(false)
             }
             return { status: response.status, errorsMessage }
@@ -177,6 +281,7 @@ export const useSendPayment = (
   }, [
     sendPaymentMutation,
     hasAttemptedSend,
+    graphqlUri,
     paymentDetail,
     selectedFeeType,
     intraLedgerPaymentSend,

--- a/app/screens/send-bitcoin-screen/use-send-payment.ts
+++ b/app/screens/send-bitcoin-screen/use-send-payment.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react"
+import { useCallback, useMemo, useRef, useState } from "react"
 import { v4 as uuidv4 } from "uuid"
 
 // gql
@@ -22,7 +22,10 @@ import { useAppConfig } from "@app/hooks"
 
 // utils
 import { getErrorMessages } from "@app/graphql/utils"
-import { isIdempotencyKeyReuseError } from "./payment-details/idempotency-support"
+import {
+  CHECK_TRANSACTION_HISTORY_MESSAGE,
+  isIdempotencyKeyReuseError,
+} from "./payment-details/idempotency-support"
 
 // types
 import {
@@ -37,6 +40,15 @@ import { payLightningBreez, payOnchainBreez, payLnurlBreez } from "@app/utils/br
 type UseSendPaymentResult = {
   loading: boolean
   hasAttemptedSend: boolean
+  /**
+   * Synchronous read of the in-flight guard. The screen's handler must decide
+   * BEFORE its side effects (analytics, spinner) whether this tap is a
+   * duplicate: `sendPayment`'s own `ignored` answer only arrives after the
+   * call, by which point `logPaymentAttempt` would already have fired and
+   * inflated attempt counts against results. A ref-backed getter (not state)
+   * so two taps in one frame see the truth.
+   */
+  isInFlight: () => boolean
   sendPayment:
     | (() => Promise<{
         status: PaymentSendResult | null | undefined
@@ -127,6 +139,15 @@ export const useSendPayment = (
     // keyless fallback on a coercion refusal is only safe on a first
     // dispatch, where the refusal proves nothing executed.
     dispatched: boolean
+    // Flipped (via onKeylessDispatch) when any dispatch of this attempt went
+    // out WITHOUT the key — the gate's keyless fallback. The design contract
+    // "a retry re-runs identical input under the same key and the backend
+    // replays" only holds when the earlier dispatch actually CARRIED the key.
+    // If a keyless dispatch throws with its outcome unknown, a keyed retry is
+    // not a replay — the server never saw the key — so it could execute a
+    // second payment. Such an attempt must never be auto-retried; the user is
+    // sent to their history instead.
+    wentKeyless: boolean
     run: (params: SendPaymentMutationParams) => ReturnType<SendPaymentMutation>
   } | null>(null)
 
@@ -240,11 +261,25 @@ export const useSendPayment = (
               attemptRef.current = {
                 key: uuidv4(),
                 dispatched: false,
+                wentKeyless: false,
                 run: sendPaymentMutation,
               }
             }
             const attempt = attemptRef.current
             const attemptIsRetry = attempt.dispatched
+
+            // A retry of an attempt whose earlier dispatch went out KEYLESS:
+            // the server has never seen this key, so there is nothing for it
+            // to replay — re-dispatching (keyed or not) could execute a second
+            // payment while the keyless one may have committed. Same answer as
+            // the IdempotencyKeyReuseError branch below: keep the button
+            // disarmed and send the user to their history.
+            if (attemptIsRetry && attempt.wentKeyless) {
+              return {
+                status: PaymentSendResult.Failure,
+                errorsMessage: CHECK_TRANSACTION_HISTORY_MESSAGE,
+              }
+            }
             attempt.dispatched = true
 
             let response
@@ -252,6 +287,9 @@ export const useSendPayment = (
               response = await attempt.run({
                 idempotencyKey: attempt.key,
                 attemptIsRetry,
+                onKeylessDispatch: () => {
+                  attempt.wentKeyless = true
+                },
                 apiEndpoint: graphqlUri,
                 intraLedgerPaymentSend,
                 intraLedgerUsdPaymentSend,
@@ -298,8 +336,7 @@ export const useSendPayment = (
             ) {
               return {
                 status: response.status,
-                errorsMessage:
-                  "This payment may have already been sent. Check your transaction history before trying again.",
+                errorsMessage: CHECK_TRANSACTION_HISTORY_MESSAGE,
               }
             }
             if (response.status === PaymentSendResult.Failure) {
@@ -328,9 +365,12 @@ export const useSendPayment = (
     onChainUsdPaymentSendAsBtcDenominated,
   ])
 
+  const isInFlight = useCallback(() => inFlightRef.current, [])
+
   return {
     hasAttemptedSend,
     loading,
     sendPayment,
+    isInFlight,
   }
 }

--- a/app/screens/send-bitcoin-screen/use-send-payment.ts
+++ b/app/screens/send-bitcoin-screen/use-send-payment.ts
@@ -22,6 +22,7 @@ import { useAppConfig } from "@app/hooks"
 
 // utils
 import { getErrorMessages } from "@app/graphql/utils"
+import { isIdempotencyKeyReuseError } from "./payment-details/idempotency-support"
 
 // types
 import {
@@ -120,6 +121,12 @@ export const useSendPayment = (
   // recovery wants a server-side lookup, not client heuristics.
   const attemptRef = useRef<{
     key: string
+    // Flipped on the attempt's first dispatch. A later run of the same
+    // attempt is therefore a RETRY — an earlier dispatch with an unknown
+    // outcome exists — which the idempotency-support gate must know: its
+    // keyless fallback on a coercion refusal is only safe on a first
+    // dispatch, where the refusal proves nothing executed.
+    dispatched: boolean
     run: (params: SendPaymentMutationParams) => ReturnType<SendPaymentMutation>
   } | null>(null)
 
@@ -230,14 +237,21 @@ export const useSendPayment = (
             // First tap of a new attempt → freeze the CURRENT closure with a
             // fresh key. See attemptRef above for why this is the whole design.
             if (!attemptRef.current) {
-              attemptRef.current = { key: uuidv4(), run: sendPaymentMutation }
+              attemptRef.current = {
+                key: uuidv4(),
+                dispatched: false,
+                run: sendPaymentMutation,
+              }
             }
             const attempt = attemptRef.current
+            const attemptIsRetry = attempt.dispatched
+            attempt.dispatched = true
 
             let response
             try {
               response = await attempt.run({
                 idempotencyKey: attempt.key,
+                attemptIsRetry,
                 apiEndpoint: graphqlUri,
                 intraLedgerPaymentSend,
                 intraLedgerUsdPaymentSend,
@@ -268,6 +282,25 @@ export const useSendPayment = (
             let errorsMessage = undefined
             if (response.errors) {
               errorsMessage = getErrorMessages(response.errors)
+            }
+            // Defense in depth: the frozen-closure design should make key
+            // reuse unreachable (a key is only ever re-sent with the same
+            // frozen input), but if the server ever answers with
+            // IdempotencyKeyReuseError it is telling us it HOLDS an outcome
+            // for this key. Treating that as an ordinary Failure would retire
+            // the key and re-arm the button — the next tap gets a fresh key
+            // for a payment that may already have settled, and the money
+            // leaves twice. So: keep the button disarmed and send the user to
+            // their history instead.
+            if (
+              response.status === PaymentSendResult.Failure &&
+              isIdempotencyKeyReuseError(response.errors)
+            ) {
+              return {
+                status: response.status,
+                errorsMessage:
+                  "This payment may have already been sent. Check your transaction history before trying again.",
+              }
             }
             if (response.status === PaymentSendResult.Failure) {
               // eslint-disable-next-line require-atomic-updates -- ref as a synchronous flag; the write-after-await IS the design


### PR DESCRIPTION
Closes ENG-533. Supersedes #713 (six review rounds established that content-fingerprinting a send attempt doesn't converge — every fingerprint either collided two deliberate payments or mismatched the server's own fingerprint, turning the one retry this feature exists for into \`IdempotencyKeyReuseError\` → double pay).

## Design

**An attempt is an object, not a fingerprint.** At the first tap we freeze the current send closure together with one random uuid key. Nothing ever *recognises* a repeat — a repeat is simply the retained object being re-run.

| Event | Attempt | Why |
|---|---|---|
| First tap | created (closure + fresh key) | wire input frozen: later re-renders may re-mint the invoice or re-derive the amount; we never call the new closure |
| Send **throws** | **retained** | outcome unknown — the retry re-runs the identical input under the same key and the backend replays the original result if it committed |
| **Any** server status | cleared | outcome known — next tap is a new payment with a fresh key *by construction* (kills both residual fingerprint bugs: deliberate-repeat collision and the 24h cached-FAILURE lockout) |

Deliberately **not persisted**: force-quit mid-send leaves exactly today's pre-existing risk. Cross-session recovery wants a server-side lookup, not client heuristics.

## Capability gate

GraphQL input coercion rejects unknown fields before execution, so a backend without the \`idempotencyKey\` inputs would fail every send. \`idempotency-support.ts\` gates the field per (endpoint, input type): on coercion refusal the send retries keyless (safe — refusal proves nothing settled) and the gate remembers.

## UI contract

- Synchronous \`inFlightRef\` guard: a second tap in the same frame returns \`{ ignored: true }\` — no spinner toggle, no analytics, no phantom error toast.
- Retry is reachable: Failure/throw re-arm the button (\`paymentError\` no longer pins it disabled; it's cleared at tap start). \`ALREADY_PAID\`/success keep it disabled via \`hasAttemptedSend\`.
- Breez (BTC-wallet) sends now share the Failure re-arm semantics; they take no key (local SDK, no idempotency surface).

## Tests

- \`use-send-payment.spec.tsx\` — lifecycle behavioral suite: double-tap → one call + \`ignored\`; throw → retry runs the **original** closure with the **same** key even after a re-render swapped the mutation; Failure → fresh key + current closure; throw/Failure re-arm, success doesn't.
- \`idempotency-support.spec.ts\` — gate behavior + input-type names pinned against \`public-schema.graphql\`.
- Existing payment-details suites extended to assert the key reaches each mutation input.

Full suite: 949 passed. tsc clean. No new lint findings (three \`require-atomic-updates\` suppressions are refs-as-synchronous-flags — the write-after-await is the design).